### PR TITLE
fix: externalize Supplier.purchase_taxes_and_charges_template (#102)

### DIFF
--- a/docs/SessionLogs/2026-04-05-1330-supplier-tax-template-externalize-minutes.md
+++ b/docs/SessionLogs/2026-04-05-1330-supplier-tax-template-externalize-minutes.md
@@ -1,0 +1,42 @@
+# Minutes — 2026-04-05 13:30 — Externalize Supplier Tax Template (#102)
+
+## Objective
+
+Externalize `Supplier.purchase_taxes_and_charges_template` — the last of 13 Developer Mode field additions — as a Custom Field fixture in ce_sri. Verify via full destroy+deploy of dev03.
+
+Corresponds to **Session B** from the 2026-04-05-1000 agenda. Issue #102, branch `fix/102-supplier-tax-template`.
+
+## Completed ✅
+
+### Fixture added to ce_sri
+- Added `Supplier-purchase_taxes_and_charges_template` (Link → Purchase Taxes and Charges Template) to `ce_sri/fixtures/custom_field.json`
+- `insert_after: supplier_primary_address` (from production's `supplier.json`)
+- Committed `7c99ccc` on `wip/2026-03-25`, pushed to GitHub
+
+### dev03 full lifecycle verified
+- Destroyed dev03 completely via Playwright topology UI
+- Fresh deploy from template — full pipeline including DB restore + G2 step
+- G2 cleared 48 Custom Fields + colliding DocFields, bench migrate reimported all cleanly
+- DB query confirmed: field exists in `tabCustom Field` (not `tabDocField`)
+- Pipeline completed in ~25 minutes (DB restore ~17 min on toshiba hardware)
+
+### 13/13 Developer Mode audit complete
+- All 13 Developer Mode field additions across 7 doctypes are now externalized as Custom Field fixtures
+- `apps/erpnext` remains 100% stock on all dev/staging VMs
+
+### Side findings
+- Telegram 3-min idle alert works correctly for multiple-choice (AskUserQuestion) wait states — memory updated
+- Opened #103: `cd + git` compound command approval friction
+
+## Key Decisions
+
+- Confirmed the field IS non-standard (not in stock ERPNext v13 `supplier.json`) despite appearing on dev VMs — it was carried in as a DocField by the production DB restore
+- Understood why #100 (commission fields) caused collisions but #102 didn't: commission fields were half-migrated (in fixture AND DocField), Supplier field was DocField-only (no fixture to collide with)
+
+## Action Points
+
+| # | Action | Owner | Target |
+|---|--------|-------|--------|
+| 1 | Close or link #98 — overlaps with completed #100 | User | Next session |
+| 2 | Fix #103 — cd+git compound command permissions | Claude + user | Next session |
+| 3 | Retry SRI PRUEBAS submit on dev01 | Claude + user | 2026-04-07 |

--- a/docs/SessionLogs/2026-04-05-1330-supplier-tax-template-externalize-next-agenda.md
+++ b/docs/SessionLogs/2026-04-05-1330-supplier-tax-template-externalize-next-agenda.md
@@ -1,0 +1,65 @@
+# Agenda — Next Sessions (1:1:1 Discipline)
+
+Each session works exactly one issue on its own branch. PR to main at session end.
+
+---
+
+## Session A — #103: Allow cd + git compound commands without approval prompt
+
+**Branch:** `fix/103-cd-git-permissions`
+
+### Steps
+1. Add permissions rule in `.claude/settings.local.json` for `cd && git` compound commands
+2. Test with `cd /home/hasan/projects/Logichem/ce_sri && git status`
+3. Verify no prompt appears for known project directories
+
+### Acceptance
+- Compound `cd && git` commands run without approval prompt for repos under `/home/hasan/projects/Logichem/`
+
+---
+
+## Session B — Close or link #98
+
+**#98** (externalize 4 commission fields) overlaps with completed **#100**. Decide: close as duplicate, or keep for any remaining scope.
+
+---
+
+## Session C — Retry SRI PRUEBAS on dev01
+
+Error 70 was likely Easter weekend SRI downtime. Retest invoice 001-004-000000074.
+
+---
+
+## Session D — Terminal friction: Ctrl+Z recovery + Telegram alerts (need issue first)
+
+Two parts of one problem — Claude Code terminal session resilience:
+
+1. **Ctrl+Z muscle memory**: standard text-editor undo fires SIGTSTP, suspends Claude Code, and `fg` often fails to restore.
+2. **Telegram alerts**: permission-prompt (action authorization) wait state still unverified for 3-min alert.
+
+### Acceptance
+- Ctrl+Z no longer kills a session (prevented or recoverable)
+- Telegram alerts verified for all wait states
+
+---
+
+## Session E — ce_sri repo bugs (need issue first)
+
+Open issue for: `modules.txt` accent + Supplier fixture conflict. These block fresh provisions that don't apply manual workarounds.
+
+---
+
+## Session F — erpadm SSH key deployment (need issue first)
+
+Add `hasan_mighty.pub` as authorized_key for erpadm during `differentiate.sh`.
+
+---
+
+## Backlog (not yet scheduled)
+
+- #68: split Refresh into fast path (skip G/H DB restore)
+- #50: cf-mcp-refresh into repo + setup docs
+- ce_sri_svc install timing (need own issue)
+- Customization inventory (upgrade prep phase 1)
+- Playwright regression suite (upgrade prep phase 2)
+- Latest production backup verification


### PR DESCRIPTION
## Summary

- Last of 13 Developer Mode field additions externalized as a Custom Field fixture
- Field added to `ce_sri/fixtures/custom_field.json` (commit `7c99ccc` on `wip/2026-03-25`)
- Verified via full destroy+deploy of dev03 — field present in `tabCustom Field`, no DocField collision
- G2 step handles cleanup automatically
- Session minutes and updated agenda included

## Test plan

- [x] Confirmed field is non-standard (not in stock ERPNext v13 `supplier.json`)
- [x] Full destroy+deploy of dev03 via Playwright topology UI
- [x] DB query: `Supplier-purchase_taxes_and_charges_template` in `tabCustom Field`, absent from `tabDocField`
- [x] G2 cleared 48 Custom Fields + colliding DocFields, bench migrate reimported cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)