### PR TITLE
fix(kvm): defer social login to after H4a clears __Auth

### DIFF
--- a/tools/api.py
+++ b/tools/api.py
@@ -1454,8 +1454,8 @@ echo "  [OK] installApps.sh complete"
 echo "=== G-pre: strip DEFINER clauses from backup SQL ==="
 python3 /tmp/vm_scripts/gpre_strip_definer.py --bench-dir "$BENCH_DIR"
 
-echo "=== G: handleRestore.sh ==="
-sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bash BaRe/handleRestore.sh"
+echo "=== G: handleRestore.sh (social login deferred to post-H4a) ==="
+sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && DEFER_SOCIAL_LOGIN=1 bash BaRe/handleRestore.sh"
 echo "  [OK] database restored"
 
 echo "=== G1: re-seed tabPatch Log (restore wiped DB) ==="
@@ -1500,6 +1500,28 @@ fi
 
 echo "=== H4a: clear stale encrypted secrets + regenerate API key ==="
 sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && $BENCH_DIR/env/bin/python /tmp/vm_scripts/h4a_apikeys.py --site $SITE_URL --bench-dir $BENCH_DIR"
+
+echo "=== H4a-sl: restore Social Login config (deferred from G — needs fresh __Auth) ==="
+APIKEY_SH="$BENCH_DIR/sites/$SITE_URL/private/files/apikey.sh"
+if [ -f "$APIKEY_SH" ]; then
+    source "$APIKEY_SH"
+    RESOURCE_URL="https://$SITE_URL/api/resource"
+    SWITCHES="--location --insecure --no-progress-meter --request"
+    AUTH_HEADER="Authorization: token $KEYS"
+    CONTENT_HEADER="Content-Type: application/json"
+    SLK="Social%20Login%20Key"
+    SOCIAL_CONF="$BENCH_DIR/sites/$SITE_URL/socials_google.json"
+    if [ -f "$SOCIAL_CONF" ]; then
+        curl $SWITCHES DELETE --header "$AUTH_HEADER" --header "$CONTENT_HEADER" "$RESOURCE_URL/$SLK/google" >/dev/null 2>&1 || true
+        RSLT=$(curl $SWITCHES POST --header "$AUTH_HEADER" --header "$CONTENT_HEADER" -d @"$SOCIAL_CONF" "$RESOURCE_URL/$SLK")
+        MSG=$(echo "$RSLT" | jq -r .data.social_login_provider 2>/dev/null || echo "unknown")
+        echo "  [OK] Social Login restored (provider: $MSG)"
+    else
+        echo "  [SKIP] No socials_google.json found — Social Login not configured"
+    fi
+else
+    echo "  [WARN] apikey.sh not found — cannot restore Social Login"
+fi
 
 echo "=== H3: reset admin password (H4a wipes __Auth — must run after) ==="
 sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench --site $SITE_URL set-admin-password $ERP_USER_PWD"


### PR DESCRIPTION
## Summary
- Step G now passes `DEFER_SOCIAL_LOGIN=1` to `handleRestore.sh`, skipping the social login API call that fails with stale production-encrypted `__Auth` entries
- New step H4a-sl restores social login config using fresh API credentials generated by H4a
- Re-enables post-restore ERPNext restart in BaRe (was a debug toggle)

## Root cause
`handleRestore.sh`'s `restoreSocialLoginConfig()` called the ERPNext API with `__Auth` entries still encrypted with production's `encryption_key`. H4a (which clears `__Auth` and regenerates keys) ran ~2 minutes later. The API returned `Encryption key is invalid`.

## Pipeline order (after fix)
G (restore + restart, no social login) → H/H2/H2b (pipeline restart + gunicorn wait) → H4a (clear `__Auth`) → **H4a-sl (social login with fresh keys)** → H3 (admin password)

Fixes #117
Companion PR: martinhbramwell/BaRe#TBD

## Test plan
- [ ] Playwright Refresh on dev02 — zero encryption key errors in job log
- [ ] Social login provider restored in H4a-sl output
- [ ] No regression in Deploy pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)