### PR TITLE
fix(cytoscape): Deploy/Refresh tests wait for job completion

### DIFF
--- a/prototypes/cytoscape/tests/topology-ops.spec.js
+++ b/prototypes/cytoscape/tests/topology-ops.spec.js
@@ -165,6 +165,18 @@ test.describe('Deploy from Template', () => {
       ([, j]) => j.hostname === hostname && j.status === 'running'
     )
     expect(activeJob).toBeTruthy()
+    const [jobId] = activeJob
+
+    // Wait for provisioning to complete (template clone + differentiation — up to 35 min)
+    await waitForJob(page, jobId, 2_100_000)
+
+    // Verify node is now provisioned and ERPNext is reachable
+    const resp2 = await page.request.get(`${API_URL}/api/hosts`)
+    const data2 = await resp2.json()
+    const host = data2.hosts.find(h => h.hostname === hostname)
+    expect(host).toBeTruthy()
+    expect(host.provisioned).toBe(true)
+    expect(host.erp_url).toBeTruthy()
   })
 })
 
@@ -187,6 +199,18 @@ test.describe('Refresh', () => {
       ([, j]) => j.hostname === hostname && j.status === 'running'
     )
     expect(refreshJob).toBeTruthy()
+    const [jobId] = refreshJob
+
+    // Wait for refresh to complete (differentiation re-run — up to 35 min)
+    await waitForJob(page, jobId, 2_100_000)
+
+    // Verify VM is still provisioned and healthy via API
+    const resp2 = await page.request.get(`${API_URL}/api/hosts`)
+    const data2 = await resp2.json()
+    const host = data2.hosts.find(h => h.hostname === hostname)
+    expect(host).toBeTruthy()
+    expect(host.provisioned).toBe(true)
+    expect(host.erp_url).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
## Summary

- Deploy test now calls `waitForJob()` (up to 35 min) then asserts `provisioned === true` and `erp_url` present
- Refresh test does the same — waits for differentiation re-run to finish, verifies VM still healthy
- Both become real acceptance gates instead of fire-and-forget checks

Fixes #129

## Test plan

- [ ] `DEPLOY_HOSTNAME=dev01 DEPLOY_NICKNAME=D1IRBL DEPLOY_WG_IP=10.10.0.13 DEPLOY_VIRBR0_IP=192.168.122.21 npx playwright test --grep "deploy"` — full end-to-end deploy with wait
- [ ] `REFRESH_HOSTNAME=dev03 npx playwright test --grep "Refresh"` — full refresh with wait
- [ ] Verify test fails if job status becomes `failed` (kill the backend mid-job to simulate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)