### PR TITLE
chore(pipeline): fix log formatting, fixes #162

### DIFF
--- a/tools/pipeline/macro/provision.py
+++ b/tools/pipeline/macro/provision.py
@@ -6,6 +6,7 @@ import subprocess
 
 from tools.pipeline.orchestration.load_host_config import load_host_config
 from tools.pipeline.stages.common.config import build_config
+from tools.pipeline.stages.common.log_format import stage_banner
 from tools.pipeline.stages.common.types import Emit
 from tools.pipeline.stages.env_kvm import KvmEnv
 from tools.pipeline.stages.stage_1_vm_creation import run_stage_1
@@ -32,7 +33,7 @@ def run(
     Raises RuntimeError on the first stage that fails.
     """
     # ── Stage 1: VM Creation (special signature — not yet Config-based) ──
-    emit("═══ Stage 1: VM Creation ═══")
+    emit(stage_banner("Stage 1: VM Creation"))
     kvm_env = KvmEnv.from_project_root(project_root)
     run_stage_1(
         hostname=hostname,
@@ -58,11 +59,11 @@ def run(
         ("Stage 9: Service Activation", run_stage_9),
     ]
     for label, stage_fn in _STAGES:
-        emit(f"═══ {label} ═══")
+        emit(stage_banner(label))
         stage_fn(config, emit)
 
     # ── Final snapshot ──
-    emit("═══ Final snapshot ═══")
+    emit(stage_banner("Final snapshot"))
     _take_final_snapshot(hostname, kvm_env.hypervisor_alias, emit)
 
 

--- a/tools/pipeline/macro/refresh.py
+++ b/tools/pipeline/macro/refresh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from tools.pipeline.stages.common.config import build_config
+from tools.pipeline.stages.common.log_format import stage_banner
 from tools.pipeline.stages.common.types import Emit
 from tools.pipeline.stages.stage_3_connectivity import run_stage_3
 from tools.pipeline.stages.stage_4_content_delivery import run_stage_4
@@ -36,5 +37,5 @@ def run(
         ("Stage 9: Service Activation", run_stage_9),
     ]
     for label, stage_fn in _STAGES:
-        emit(f"═══ {label} ═══")
+        emit(stage_banner(label))
         stage_fn(config, emit)

--- a/tools/pipeline/stages/common/log_format.py
+++ b/tools/pipeline/stages/common/log_format.py
@@ -1,0 +1,22 @@
+"""ANSI color helpers for pipeline log output."""
+
+# Bold cyan for stage banners, yellow for steps
+_BOLD_CYAN = "\033[1;36m"
+_YELLOW = "\033[0;33m"
+_RESET = "\033[0m"
+
+
+def stage_banner(label: str) -> str:
+    """Format a stage banner with spacing and color.
+
+    Returns a string like: \\n\\n<bold cyan>═══ Stage 1: VM Creation ═══</bold cyan>
+    """
+    return f"\n\n{_BOLD_CYAN}═══ {label} ═══{_RESET}"
+
+
+def step_header(label: str) -> str:
+    """Format a step header with spacing and color.
+
+    Returns a string like: \\n<yellow>── Deploy keys ──</yellow>
+    """
+    return f"\n{_YELLOW}── {label} ──{_RESET}"

--- a/tools/pipeline/stages/stage_1_vm_creation/__init__.py
+++ b/tools/pipeline/stages/stage_1_vm_creation/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.types import Emit
 from tools.pipeline.stages.env_kvm import KvmEnv
 
@@ -65,34 +66,34 @@ def run_stage_1(
 
     # ── Step 0: Clean up residue from a previous build ──
     if cleanup_cfg:
-        emit("── Step 0: Cleaning up residue from previous build ──")
+        emit(step_header("Clean up residue from previous build"))
         cleanup_residue(hostname, cleanup_cfg, env.hypervisor_alias, emit)
         emit("  [OK] Old VM residue removed — starting fresh")
 
     # ── Step 1: WireGuard peer ──
-    emit("── Step 1: Add WireGuard peer ──")
+    emit(step_header("Add WireGuard peer"))
     add_wireguard_peer(hostname, env, emit)
 
-    # ── Step 2: Build seed ISO ──
-    emit("── Step 2: Build cloud-config seed ISO ──")
+    # ── Build seed ISO ──
+    emit(step_header("Build cloud-config seed ISO"))
     seed_local = build_seed_iso(hostname, virbr0_ip, env.platforms_kvm, emit)
 
-    # ── Step 3: Upload seed ISO to hypervisor ──
-    emit("── Step 3: Upload seed ISO to hypervisor ──")
+    # ── Upload seed ISO to hypervisor ──
+    emit(step_header("Upload seed ISO to hypervisor"))
     remote_seed = upload_seed_iso(hostname, seed_local, env, emit)
 
-    # ── Step 4: Clone template qcow2 ──
-    emit("── Step 4: Clone template qcow2 ──")
+    # ── Clone template qcow2 ──
+    emit(step_header("Clone template qcow2"))
     clone_template(hostname, env, emit)
 
-    # ── Step 5: virt-install --import ──
-    emit("── Step 5: virt-install --import ──")
+    # ── virt-install --import ──
+    emit(step_header("virt-install --import"))
     virt_install_import(hostname, remote_seed, env, emit)
 
-    # ── Step 6: Wait for SSH ──
-    emit("── Step 6: Wait for SSH ──")
+    # ── Wait for SSH ──
+    emit(step_header("Wait for SSH"))
     wait_for_ssh(hostname, virbr0_ip, env.hypervisor_alias, ssh_key, emit)
 
-    # ── Step 7: Take Baseline snapshot ──
-    emit("── Step 7: Take Baseline snapshot ──")
+    # ── Take Baseline snapshot ──
+    emit(step_header("Take Baseline snapshot"))
     take_baseline_snapshot(hostname, env.hypervisor_alias, emit)

--- a/tools/pipeline/stages/stage_2_network/__init__.py
+++ b/tools/pipeline/stages/stage_2_network/__init__.py
@@ -6,6 +6,7 @@ Orchestrates Steps 8–9 of the provision pipeline.  Extracted from
 
 from __future__ import annotations
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.types import Config, Emit
 
 from .cloudflare_dns import upsert_cloudflare_dns
@@ -43,32 +44,32 @@ def run_stage_2(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 2 already satisfied — skipping")
         return
 
-    # ── Step 8: Update saconsole WireGuard hub ──
-    emit("── Step 8: Update saconsole WireGuard (Ansible) ──")
+    # ── Update saconsole WireGuard hub ──
+    emit(step_header("Update saconsole WireGuard (Ansible)"))
     r = update_saconsole_wg_hub(config, emit)
     if not r.success:
         emit(f"  [WARN] {r.message}")
     else:
         emit(f"  [OK] {r.message}")
 
-    # ── Step 8b: Cloudflare DNS A record ──
-    emit("── Step 8b: Cloudflare DNS A record ──")
+    # ── Cloudflare DNS A record ──
+    emit(step_header("Cloudflare DNS A record"))
     r = upsert_cloudflare_dns(config, emit)
     if not r.success:
         raise RuntimeError(r.message)
     tag = "[CHANGED]" if r.changed else "[OK]"
     emit(f"  {tag} {r.message}")
 
-    # ── Step 8c: Distribute TLS cert from saconsole to VM ──
-    emit("── Step 8c: Distribute TLS wildcard cert to VM ──")
+    # ── Distribute TLS cert from saconsole to VM ──
+    emit(step_header("Distribute TLS wildcard cert to VM"))
     r = ensure_tls_cert(config, emit)
     if not r.success:
         raise RuntimeError(r.message)
     tag = "[CHANGED]" if r.changed else "[OK]"
     emit(f"  {tag} {r.message}")
 
-    # ── Step 9: Configure WireGuard spoke on new VM ──
-    emit("── Step 9: Configure WireGuard spoke (Ansible) ──")
+    # ── Configure WireGuard spoke on new VM ──
+    emit(step_header("Configure WireGuard spoke (Ansible)"))
     r = configure_wireguard_spoke(config, emit)
     if not r.success:
         emit(f"  [WARN] {r.message}")

--- a/tools/pipeline/stages/stage_3_connectivity/__init__.py
+++ b/tools/pipeline/stages/stage_3_connectivity/__init__.py
@@ -6,6 +6,7 @@ Orchestrates Steps 10–11 of the provision pipeline.  Extracted from
 
 from __future__ import annotations
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.types import Config, Emit
 
 from .backup import ensure_backup
@@ -43,40 +44,40 @@ def run_stage_3(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 3 already satisfied — skipping")
         return
 
-    # ── Step 10a: Deploy keys ──
-    emit("── Step 10a: SCP deploy keys ──")
+    # ── Deploy keys ──
+    emit(step_header("SCP deploy keys"))
     r = ensure_deploy_keys(config, emit)
     if not r.success:
         raise RuntimeError(r.message)
     tag = "[CHANGED]" if r.changed else "[OK]"
     emit(f"  {tag} {r.message}")
 
-    # ── Step 10b: Controller pubkey ──
-    emit("── Step 10b: SCP controller pubkey ──")
+    # ── Controller pubkey ──
+    emit(step_header("SCP controller pubkey"))
     r = ensure_controller_pubkey(config, emit)
     if not r.success:
         raise RuntimeError(r.message)
     tag = "[CHANGED]" if r.changed else "[OK]"
     emit(f"  {tag} {r.message}")
 
-    # ── Step 10c: ce_sri secrets ──
-    emit("── Step 10c: ce_sri secrets (SOPS decrypt + patch + SCP) ──")
+    # ── ce_sri secrets ──
+    emit(step_header("ce_sri secrets (SOPS decrypt + patch + SCP)"))
     r = ensure_cesri_secrets(config, emit)
     if not r.success:
         raise RuntimeError(r.message)
     tag = "[CHANGED]" if r.changed else "[OK]"
     emit(f"  {tag} {r.message}")
 
-    # ── Step 10d: Rsync database backup ──
-    emit("── Step 10d: Rsync database backup ──")
+    # ── Rsync database backup ──
+    emit(step_header("Rsync database backup"))
     r = ensure_backup(config, emit)
     if not r.success:
         raise RuntimeError(r.message)
     tag = "[CHANGED]" if r.changed else "[OK]"
     emit(f"  {tag} {r.message}")
 
-    # ── Step 11: ddlViews.sql ──
-    emit("── Step 11: SCP ddlViews.sql ──")
+    # ── ddlViews.sql ──
+    emit(step_header("SCP ddlViews.sql"))
     r = ensure_ddl_views(config, emit)
     if not r.success:
         emit(f"  [WARN] {r.message}")

--- a/tools/pipeline/stages/stage_4_content_delivery/__init__.py
+++ b/tools/pipeline/stages/stage_4_content_delivery/__init__.py
@@ -6,6 +6,7 @@ Orchestrates Step 12 of the provision pipeline.  Extracted from
 
 from __future__ import annotations
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.types import Config, Emit
 
 from .config_bundle import render_and_deploy_config
@@ -37,8 +38,8 @@ def run_stage_4(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 4 already satisfied — skipping")
         return
 
-    # ── Step 12: Render config artifacts + deploy bundle ──
-    emit("── Step 12: Render config + deploy bundle ──")
+    # ── Render config artifacts + deploy bundle ──
+    emit(step_header("Render config + deploy bundle"))
     r = render_and_deploy_config(config, emit)
     if not r.success:
         raise RuntimeError(r.message)

--- a/tools/pipeline/stages/stage_5_tls/__init__.py
+++ b/tools/pipeline/stages/stage_5_tls/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.ssh import scp_to_vm, ssh_run
 from tools.pipeline.stages.common.types import Config, Emit
 
@@ -46,7 +47,7 @@ def run_stage_5(config: Config, emit: Emit) -> None:
         return
 
     # ── SCP tls_setup.sh + shared dhparam.pem to VM ──
-    emit("── Stage 5: TLS setup (sections I, J, K) ──")
+    emit(step_header("TLS setup (sections I, J, K)"))
     r = scp_to_vm(config, [str(_SCRIPT), str(_DHPARAM)], "/tmp/", timeout=15)
     if r.returncode != 0:
         raise RuntimeError(f"SCP tls_setup.sh failed: {r.stderr.strip()}")

--- a/tools/pipeline/stages/stage_6_base_platform/__init__.py
+++ b/tools/pipeline/stages/stage_6_base_platform/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.ssh import scp_to_vm, ssh_run
 from tools.pipeline.stages.common.types import Config, Emit
 
@@ -41,7 +42,7 @@ def run_stage_6(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 6 already satisfied — skipping")
         return
 
-    emit("── Stage 6: Base platform (sections A–C + B2b) ──")
+    emit(step_header("Base platform (sections A\u2013C + B2b)"))
 
     # SCP both scripts
     r = scp_to_vm(config, [str(_PLATFORM_SETUP), str(_CLONE_AND_SERVICES)],

--- a/tools/pipeline/stages/stage_7_data_restoration/__init__.py
+++ b/tools/pipeline/stages/stage_7_data_restoration/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.ssh import scp_to_vm, ssh_run
 from tools.pipeline.stages.common.types import Config, Emit
 
@@ -37,7 +38,7 @@ def run_stage_7(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 7 already satisfied — skipping")
         return
 
-    emit("── Stage 7: Data restoration (sections D–G2) ──")
+    emit(step_header("Data restoration (sections D\u2013G2)"))
 
     # SCP script
     r = scp_to_vm(config, [str(_DATA_RESTORE)], "/tmp/", timeout=15)

--- a/tools/pipeline/stages/stage_8_app_config/__init__.py
+++ b/tools/pipeline/stages/stage_8_app_config/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.ssh import scp_to_vm, ssh_run
 from tools.pipeline.stages.common.types import Config, Emit
 
@@ -48,7 +49,7 @@ def run_stage_8(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 8 already satisfied — skipping")
         return
 
-    emit("── Stage 8: App config (sections H–H4g) ──")
+    emit(step_header("App config (sections H\u2013H4g)"))
 
     # Ensure poll_gunicorn.py is on the VM (may be absent if Stage 4 ran
     # before this file was added to tools/vm_scripts/)

--- a/tools/pipeline/stages/stage_9_service_activation/__init__.py
+++ b/tools/pipeline/stages/stage_9_service_activation/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tools.pipeline.stages.common.log_format import step_header
 from tools.pipeline.stages.common.ssh import scp_to_vm, ssh_run
 from tools.pipeline.stages.common.types import Config, Emit
 
@@ -38,7 +39,7 @@ def run_stage_9(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 9 already satisfied — skipping")
         return
 
-    emit("── Stage 9: Service activation (sections H4a-sl, L0, L) ──")
+    emit(step_header("Service activation (sections H4a-sl, L0, L)"))
 
     r = scp_to_vm(config, [str(_SCRIPT)], "/tmp/", timeout=15)
     if r.returncode != 0:


### PR DESCRIPTION
## Summary
- Centralized ANSI color + spacing helpers in `log_format.py`
- Stage banners: bold cyan, preceded by `\n\n` for visual separation
- Step headers: yellow, preceded by `\n` for readability
- Dropped incoherent global step numbers (Step 0–12) — replaced with descriptive labels
- Fixed stages 5–9 which used "Stage N:" as step labels (collided with stage banners)

## Test plan
- [x] All pipeline imports verified (`python3 -c "from tools.pipeline.macro.provision import run"`)
- [x] Visual output verified — colors and spacing render correctly
- [ ] Full provision run to confirm log output in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)