### PR TITLE
fix(kvm): pipeline improvements from dev01/dev02 rebuilds

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -11,7 +11,7 @@ wg_pubkey_controller: "j94APdOpRArs3J78vcnRVJC5ALIFy/W9qLFacKbwGzk="
 wg_pubkey_saconsole:  "nn916J0YAufbwZNOKvWs2VX6sV4BKuTqE//985lIiRw="
 wg_pubkey_dev03: "KJex8B/eHaNlf589uiY7ymqyTfcPsWTdlLFb5VlKkhg="
 wg_pubkey_dev01: "TJihVKgqhp/AjiWL/IKaWvujs9dB3VmrYUPf8+d3XCA="
-wg_pubkey_dev02: "xoNPFLAq/Q8qA4j+u6ouY8CMuuO6ig3GiL/aKdLsKhk="
+wg_pubkey_dev02: "iNjyvEMOfPdWOHFwcwGx9o52jjE9B+pB2sE+wzL9qio="
 
 # ── System configuration ───────────────────────────────────────────────────
 system_timezone: "America/New_York"

--- a/config/wireguard/keys.sops.yml
+++ b/config/wireguard/keys.sops.yml
@@ -1,35 +1,35 @@
 controller:
-    private_key: ENC[AES256_GCM,data:yS/oVPfUT5lLrz5TNZ6GrzxsyLswXr75X11+ScXHKS3XgiRMjNWJ1gt5Msg=,iv:t0pL0NseOHPBRGmmhZgWy9SvEGqTV0eaxhSRIT1Dn5A=,tag:ajG7Sxq3+CgPa0rUPRSKyA==,type:str]
-    public_key: ENC[AES256_GCM,data:qwKnfoTAN+IsWko41Ff4IHukvSv2F+0iglSfbONLsk3OClHVTsok5lurDnI=,iv:xVNtdstNF/+swQj1d3kvZSK4BsMBMUfTjyUXI8LMO90=,tag:pXA9piA/1gZC90NNA+hmug==,type:str]
+    private_key: ENC[AES256_GCM,data:f1Atmp4mIASR5PCzaK2Wn0CNENlSaF6Su4pDVk5fWTFisV6eZ3Dd94BR3Js=,iv:PacgN3SBG6T1FceZG+nCUeK6fvFy8m7S9gKj0FfIHNM=,tag:MZcP5be0s7v82D/YjwgJGA==,type:str]
+    public_key: ENC[AES256_GCM,data:Bxy5x1LXKqdqoAVTQcXEuS0z1VLFosoVvk2TP67qUTvFC7A8V+iBlocmDmc=,iv:RWhMVrLxRjLNAG8cVri5KBQlJqMbnopAd8ULRFbYxjA=,tag:0S9oITjWDPNSG+U4TmTGpw==,type:str]
 saconsole:
-    private_key: ENC[AES256_GCM,data:Ln9IJ63Wg9/Mx7QCJUPUjvVPGajtEgzDKbSEaqCDyRjGQ+QUV7J4aOsAC1M=,iv:m8Jy2emv4DtEJ2KEDwkgzFAEnVgDghYIX67ubowYwyU=,tag:5nq57Xhmjbbzm7SZFH24AQ==,type:str]
-    public_key: ENC[AES256_GCM,data:eIbirrEShmx/6NLbsuaq/0f1gkObi5XhNekgotw3afOUFZrtN1T1bpAE3Wo=,iv:KsLc3+TqMpKW4Dk+ZfGuoHHe9E6phJWtOR5b/9Hr/Z4=,tag:uIlCopeZQTFdy4gnD2SGXw==,type:str]
+    private_key: ENC[AES256_GCM,data:JKtICmU9cK3q0d971cqeamItihn2NqkClg+m56nuqGDXW2Vld1TTgzYyvMs=,iv:FIIhT66Npc+nUXPFHubAuz2Z7elQW97U+Fq6suuYiTE=,tag:iENq4EmefBuop+xUVqQFcA==,type:str]
+    public_key: ENC[AES256_GCM,data:wlHPFpQHwUpHoktjGqqgfJ24H/G89ab1XWQf6wnuZwtFkBQ/fSPJm89v6Ok=,iv:wphpwbLcDygXpKZWN4oetjkxuY+AlNXQJ27Ui1lYZ/E=,tag:1zMgLPOZFvLqmxUf9NZodw==,type:str]
 dev03:
-    private_key: ENC[AES256_GCM,data:zscAJ9YLS32QS94ftNDANjsVNrBMo2bjbOM1F/74n2AZdFkVmzmKA6T+Sew=,iv:kfXS52kdDA4KdfzOyVgwfJo5HnZxAspNPXOd56IwEHc=,tag:guw1NQ8MqNnIAEaoDfbHlA==,type:str]
-    public_key: ENC[AES256_GCM,data:WolboHCMecpwIVOOG+P2TPdmwLh26akPImWQI0Alkb9wfeHTm+74zRgLt6I=,iv:cKkA+erMBReX8mQaTkAgqCjNDC5pBm3d6K+ahC1ObjU=,tag:kdHKJVpybM+5SMFF+i1ZZg==,type:str]
+    private_key: ENC[AES256_GCM,data:er0UCCpncN+BdSAj7yBH2mcaw+mCbvkuu3D9OdjMSsLkBcbQKdnvo0YrFPs=,iv:8CPFjmd4vJoi+bKS0J8vph5wpezWrs1OlHTNKvC0xdw=,tag:7DSV/k9ibwmFYxeSpKXp2A==,type:str]
+    public_key: ENC[AES256_GCM,data:RzDG/CrZdbGf2FIlA9UtXGuNjbcetzIs766BO8UPV8DP1luv4dJJHZmFROQ=,iv:qWKQZTH3Z89eGOOXHqERHjBXMEyyd6Y5KxtoZNHObRI=,tag:t97+i4AFNgBPQVwzJjH+Kw==,type:str]
 dev01:
-    private_key: ENC[AES256_GCM,data:gqkIRLRxilFqZ0ddG7fYRcqIgYR57w9Ff78J4QiA9YRcPQ1p1tP310yAPZU=,iv:coVU9JhDfERs815mRsabl5FbpSRXwuXg3QK1uEfdxP8=,tag:wmhX/XvUJrRDPvhmw4K6nQ==,type:str]
-    public_key: ENC[AES256_GCM,data:PYrCXgBv3jboSyko8ueL18NW+Ay/xP4SG0NkeN6Q6J85zy6N6vssZmBBTlg=,iv:RE8FFEJBcTxEpX4aQGAra1s9nakZLaQpvRzwpRWUKS8=,tag:a5D9TbSW2U5QoMHHBgxlJA==,type:str]
+    private_key: ENC[AES256_GCM,data:vzP4St9D2nHeGHx/QyvIHvFgOZjAKfNWTlr+X+cZfjNFPjR7twXhuG5SGKY=,iv:yBsLDmee8QCqL0ZqtZlf3SIJnTE3IFymzxg2vdGXeGo=,tag:ok6S9mhgS8YtYMsuZ56Owg==,type:str]
+    public_key: ENC[AES256_GCM,data:15DGBUAzTkqmbLH0EtyPqAGFz1bXtPYOjV64pduDptD0pBfvgm3dhzZm+7w=,iv:8ry5hhxPQ5oLc7H0mphkCqilF2qislJvHtlXnsnTRDM=,tag:2/xMyzyRXHy4fzcBHhjIRA==,type:str]
 dev02:
-    private_key: ENC[AES256_GCM,data:UTC43g8RBMivnacNZ509saPJvBTCXeHeA4woxTfio/f7AfaBWxj2xwPqRvE=,iv:Px5Pe6zbpNBk0UyYVX7nCmzJBn+M2yAL/JLhcM01vQ8=,tag:OyD4+/EWP1PbSDG/BLDk7A==,type:str]
-    public_key: ENC[AES256_GCM,data:n3eqMC6gcQ6D9xUocWcjmwypJWXLbeetBOIQClIQ99/1nsBzRwX5bJY58Bc=,iv:y3OTPX9xWtOwkrnOH0tgkqDBSvkAdXc0O4Sb/+1Lsd4=,tag:Kq9IjfDNUMO1NlL1/uBNew==,type:str]
+    private_key: ENC[AES256_GCM,data:yjeYoRGmyZxB1kgxAYb0X8qFGOggjDe5tROvMpv2zpZ5q+xL/KkLhY7NaGc=,iv:kgCy1GhqK5W5JFC1H7d/LSLjyirZKA+x677JBl/z57E=,tag:qs7ftslKYwCnQZM4sbKy4w==,type:str]
+    public_key: ENC[AES256_GCM,data:FmUZflTkuwUGhHthe1ztT+94MQTrt3o8UjD+SuZ8FZR5vcSkQr5tqRpGzbg=,iv:4G6UvbPdkUrcMQmVxsqaGEXcfaHI0LKPXxG1OA2pm3s=,tag:jqSHb7Acizt/BRZtaReKLQ==,type:str]
 preshared_keys:
-    controller_saconsole: ENC[AES256_GCM,data:hu0XyzhLxfzjiK0uJFCzNI9IomOjViSyyKIMmegwxkoPo0RF+geRSJ5rBNw=,iv:pVhyzRCamIPZT/a+ibxr0Uq/2hOHe2qoWU9vNWDyBz0=,tag:9/CuzEemQiDDe/aXSYovaA==,type:str]
-    dev03_saconsole: ENC[AES256_GCM,data:wPYJOlZU15aFYIMF+EYKmTLmeFeYVjFKJkdsidp84+LqgOgmieQJIEiAegg=,iv:SiaCEq2zYvNt/T/sODANCDqHM13ZiEslzqjUjQoIeFk=,tag:7fatPx0M9C2hb7SWMA31Cg==,type:str]
-    dev01_saconsole: ENC[AES256_GCM,data:eu7piVEBGap1lNThKWSfkBO2gBjyKNKfyYyYUr5bgaCPViQz4CdiYX0AQw0=,iv:top9JJ0Qup+lgLVDREd7bDAWQeGzdap55sDGOyVd8Qo=,tag:+AjfIGsxVMVxefzanVCKiQ==,type:str]
-    dev02_saconsole: ENC[AES256_GCM,data:kOD2KzQdM2PODNgy7fgutsM+jkQVvygdThPZjQMPafQtwZDz0Gay3I+iKis=,iv:AjAPvYgr5xhRsVqBu7bwFhcTne374zHVvIz1oadvjXE=,tag:CfmVu7eBCw38aHBcOn52pg==,type:str]
+    controller_saconsole: ENC[AES256_GCM,data:yMdjuzjP6d8cGdm0mUDNLgMX6t0Et8YEdKBUy+vq5aDRnM7IfU+If3T/B9I=,iv:ry3thTDx+Ok12GBMAnIUeS3VvLbB2trrfhnC5v2fV1A=,tag:CmWjCwG+DCa8rIvj1pg4oA==,type:str]
+    dev03_saconsole: ENC[AES256_GCM,data:CARTx2h2eZaHfxtz8rRPPccu7naPUPCLFHO8Sb45vvAqM21vyEJ8UDGotQ4=,iv:NuoGvFAS3l57fVND0yPbFsSl87KjKzEMw87QgJdTVmg=,tag:nubcSGcIDoYUwu7fAmIVcw==,type:str]
+    dev01_saconsole: ENC[AES256_GCM,data:T8UDy9d/GLoUb+VSxpCSnRPvKIKftvxNSBsKqNCT8phtxpt/aJWLYvkrb0E=,iv:hdIJDHC80tiv1FwH4inVnqd7BfCvVTqB9fSNobkwOtw=,tag:n4YhLwAsJg/vzK/WiAQmwA==,type:str]
+    dev02_saconsole: ENC[AES256_GCM,data:tl7OlH6//UKin6IV4lKd/qr0NfNzVEqu/cytRbfMj2Z/KSG2lOsULTE3lTk=,iv:0wxlBr2B7akJ+gCOiVQ17NH7jItspBr0Aab1ixU7XAY=,tag:I1c2YzBBqApRPKOf3uANKw==,type:str]
 sops:
     age:
         - recipient: age185wy6suru3x53leqjf866zsz02vece8cnsy6g92tz7ae0ykw45dsjp2sl8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzcTFlNW1IK2YxaXpuOXNk
-            dDliMXRjNGtlbTg5K1N0U2g3MzQ0bXM1VDJZCk8wY3d1aTVvdUVPbHV0bEl6WHVP
-            V1pjQmppUmhqZEhCTDUxVzF0ZTZpODgKLS0tIEZ6M0FwT2NKaWlMNlRRTlpqeC9z
-            R1liUjIzUDVkMkcrNTV2V0tKOU1MY2cKmxyW44ouUzQLuSMpcdpAlZp+eWEvUMMM
-            dnxeVz54MuY6U1oSlu8yV1BfUPKSZBbxXjO8vpi+ZGzNhAtVP0pneg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIN3c1L2kyd2VvV1VzV1k0
+            WjFNSldhWU43K1h5LzJHbUNSNjZvejQ1Y3dBCk1ET0g5b3Ria0g3azU3dHBIaTQ2
+            RDFNa0JQcDYwbHFjTnVySWdobnVLVFUKLS0tIEtMWWtWbmNZVEpNNGRaZjM5NWdN
+            OGVFT2pmM0poRzRLQzU5SllMVy94bk0Kitcx4dPyHXg3AwULlpnwOfHJmwTNRuxr
+            91JKH4bRKT3vY3m+RrvVp0sdBnilb+nGrEuwyisKDRXFj5AklJDI6Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-08T19:33:32Z"
-    mac: ENC[AES256_GCM,data:OiHbrSy9ssxgkcm5pD7dBEtwesmcEtgS0kmit4LVFfGEvmN5fyfDin4B81EghqNlyVGYN+ibGQKDyOBpegOxeQZzOy9muLhr4B6lOks4v4Vk2UZEo5K/WUkIaXJkuDAN/4gma+iA+ziNBfFv8hNzFCvfmgsMX4tJ0ZHZg2XD2Rw=,iv:xKatvxghJ4oyPs16s1qgHgfPFZu/s5LggJ0qjbjncpc=,tag:Rj8ojVZZy0oo29HrLrNnxA==,type:str]
+    lastmodified: "2026-04-10T12:45:58Z"
+    mac: ENC[AES256_GCM,data:I+sJEDXLM+gQXMmnS7+g2UF1Qzkh+81CuqLiYCW8ju14gEMDK/tDnMQCwq1Loofu7+JSpPsfSOoK6VI4gTyHsIWqtyv5zxD1E+N0mLS57DWKhBdIKuH2hadOyHB18HzHXcss61QeCAdp2qNdplVHUZVaieaciJIbpZXeoIJsDuU=,iv:KmifWLgwN+w5yASGCA8phf454Bt4gb3dcj6Nh54xMQg=,tag:Cch/kRLXT4LTjTXj6sPzlQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1

--- a/platforms/kvm/dev01-differentiate.sh
+++ b/platforms/kvm/dev01-differentiate.sh
@@ -174,6 +174,10 @@ else
   echo "  [OK] site created, erpnext installed"
 fi
 
+echo "=== D1: ensure currentsite.txt ==="
+sudo -u "$ERP_USER" bash -c "echo '$SITE_URL' > $BENCH_DIR/sites/currentsite.txt"
+echo "  [OK] currentsite.txt set to $SITE_URL"
+
 echo "=== E: place ddlViews.sql ==="
 sudo -u "$ERP_USER" mkdir -p "$BENCH_DIR/sites/$SITE_URL/private/files"
 sudo -u "$ERP_USER" cp /tmp/ddlViews.sql "/home/erpadm/frappe-bench-D1IRBL/sites/dev01.iridium.blue/private/files/ddlViews.sql"
@@ -181,8 +185,7 @@ rm -f /tmp/ddlViews.sql
 echo '  [OK] ddlViews.sql placed'
 
 echo "=== E1: seed tabPatch Log (skip patches that crash on restored DB) ==="
-python3 /tmp/vm_scripts/g1_seed_patch_log.py \
-  --bench-dir "$BENCH_DIR" --site "$SITE_URL"
+python3 /tmp/vm_scripts/g1_seed_patch_log.py   --bench-dir "$BENCH_DIR" --site "$SITE_URL"
 
 echo "=== F: installApps.sh ==="
 sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bash BaRe/installApps.sh"
@@ -191,13 +194,12 @@ echo "  [OK] installApps.sh complete"
 echo "=== G-pre: strip DEFINER clauses from backup SQL ==="
 python3 /tmp/vm_scripts/gpre_strip_definer.py --bench-dir "$BENCH_DIR"
 
-echo "=== G: handleRestore.sh ==="
-sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bash BaRe/handleRestore.sh"
+echo "=== G: handleRestore.sh (social login deferred to post-H4a) ==="
+sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && DEFER_SOCIAL_LOGIN=1 bash BaRe/handleRestore.sh"
 echo "  [OK] database restored"
 
 echo "=== G1: re-seed tabPatch Log (restore wiped DB) ==="
-python3 /tmp/vm_scripts/g1_seed_patch_log.py \
-  --bench-dir "$BENCH_DIR" --site "$SITE_URL"
+python3 /tmp/vm_scripts/g1_seed_patch_log.py   --bench-dir "$BENCH_DIR" --site "$SITE_URL"
 
 echo "=== G2: clear fixture Custom Fields + re-migrate ==="
 echo "  Clearing fixture-defined Custom Fields from restored DB..."
@@ -211,6 +213,14 @@ sudo supervisorctl reread
 sudo supervisorctl update
 echo "  [OK] supervisor updated"
 
+echo "=== H2a: ensure site hostname resolves to localhost ==="
+if ! grep -q "$SITE_URL" /etc/hosts; then
+    echo "127.0.0.1 $SITE_URL" | sudo tee -a /etc/hosts >/dev/null
+    echo "  [OK] added $SITE_URL to /etc/hosts"
+else
+    echo "  [OK] $SITE_URL already in /etc/hosts"
+fi
+
 echo "=== H2: bench restart ==="
 sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && python3 stop.py"
 sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench restart"
@@ -218,9 +228,9 @@ sudo supervisorctl restart frappe-bench-ce-sri-svc
 echo "  [OK] bench + ce_sri_svc restarted"
 
 echo "=== H2b: wait for gunicorn to respond ==="
-PING_URL="http://127.0.0.1:8000/api/method/ping"
+PING_URL="http://$SITE_URL:8000/api/method/ping"
 WAITED=0
-MAX_WAIT=60
+MAX_WAIT=120
 while [ $WAITED -lt $MAX_WAIT ]; do
     if curl -sf "$PING_URL" >/dev/null 2>&1; then
         echo "  [OK] gunicorn responding after ${WAITED}s"
@@ -230,7 +240,8 @@ while [ $WAITED -lt $MAX_WAIT ]; do
     WAITED=$((WAITED + 2))
 done
 if [ $WAITED -ge $MAX_WAIT ]; then
-    echo "  [WARN] gunicorn did not respond within ${MAX_WAIT}s — continuing anyway"
+    echo "  [FAIL] gunicorn did not respond within ${MAX_WAIT}s — aborting"
+    exit 1
 fi
 
 echo "=== H4a: clear stale encrypted secrets + regenerate API key ==="
@@ -259,9 +270,10 @@ echo "=== H4c: generate bench nginx.conf (install.py patches it) ==="
 sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench setup nginx --yes" || true
 echo "  [OK] config/nginx.conf generated"
 
-echo "=== H4d: run ce_sri before_install ==="
-sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench --site $SITE_URL execute ce_sri.install.before_install"
-echo "  [OK] ce_sri before_install complete"
+echo "=== H4d: run install_specific.py before-install (file patches — no gunicorn needed) ==="
+export TARGET_BENCH="$BENCH_DIR" ERPNEXT_SITE_URL="$SITE_URL"
+sudo -u "$ERP_USER" -E bash -c "cd $BENCH_DIR && python3 /tmp/install_specific.py before-install"
+echo "  [OK] install_specific.py before-install complete"
 
 echo "=== H4e: generate .env via UPDATE_SRI_SERVICE_PARAMETERS.py ==="
 _CESRI_SVC="$BENCH_DIR/apps/ce_sri/services/ce_sri_svc"
@@ -277,6 +289,27 @@ sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench restart"
 sudo supervisorctl restart frappe-bench-ce-sri-svc
 sudo nginx -t && sudo systemctl reload nginx
 echo "  [OK] services restarted after install.py"
+
+echo "=== H4f-poll: wait for gunicorn to respond after restart ==="
+WAITED=0
+MAX_WAIT=120
+while [ $WAITED -lt $MAX_WAIT ]; do
+    if curl -sf --max-time 5 "http://$SITE_URL:8000/api/method/ping" >/dev/null 2>&1; then
+        echo "  [OK] gunicorn responding after ${WAITED}s"
+        break
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+done
+if [ $WAITED -ge $MAX_WAIT ]; then
+    echo "  [FAIL] gunicorn did not respond within ${MAX_WAIT}s — aborting"
+    exit 1
+fi
+
+echo "=== H4g: run install_specific.py after-restart (API config — gunicorn must be up) ==="
+export TARGET_BENCH="$BENCH_DIR" ERPNEXT_SITE_URL="$SITE_URL"
+sudo -u "$ERP_USER" -E bash -c "cd $BENCH_DIR && python3 /tmp/install_specific.py after-restart"
+echo "  [OK] install_specific.py after-restart complete"
 
 echo "=== I: install TLS cert ==="
 sudo mkdir -p /etc/nginx/certs/iridium.blue
@@ -307,6 +340,32 @@ sudo ln -sf /etc/nginx/sites-available/dev01.iridium.blue /etc/nginx/sites-enabl
 sudo rm -f /etc/nginx/sites-enabled/default
 sudo nginx -t && sudo systemctl reload nginx
 echo "  [OK] nginx reloaded with SSL site"
+
+echo "=== H4a-sl: restore Social Login config (needs HTTPS + fresh __Auth from H4a) ==="
+if [ -f /tmp/socials_google.json ]; then
+    sudo -u "$ERP_USER" cp /tmp/socials_google.json "$BENCH_DIR/sites/$SITE_URL/socials_google.json"
+    echo "  [OK] socials_google.json placed in site directory"
+fi
+APIKEY_SH="$BENCH_DIR/sites/$SITE_URL/private/files/apikey.sh"
+if [ -f "$APIKEY_SH" ]; then
+    source "$APIKEY_SH"
+    RESOURCE_URL="https://$SITE_URL/api/resource"
+    SWITCHES="--location --insecure --no-progress-meter --request"
+    AUTH_HEADER="Authorization: token $KEYS"
+    CONTENT_HEADER="Content-Type: application/json"
+    SLK="Social%20Login%20Key"
+    SOCIAL_CONF="$BENCH_DIR/sites/$SITE_URL/socials_google.json"
+    if [ -f "$SOCIAL_CONF" ]; then
+        curl $SWITCHES DELETE --header "$AUTH_HEADER" --header "$CONTENT_HEADER" "$RESOURCE_URL/$SLK/google" >/dev/null 2>&1 || true
+        RSLT=$(curl $SWITCHES POST --header "$AUTH_HEADER" --header "$CONTENT_HEADER" -d @"$SOCIAL_CONF" "$RESOURCE_URL/$SLK")
+        MSG=$(echo "$RSLT" | jq -r .data.social_login_provider 2>/dev/null || echo "unknown")
+        echo "  [OK] Social Login restored (provider: $MSG)"
+    else
+        echo "  [SKIP] No socials_google.json found — Social Login not configured"
+    fi
+else
+    echo "  [WARN] apikey.sh not found — cannot restore Social Login"
+fi
 
 echo "=== L0: deploy stop.py ==="
 cp /tmp/rendered/stop.py $BENCH_DIR/stop.py

--- a/platforms/kvm/dev02-differentiate.sh
+++ b/platforms/kvm/dev02-differentiate.sh
@@ -270,9 +270,10 @@ echo "=== H4c: generate bench nginx.conf (install.py patches it) ==="
 sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench setup nginx --yes" || true
 echo "  [OK] config/nginx.conf generated"
 
-echo "=== H4d: run ce_sri before_install (file patches only — no gunicorn needed) ==="
-sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench --site $SITE_URL execute ce_sri.install.before_install"
-echo "  [OK] ce_sri before_install complete (Procfile, supervisor.conf, nginx patched)"
+echo "=== H4d: run install_specific.py before-install (file patches — no gunicorn needed) ==="
+export TARGET_BENCH="$BENCH_DIR" ERPNEXT_SITE_URL="$SITE_URL"
+sudo -u "$ERP_USER" -E bash -c "cd $BENCH_DIR && python3 /tmp/install_specific.py before-install"
+echo "  [OK] install_specific.py before-install complete"
 
 echo "=== H4e: generate .env via UPDATE_SRI_SERVICE_PARAMETERS.py ==="
 _CESRI_SVC="$BENCH_DIR/apps/ce_sri/services/ce_sri_svc"
@@ -305,9 +306,10 @@ if [ $WAITED -ge $MAX_WAIT ]; then
     exit 1
 fi
 
-echo "=== H4g: run ce_sri after_restart (API config — polls gunicorn internally) ==="
-sudo -u "$ERP_USER" bash -c "cd $BENCH_DIR && bench --site $SITE_URL execute ce_sri.install.after_restart"
-echo "  [OK] ce_sri after_restart complete"
+echo "=== H4g: run install_specific.py after-restart (API config — gunicorn must be up) ==="
+export TARGET_BENCH="$BENCH_DIR" ERPNEXT_SITE_URL="$SITE_URL"
+sudo -u "$ERP_USER" -E bash -c "cd $BENCH_DIR && python3 /tmp/install_specific.py after-restart"
+echo "  [OK] install_specific.py after-restart complete"
 
 echo "=== I: install TLS cert ==="
 sudo mkdir -p /etc/nginx/certs/iridium.blue


### PR DESCRIPTION
## Summary
- **dev01-differentiate.sh**: 6 pipeline improvements — `currentsite.txt` creation (D1), deferred Social Login restoration to post-HTTPS (H4a-sl), `/etc/hosts` hostname resolution (H2a), hard abort on gunicorn timeout, `install_specific.py` migration (H4d/H4g), post-restart gunicorn poll (H4f-poll)
- **dev02-differentiate.sh**: same `install_specific.py` migration (H4d, H4g)
- **WireGuard keys**: dev02 pubkey updated after 2026-04-08 rebuild; SOPS re-encrypted all keys

These changes were tested during the dev01 Deploy acceptance test (PR #145) but never committed to the repo.

## Test plan
- [x] dev01 Deploy acceptance test passed (PR #145, 29.6 min end-to-end)
- [x] dev02 rebuilt 2026-04-08 with H4d/H4g changes
- [x] WireGuard mesh healthy (sync_check section 9b: 4 peers match inventory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)