### PR TITLE
feat(cytoscape): Playwright unprovisioned VM tests

### DIFF
--- a/prototypes/cytoscape/CLAUDE.md
+++ b/prototypes/cytoscape/CLAUDE.md
@@ -78,13 +78,19 @@ Any operation the Cytoscape UI can perform MUST be performed via the browser ext
 
 ## Playwright Tests
 
-Tests live in `prototypes/cytoscape/tests/`. Run from the `prototypes/cytoscape` directory.
+Tests live in `prototypes/cytoscape/tests/`. Run from the `prototypes/cytoscape` directory. Shared helpers (`waitForGraph`, `selectNode`, `clickInfoButton`, `waitForJob`, constants) in `tests/helpers.js` — imported by all spec files.
 
 ```bash
-npx playwright test --grep "inspect"    # read-only, safest
-npx playwright test --grep "lifecycle"  # destroy + deploy cycle
-npx playwright test --grep "fixture"    # verify ce_sri fixtures post-deploy
+npx playwright test --grep "inspect"        # read-only, safest
+npx playwright test --grep "lifecycle"      # destroy + deploy cycle
+npx playwright test --grep "fixture"        # verify ce_sri fixtures post-deploy
+npx playwright test --grep "button guards"  # unprovisioned node negative test
+npx playwright test --grep "e2e"            # cloud-init provision (real run)
 ```
+
+Test files:
+- `topology-ops.spec.js` — Deploy, Refresh, Destroy, Inspect, Rebuild, Lifecycle, Power, Provisioning state
+- `unprovisioned.spec.js` — button guards (negative) + e2e Provision via cloud-init path (#143)
 
 **Prefer Playwright over Chrome extension** for topology operations (Deploy, Refresh, Destroy, Inspect). Cheaper in API credits, more reliable, and produces repeatable regression scripts. Chrome extension remains valid for visual inspection, ad-hoc exploration, and read-only production browsing.
 

--- a/prototypes/cytoscape/tests/helpers.js
+++ b/prototypes/cytoscape/tests/helpers.js
@@ -1,0 +1,40 @@
+// helpers.js — shared Playwright utilities for ESACP topology tests
+
+export const BASE_URL = process.env.TOPOLOGY_URL || 'http://localhost:5173'
+export const API_URL  = process.env.API_URL || 'http://localhost:8088'
+
+export async function waitForGraph(page) {
+  await page.waitForSelector('#cy canvas', { timeout: 10_000 })
+  await page.waitForTimeout(1500)
+}
+
+export async function selectNode(page, hostname) {
+  await page.evaluate((h) => {
+    const cy = document.querySelector('#cy')?._cyreg?.cy
+    if (!cy) throw new Error('Cytoscape instance not found')
+    const node = cy.$(`#${h}`)
+    if (node.empty()) throw new Error(`Node '${h}' not found on graph`)
+    node.emit('tap')
+  }, hostname)
+  await page.waitForTimeout(500)
+}
+
+export async function clickInfoButton(page, buttonText) {
+  const btn = page.locator('#info-panel button', { hasText: buttonText })
+  await btn.waitFor({ state: 'visible', timeout: 5_000 })
+  await btn.click()
+}
+
+export async function waitForJob(page, jobId, timeoutMs = 2_100_000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const resp = await page.request.get(`${API_URL}/api/jobs`)
+    const jobs = await resp.json()
+    const job = jobs[jobId]
+    if (!job) throw new Error(`Job ${jobId} not found`)
+    if (job.status === 'done') return job
+    if (job.status === 'failed') throw new Error(`Job ${jobId} failed`)
+    await page.waitForTimeout(5_000)
+  }
+  throw new Error(`Job ${jobId} timed out after ${timeoutMs}ms`)
+}

--- a/prototypes/cytoscape/tests/topology-ops.spec.js
+++ b/prototypes/cytoscape/tests/topology-ops.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test'
+import { BASE_URL, API_URL, waitForGraph, selectNode, clickInfoButton, waitForJob } from './helpers.js'
 
 /**
  * ESACP Topology UI — Playwright end-to-end tests
@@ -19,63 +20,6 @@ import { test, expect } from '@playwright/test'
  *   - uvicorn tools.api:app --port 8088  (FastAPI backend)
  *   - bash doCytoscape.sh                (Vite dev server on :5173)
  */
-
-const BASE_URL = process.env.TOPOLOGY_URL || 'http://localhost:5173'
-const API_URL  = process.env.API_URL || 'http://localhost:8088'
-
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Wait for the Cytoscape graph to initialise (nodes rendered).
- */
-async function waitForGraph(page) {
-  await page.waitForSelector('#cy canvas', { timeout: 10_000 })
-  // Give Cytoscape a moment to lay out nodes
-  await page.waitForTimeout(1500)
-}
-
-/**
- * Click a VM node on the graph by hostname.
- * Uses the API to find the node's WG IP, then clicks via evaluate.
- */
-async function selectNode(page, hostname) {
-  await page.evaluate((h) => {
-    const cy = document.querySelector('#cy')?._cyreg?.cy
-    if (!cy) throw new Error('Cytoscape instance not found')
-    const node = cy.$(`#${h}`)
-    if (node.empty()) throw new Error(`Node '${h}' not found on graph`)
-    node.emit('tap')
-  }, hostname)
-  // Wait for info panel to populate
-  await page.waitForTimeout(500)
-}
-
-/**
- * Click an action button in the info panel by text content.
- */
-async function clickInfoButton(page, buttonText) {
-  const btn = page.locator('#info-panel button', { hasText: buttonText })
-  await expect(btn).toBeVisible({ timeout: 5_000 })
-  await btn.click()
-}
-
-/**
- * Wait for a provisioning/refresh/destroy job to complete.
- * Polls the API /api/jobs endpoint.
- */
-async function waitForJob(page, jobId, timeoutMs = 2_100_000) {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const resp = await page.request.get(`${API_URL}/api/jobs`)
-    const jobs = await resp.json()
-    const job = jobs[jobId]
-    if (!job) throw new Error(`Job ${jobId} not found`)
-    if (job.status === 'done') return job
-    if (job.status === 'failed') throw new Error(`Job ${jobId} failed`)
-    await page.waitForTimeout(5_000)
-  }
-  throw new Error(`Job ${jobId} timed out after ${timeoutMs}ms`)
-}
 
 // ── Deploy from Template ────────────────────────────────────────────────────
 

--- a/prototypes/cytoscape/tests/unprovisioned.spec.js
+++ b/prototypes/cytoscape/tests/unprovisioned.spec.js
@@ -1,0 +1,88 @@
+// @ts-check
+import { test, expect } from '@playwright/test'
+import { BASE_URL, API_URL, waitForGraph, selectNode, waitForJob } from './helpers.js'
+
+/**
+ * #143 — Unprovisioned node: button guards + e2e Provision
+ *
+ * Usage:
+ *   npx playwright test tests/unprovisioned.spec.js
+ *   PROVISION_HOSTNAME=target3 npx playwright test --grep "e2e"
+ */
+
+// ── Negative test: button visibility on unprovisioned node ──────────────────
+
+test.describe('unprovisioned node — button guards', () => {
+  test('Refresh absent, Provision + Destroy present', async ({ page }) => {
+    await page.goto(BASE_URL)
+    await waitForGraph(page)
+
+    const hostname = await page.evaluate(() => {
+      const cy = document.querySelector('#cy')?._cyreg?.cy
+      if (!cy) return null
+      const unprov = cy.nodes('[role = "spoke"][!provisioned]:not(.phantom):not(.template-node)')
+      if (unprov.length) return unprov[0].id()
+      const spoke = cy.nodes('[role = "spoke"]:not(.phantom):not(.template-node)')
+      if (!spoke.length) return null
+      const h = spoke[0].id()
+      spoke[0].data('provisioned', false)
+      spoke[0].data('erp_url', null)
+      spoke[0].data('label', `${h}\n[unprovisioned]`)
+      return h
+    })
+    test.skip(!hostname, 'No spoke node available')
+
+    await selectNode(page, hostname)
+
+    const panel = page.locator('#info-panel')
+    await expect(panel.locator('button', { hasText: 'Provision' })).toBeVisible({ timeout: 3_000 })
+    await expect(panel.locator('button', { hasText: 'Destroy' })).toBeVisible({ timeout: 3_000 })
+    for (const absent of ['Refresh', 'Start', 'Stop', 'Reboot', 'Inspect']) {
+      await expect(panel.locator('button', { hasText: absent })).toHaveCount(0)
+    }
+  })
+})
+
+// ── E2e: Provision an unprovisioned VM via cloud-init path ──────────────────
+
+test.describe('Provision unprovisioned VM (e2e)', () => {
+  test('Provision button starts job, waits for completion', async ({ page }) => {
+    const hostname = process.env.PROVISION_HOSTNAME || 'target3'
+
+    await page.goto(BASE_URL)
+    await waitForGraph(page)
+
+    const nodeState = await page.evaluate((h) => {
+      const cy = document.querySelector('#cy')?._cyreg?.cy
+      if (!cy) return null
+      const node = cy.$(`#${h}`)
+      if (node.empty()) return null
+      return { provisioned: node.data('provisioned') }
+    }, hostname)
+    test.skip(!nodeState, `'${hostname}' not on graph`)
+    test.skip(nodeState.provisioned === true, `'${hostname}' already provisioned`)
+
+    await selectNode(page, hostname)
+    const provBtn = page.locator('#info-panel button', { hasText: 'Provision' })
+    await expect(provBtn).toBeVisible({ timeout: 3_000 })
+    await provBtn.click()
+
+    await expect(page.locator('#info-panel pre.job-log')).toBeVisible({ timeout: 5_000 })
+
+    await page.waitForTimeout(3_000)
+    const resp = await page.request.get(`${API_URL}/api/jobs`)
+    const jobs = await resp.json()
+    const [jobId] = Object.entries(jobs).find(
+      ([, j]) => j.hostname === hostname && j.status === 'running'
+    ) || []
+    expect(jobId).toBeTruthy()
+
+    await waitForJob(page, jobId, 900_000)
+
+    const resp2 = await page.request.get(`${API_URL}/api/hosts`)
+    const data2 = await resp2.json()
+    const host = data2.hosts.find(h => h.hostname === hostname)
+    expect(host).toBeTruthy()
+    expect(host.provisioned).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- **Negative test**: confirms Refresh/Start/Stop/Reboot/Inspect buttons are absent on unprovisioned nodes; Provision + Destroy are present
- **E2e Provision test**: clicks Provision on an unprovisioned node, waits for cloud-init job to complete, verifies provisioned state via API
- **Helper extraction**: shared Playwright utilities (`waitForGraph`, `selectNode`, `clickInfoButton`, `waitForJob`) moved from `topology-ops.spec.js` to `tests/helpers.js` — imported by both spec files

Note: the e2e test may surface #142 (`_generate_cloud_init()` hardcodes stale path) — that's by design.

Fixes #143

## Test plan

- [ ] `npx playwright test --grep "button guards"` — negative test (no live VM needed)
- [ ] `PROVISION_HOSTNAME=target3 npx playwright test --grep "e2e"` — real cloud-init provision run
- [ ] `npx playwright test tests/topology-ops.spec.js --grep "inspect"` — verify existing tests still pass after helper extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)