### PR TITLE
fix(kvm): detect WG hub peer drift in sync_check

### DIFF
--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -18,6 +18,7 @@
 #   7.  VMs on toshiba (derived from hosts_map.yml)
 #   8.  WireGuard — local interface + handshake
 #   9.  WireGuard mesh — ping all peers (derived from hosts_map.yml)
+#   9b. WireGuard hub peer drift — saconsole live peers vs inventory spokes
 #  10.  Observability stack (saconsole)
 #  11.  ERPNext sites — HTTPS reachability (derived from hosts_map.yml)
 #  12.  MCP endpoints — all SSE servers in ~/.claude/settings.json
@@ -242,6 +243,34 @@ for label_ip in ${WG_PEERS}; do
         fix "Check wg0 handshake and that ${label} VM is running on toshiba"
     fi
 done
+
+# ── 9b. WireGuard hub peer drift — saconsole live peers vs inventory spokes ───
+hdr "9b. WireGuard hub peer drift (saconsole)"
+
+# Count expected spokes from hosts_map.yml (all hosts with wg_role=spoke, any group)
+EXPECTED_SPOKES=$(python3 - "${PROJ_ROOT}/hosts_map.yml" <<'PYEOF'
+import yaml, sys
+d = yaml.safe_load(open(sys.argv[1]))
+seen = set()
+for group_name, members in d.get('groups', {}).items():
+    if not isinstance(members, dict):
+        continue
+    for name, h in members.items():
+        if isinstance(h, dict) and h.get('wg_role') == 'spoke' and name not in seen:
+            seen.add(name)
+print(len(seen))
+PYEOF
+)
+
+# Count live peers on saconsole hub
+LIVE_PEERS=$(remote_saconsole "sudo wg show wg0 2>/dev/null | grep -c '^peer:'" 2>/dev/null || echo "0")
+
+if [[ "${LIVE_PEERS}" -eq "${EXPECTED_SPOKES}" ]]; then
+    ok "saconsole hub has ${LIVE_PEERS} WG peers — matches inventory (${EXPECTED_SPOKES} spokes)"
+else
+    fail "saconsole hub has ${LIVE_PEERS} WG peers — inventory expects ${EXPECTED_SPOKES} spokes"
+    fix "Re-run: cd ansible && ansible-playbook -i inventory/kvm.yml site-kvm.yml --limit saconsole --tags wireguard"
+fi
 
 # ── 10. Observability stack — saconsole ───────────────────────────────────────
 hdr "10. Observability stack (saconsole)"


### PR DESCRIPTION
## Summary

- Added sync_check section 9b: compares saconsole's live WG peer count against inventory spoke count
- Detects drift when hosts are added to inventory but saconsole's `wg0.conf` is not regenerated
- Provides actionable fix command in failure output

**Infrastructure fix (not in this PR):** dev03's WG spoke was configured and saconsole's hub config was regenerated via Ansible — this was a runtime-only fix with no code artifact.

## Root Cause

dev03 was deployed outside the API pipeline and synced to the repo (#97) without re-running the Ansible wireguard role on saconsole. The API pipeline handles this correctly (Step 8), but bypassing the pipeline leaves the mesh broken. See #105 comment for full analysis.

## Test plan

- [x] `bash platforms/kvm/sync_check.sh` — section 9b passes (4 live peers = 4 inventory spokes)
- [x] `ping 10.10.0.14` from Mighty — dev03 reachable
- [x] `curl -sk https://dev03.iridium.blue` — HTTP 200
- [x] Full sync_check: 50 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)