### PR TITLE
fix(kvm): replace hardcoded params with config.sh, fixes #9

### DIFF
--- a/docs/SessionLogs/2026-04-14-0230-next-agenda.md
+++ b/docs/SessionLogs/2026-04-14-0230-next-agenda.md
@@ -1,0 +1,90 @@
+# Agenda — Next Session
+
+**Objective:** Full lab rebuild — acceptance test for config.sh (#9) and pipeline
+
+---
+
+## Pre-flight (before starting the rebuild session)
+
+1. **Merge PR #167** (`fix/9-hardcoded-params`) on GitHub
+2. On controller: `git checkout main && git pull`
+3. On saconsole: the control_plane role will re-clone the repo during rebuild
+
+## Phase 0: Prepare rollback
+
+1. Shut down dev03: Cytoscape UI → select dev03 → Stop
+2. Shut down saconsole: `ssh toshy "virsh --connect qemu:///system shutdown saconsole"` — wait for clean shutdown
+3. Rename saconsole as backup:
+   ```
+   ssh toshy "virsh --connect qemu:///system domrename saconsole saconsole-backup"
+   ```
+4. Verify: `ssh toshy "virsh --connect qemu:///system list --all"` — should show saconsole-backup (shut off), dev01 (shut off), dev02 (shut off), dev03 (shut off)
+
+## Phase 1: Destroy dev01 + dev02
+
+Not a full `destroy_vms.sh` run (that would also destroy saconsole-backup).
+Manual targeted destroy:
+```
+ssh toshy "virsh --connect qemu:///system undefine dev01 --remove-all-storage --snapshots-metadata"
+ssh toshy "virsh --connect qemu:///system undefine dev02 --remove-all-storage --snapshots-metadata"
+```
+
+Clear known_hosts for dev01 + dev02 (hostnames AND IPs).
+
+## Phase 2: Rebuild saconsole (`bootstrap_saconsole.sh`)
+
+```
+bash platforms/kvm/bootstrap_saconsole.sh
+```
+
+This is the primary config.sh acceptance test. The script now sources config.sh
+which derives all values from hosts_map.yml. Expected duration: ~20–30 min.
+
+**Verify after:**
+- saconsole VM running
+- SSH works via ProxyJump
+- WireGuard hub up (`wg show` on saconsole)
+- Controller wg0 handshake healthy
+- Observability stack containers running
+
+## Phase 3: Provision dev02 with ERPNext
+
+Use the Cytoscape UI (topology UI first rule):
+1. Start Cytoscape: `uvicorn tools.api:app --port 8088` + `bash doCytoscape.sh`
+2. Select dev02 node → Deploy
+3. Monitor provisioning via the UI info panel (click the node for live logs)
+4. Expected duration: ~30–40 min
+
+**Verify after:**
+- ERPNext site responds: `https://dev02.iridium.blue`
+- Login works (admin password from pipeline step H3)
+- ce_sri fixtures present
+- BaRe app installed
+- WireGuard spoke connected to hub
+
+## Phase 4: Full sync check
+
+```
+bash platforms/kvm/sync_check.sh
+```
+
+Expected: saconsole + dev02 running, dev01/dev03 absent or shut off.
+All WireGuard, observability, ERPNext, and MCP checks pass for active VMs.
+
+## Phase 5: Cleanup
+
+If everything passes:
+- Destroy saconsole-backup: `ssh toshy "virsh --connect qemu:///system undefine saconsole-backup --remove-all-storage --snapshots-metadata"`
+- Close #9 (fixed by PR #167)
+
+If something fails:
+- Destroy the broken saconsole
+- Rename saconsole-backup → saconsole: `ssh toshy "virsh --connect qemu:///system domrename saconsole-backup saconsole"`
+- Start saconsole, diagnose the failure
+
+## Constraints
+
+- ~60–90 min total rebuild time
+- toshiba RAM: saconsole + 1 dev VM at a time — dev02 only, dev03 stays shut off
+- 1:1:1 — this is its own issue + branch if any code changes are needed
+- dev01 stays destroyed (not rebuilt) — RAM constraint

--- a/platforms/kvm/CLAUDE.md
+++ b/platforms/kvm/CLAUDE.md
@@ -10,9 +10,17 @@
 - **virsh**: plain `virsh` = user session. Always use `virsh --connect qemu:///system` or `sudo virsh`
 - **saconsole manages siblings** via `qemu+ssh://<hypervisor-alias>/system`
 
+## Shared Configuration — config.sh
+
+All KVM platform scripts source `platforms/kvm/config.sh` which:
+1. Runs `parse_hosts_map.py` to derive VM names, IPs, and hypervisor identity from `hosts_map.yml`
+2. Layers env-overridable defaults for values not in the YAML (SSH alias, username, image paths)
+
+Override any value via `ESACP_*` env vars (e.g. `ESACP_HYPERVISOR_ALIAS=toshy`).
+
 ## Bootstrap Scripts
 
-- `rebuild_lab.sh` — one-command full rebuild: destroy → bootstrap_saconsole → bootstrap_targets (Phase 3 SSHes to saconsole via ProxyJump toshy)
+- `rebuild_lab.sh` — one-command full rebuild: destroy → bootstrap_saconsole → bootstrap_targets (Phase 3 SSHes to saconsole via ProxyJump)
 - `bootstrap_saconsole.sh` — idempotent 9-phase: seed ISO → upload → VM create → autoinstall wait → "Fresh Install" snapshot → Ansible → "Stage 2.2 Baseline" snapshot → handoff
   - Play 5 (controller WireGuard spoke) requires toshiba UDP 51820 port-forward first
 - `bootstrap_targets.sh` — runs FROM saconsole after `control_plane` role applied; injects saconsole pubkey via envsubst; direct virbr0 SSH (no ProxyJump)

--- a/platforms/kvm/bootstrap_saconsole.sh
+++ b/platforms/kvm/bootstrap_saconsole.sh
@@ -17,8 +17,8 @@
 #
 # Prerequisites:
 #   - cloud-image-utils (cloud-localds) installed on this controller
-#   - SSH alias 'toshy' configured in ~/.ssh/config
-#   - ~/.ssh/hasan_mighty: SSH keypair authorised on KVM VM guests
+#   - SSH alias for hypervisor configured in ~/.ssh/config (see config.sh)
+#   - SSH keypair for KVM VM guests (path from config.sh / ESACP_SSH_KEY)
 #   - SOPS age key at ~/.config/sops/age/keys.txt (for Ansible secrets)
 #
 # Idempotency: safe to re-run at any phase. Each step checks current state
@@ -27,21 +27,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJ_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-ANSIBLE_DIR="${PROJ_ROOT}/ansible"
 
-# ── Configuration ──────────────────────────────────────────────────────────────
+# ── Configuration (from hosts_map.yml + env overrides) ────────────────────────
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
 
-HYPERVISOR_ALIAS="toshy"
-HYPERVISOR_USER="hasan"
-HYPERVISOR_LAN_IP="toshy.iridium.blue"   # used in next-steps guidance only
-
-REMOTE_IMAGES_DIR="/mnt/esacp-disk/var/lib/libvirt/images"
 UBUNTU_ISO_NAME="ubuntu-24.04.4-live-server-amd64.iso"
-
-SACONSOLE_IP="192.168.122.10"
-SACONSOLE_USER="you"
-SSH_KEY="${HOME}/.ssh/hasan_mighty"
 
 SNAPSHOT_FRESH="Fresh Install"
 SNAPSHOT_BASELINE="Stage 2.2 Baseline"
@@ -332,33 +323,28 @@ chmod 600 ~/.ssh/authorized_keys
 REMOTE
 
 log "✅  saconsole SSH pubkey installed on ${HYPERVISOR_ALIAS}."
-log "    saconsole can now connect: qemu+ssh://hasan@toshiba/system"
+log "    saconsole can now connect: qemu+ssh://${HYPERVISOR_USER}@${ESACP_HYPERVISOR}/system"
 
-# Seed toshiba's host key into saconsole's known_hosts.
-# bootstrap_targets.sh runs FROM saconsole and SSHes to toshiba with
-# BatchMode=yes — on a fresh saconsole the known_hosts is empty and
-# BatchMode refuses the unknown key instead of prompting.
-# Base64 transfer avoids quoting/newline issues with multi-line key content.
-# Add toshiba to saconsole's /etc/hosts.
+# Add hypervisor to saconsole's /etc/hosts.
 # A fresh saconsole uses 8.8.8.8/1.1.1.1 (from cloud-init) and cannot
-# resolve the local hostname 'toshiba'. bootstrap_targets.sh uses
-# HYPERVISOR_ALIAS="toshiba" throughout — without this, all its SSH and
+# resolve the local hostname. bootstrap_targets.sh uses
+# HYPERVISOR_ALIAS throughout — without this, all its SSH and
 # virsh calls fail with "Temporary failure in name resolution".
-log "Adding toshiba → ${HYPERVISOR_LAN_IP} to saconsole /etc/hosts ..."
+log "Adding ${ESACP_HYPERVISOR} → ${HYPERVISOR_LAN_IP} to saconsole /etc/hosts ..."
 ssh \
     "${SACONSOLE_SSH_OPTS[@]}" \
     "${SACONSOLE_USER}@${SACONSOLE_IP}" \
-    "grep -qF 'toshiba' /etc/hosts 2>/dev/null \
-         || echo '${HYPERVISOR_LAN_IP} toshiba' | sudo tee -a /etc/hosts > /dev/null"
-log "✅  toshiba in saconsole /etc/hosts."
+    "grep -qF '${ESACP_HYPERVISOR}' /etc/hosts 2>/dev/null \
+         || echo '${HYPERVISOR_LAN_IP} ${ESACP_HYPERVISOR}' | sudo tee -a /etc/hosts > /dev/null"
+log "✅  ${ESACP_HYPERVISOR} in saconsole /etc/hosts."
 
-# Seed toshiba's host key into saconsole's known_hosts.
-# bootstrap_targets.sh runs FROM saconsole and SSHes to toshiba with
+# Seed hypervisor's host key into saconsole's known_hosts.
+# bootstrap_targets.sh runs FROM saconsole and SSHes to the hypervisor with
 # BatchMode=yes — on a fresh saconsole the known_hosts is empty and
 # BatchMode refuses the unknown key instead of prompting.
 # Base64 transfer avoids quoting/newline issues with multi-line key content.
 log "Seeding ${HYPERVISOR_ALIAS} host key into saconsole known_hosts ..."
-HYPER_KEYS_B64=$(ssh-keyscan -H toshiba "${HYPERVISOR_LAN_IP}" 2>/dev/null \
+HYPER_KEYS_B64=$(ssh-keyscan -H "${ESACP_HYPERVISOR}" "${HYPERVISOR_LAN_IP}" 2>/dev/null \
     | base64 -w0 || true)
 ssh \
     "${SACONSOLE_SSH_OPTS[@]}" \

--- a/platforms/kvm/bootstrap_targets.sh
+++ b/platforms/kvm/bootstrap_targets.sh
@@ -22,26 +22,21 @@
 # Prerequisites:
 #   - control_plane role applied to saconsole (provides: Ansible, repo, SSH keypair)
 #   - cloud-image-utils installed: sudo apt install cloud-image-utils
-#   - SSH access from saconsole to toshiba: ssh hasan@toshiba (via saconsole's ~/.ssh/id_ed25519)
+#   - SSH access from saconsole to hypervisor (via saconsole's ~/.ssh/id_ed25519)
 #   - SOPS age key at ~/.config/sops/age/keys.txt
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJ_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-ANSIBLE_DIR="${PROJ_ROOT}/ansible"
 
-# ── Configuration ──────────────────────────────────────────────────────────────
+# ── Configuration (from hosts_map.yml + env overrides) ────────────────────────
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
 
-HYPERVISOR_ALIAS="toshiba"
-HYPERVISOR_USER="hasan"
-
-REMOTE_IMAGES_DIR="/mnt/esacp-disk/var/lib/libvirt/images"
-UBUNTU_ISO_NAME="ubuntu-22.04.2-live-server-amd64.iso"
-
-# Both targets on toshiba's virbr0 — saconsole is on the same network
-VM_USER="you"
+# Saconsole-specific overrides: SSH key is saconsole's own keypair, not controller's
 SSH_KEY="${HOME}/.ssh/id_ed25519"
+
+UBUNTU_ISO_NAME="ubuntu-22.04.2-live-server-amd64.iso"
 
 SNAPSHOT_FRESH="Fresh Install"
 SNAPSHOT_BASELINE="Stage 2.2 Targets Baseline"
@@ -49,9 +44,18 @@ SNAPSHOT_BASELINE="Stage 2.2 Targets Baseline"
 AUTOINSTALL_TIMEOUT=1800   # 30 minutes — max wait for autoinstall to complete
 SSH_POLL_TIMEOUT=120       # 2 minutes  — max wait for SSH after first boot
 
-TARGETS=(target1 target2)
-declare -A TARGET_IP=( [target1]="192.168.122.11" [target2]="192.168.122.12" )
-declare -A TARGET_RAM=( [target1]="2048"          [target2]="2048" )
+# Targets derived from hosts_map.yml (all KVM hosts with vm_role set)
+# shellcheck disable=SC2206
+TARGETS=(${ESACP_KVM_TARGETS})
+declare -A TARGET_IP
+declare -A TARGET_RAM
+for _t in "${TARGETS[@]}"; do
+    _tag="${_t^^}"
+    _tag="${_tag//-/_}"
+    eval "TARGET_IP[${_t}]=\${ESACP_VM_VIRBR0_IP_${_tag}}"
+    TARGET_RAM[${_t}]="2048"
+done
+unset _t _tag
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 

--- a/platforms/kvm/config.sh
+++ b/platforms/kvm/config.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# config.sh — Shared configuration for all KVM platform scripts.
+#
+# Sources hosts_map.yml via parse_hosts_map.py, then layers env-overridable
+# defaults for values not in the YAML (SSH alias, username, paths).
+#
+# Usage (from any KVM platform script):
+#   source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+#
+# Every variable can be overridden via ESACP_* environment variables.
+# See parse_hosts_map.py for the full list of YAML-derived vars.
+
+# Guard against double-sourcing
+[[ -n "${_ESACP_CONFIG_LOADED:-}" ]] && return 0
+_ESACP_CONFIG_LOADED=1
+
+_CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJ_ROOT="${PROJ_ROOT:-$(cd "${_CONFIG_DIR}/../.." && pwd)}"
+
+# ── Derive from hosts_map.yml ────────────────────────────────────────────────
+eval "$("${_CONFIG_DIR}/parse_hosts_map.py" "${PROJ_ROOT}/hosts_map.yml")"
+
+# ── Env-overridable defaults (not in hosts_map.yml) ──────────────────────────
+HYPERVISOR_ALIAS="${ESACP_HYPERVISOR_ALIAS:-${ESACP_HYPERVISOR}}"
+HYPERVISOR_USER="${ESACP_HYPERVISOR_USER:-hasan}"
+HYPERVISOR_LAN_IP="${ESACP_HYPERVISOR_LAN_IP:-toshy.iridium.blue}"
+REMOTE_IMAGES_DIR="${ESACP_REMOTE_IMAGES_DIR:-/mnt/esacp-disk/var/lib/libvirt/images}"
+VM_USER="${ESACP_VM_USER:-you}"
+SSH_KEY="${ESACP_SSH_KEY:-${HOME}/.ssh/hasan_mighty}"
+
+# ── Convenience aliases ──────────────────────────────────────────────────────
+SACONSOLE_IP="${ESACP_SACONSOLE_VIRBR0_IP}"
+SACONSOLE_USER="${VM_USER}"
+ANSIBLE_DIR="${PROJ_ROOT}/ansible"

--- a/platforms/kvm/destroy_vms.sh
+++ b/platforms/kvm/destroy_vms.sh
@@ -16,22 +16,27 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-HYPERVISOR_ALIAS="toshy"
-HYPERVISOR_USER="hasan"
-REMOTE_IMAGES_DIR="/mnt/esacp-disk/var/lib/libvirt/images"
+# ── Configuration (from hosts_map.yml + env overrides) ────────────────────────
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
 
-ESACP_VMS=(saconsole target1 target2)
-declare -A VM_IPS=(
-    [saconsole]="192.168.122.10"
-    [target1]="192.168.122.11"
-    [target2]="192.168.122.12"
-)
+# All KVM VMs and their virbr0 IPs (derived from hosts_map.yml)
+# shellcheck disable=SC2206
+ESACP_VMS=(${ESACP_KVM_VMS})
+declare -A VM_IPS
+for _vm in "${ESACP_VMS[@]}"; do
+    _tag="${_vm^^}"
+    _tag="${_tag//-/_}"
+    eval "VM_IPS[${_vm}]=\${ESACP_VM_VIRBR0_IP_${_tag}}"
+done
+unset _vm _tag
 
-LOCAL_SEED_ISOS=(
-    saconsole-seed.iso
-    target1-toshiba-seed.iso
-    target2-toshiba-seed.iso
-)
+# Seed ISOs: saconsole + targets (targets use <vm>-<hypervisor>-seed.iso naming)
+LOCAL_SEED_ISOS=(saconsole-seed.iso)
+for _vm in ${ESACP_KVM_TARGETS}; do
+    LOCAL_SEED_ISOS+=("${_vm}-${ESACP_HYPERVISOR}-seed.iso")
+done
+unset _vm
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 

--- a/platforms/kvm/parse_hosts_map.py
+++ b/platforms/kvm/parse_hosts_map.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Read hosts_map.yml and emit shell variable assignments to stdout.
+
+Usage:
+    eval "$(platforms/kvm/parse_hosts_map.py hosts_map.yml)"
+
+Outputs variables consumed by platforms/kvm/config.sh:
+    ESACP_HYPERVISOR          — hypervisor hostname (from first KVM host's field)
+    ESACP_KVM_VMS             — space-separated list of all KVM VM hostnames
+    ESACP_KVM_TARGETS         — space-separated list of KVM hosts with vm_role
+    ESACP_SACONSOLE_VIRBR0_IP — saconsole's virbr0 IP
+    ESACP_SACONSOLE_WG_IP     — saconsole's WireGuard IP
+    ESACP_VM_VIRBR0_IP_<HOST> — per-VM virbr0 IP  (HOST uppercased)
+    ESACP_VM_WG_IP_<HOST>     — per-VM WireGuard IP (HOST uppercased)
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <hosts_map.yml>", file=sys.stderr)
+        sys.exit(1)
+
+    hosts_map = yaml.safe_load(Path(sys.argv[1]).read_text())
+    kvm = hosts_map.get("groups", {}).get("kvm", {})
+
+    all_vms: list[str] = []
+    targets: list[str] = []
+    hypervisor = ""
+
+    for hostname, attrs in kvm.items():
+        all_vms.append(hostname)
+        tag = hostname.upper().replace("-", "_")
+
+        virbr0 = attrs.get("virbr0_ip", "")
+        wg_ip = attrs.get("wg_ip", "")
+
+        print(f'ESACP_VM_VIRBR0_IP_{tag}="{virbr0}"')
+        print(f'ESACP_VM_WG_IP_{tag}="{wg_ip}"')
+
+        if hostname == "saconsole":
+            print(f'ESACP_SACONSOLE_VIRBR0_IP="{virbr0}"')
+            print(f'ESACP_SACONSOLE_WG_IP="{wg_ip}"')
+
+        if attrs.get("vm_role"):
+            targets.append(hostname)
+
+        if not hypervisor and attrs.get("hypervisor"):
+            hypervisor = attrs["hypervisor"]
+
+    print(f'ESACP_HYPERVISOR="{hypervisor}"')
+    print(f'ESACP_KVM_VMS="{" ".join(all_vms)}"')
+    print(f'ESACP_KVM_TARGETS="{" ".join(targets)}"')
+
+
+if __name__ == "__main__":
+    main()

--- a/platforms/kvm/rebuild_lab.sh
+++ b/platforms/kvm/rebuild_lab.sh
@@ -20,15 +20,14 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-cd "${PROJECT_ROOT}"
+
+# ── Configuration (from hosts_map.yml + env overrides) ────────────────────────
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+
+cd "${PROJ_ROOT}"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-HYPERVISOR_ALIAS="toshy"
-HYPERVISOR_USER="hasan"
-SACONSOLE_IP="192.168.122.10"
-SACONSOLE_USER="you"
-SSH_KEY="${HOME}/.ssh/hasan_mighty"
 
 # shellcheck source=utils.sh
 source "${SCRIPT_DIR}/utils.sh"
@@ -90,15 +89,11 @@ ssh \
 # ── Done ──────────────────────────────────────────────────────────────────────
 
 hdr "Done"
-echo "  saconsole, target1, and target2 are provisioned."
+echo "  All KVM VMs (${ESACP_KVM_VMS}) are provisioned."
 echo ""
-echo "  Grafana:       http://10.10.0.1:3000"
-echo "  Prometheus:    http://10.10.0.1:9090"
-echo "  mcp-grafana:   http://10.10.0.1:8000/sse"
-echo "  MariaDB MCP:   http://10.10.0.3:9001/sse"
-echo "                 http://10.10.0.4:9001/sse"
-echo "  Nginx MCP:     http://10.10.0.3:9000/mcp"
-echo "                 http://10.10.0.4:9000/mcp"
+echo "  Grafana:       http://${ESACP_SACONSOLE_WG_IP}:3000"
+echo "  Prometheus:    http://${ESACP_SACONSOLE_WG_IP}:9090"
+echo "  mcp-grafana:   http://${ESACP_SACONSOLE_WG_IP}:8000/sse"
 echo ""
 echo "  Next: bash platforms/kvm/sync_check.sh"
 echo ""

--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -35,20 +35,18 @@ warn() { echo "  ⚠️   $*"; WARN=$((WARN+1)); }
 hdr()  { echo ""; echo "── $* ──────────────────────────────────────────"; }
 fix()  { echo "      Fix: $*"; }
 
-PROJ_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-ANSIBLE_DIR="${PROJ_ROOT}/ansible"
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-HYPERVISOR_ALIAS="toshiba"
-HYPERVISOR_USER="hasan"
-
-SACONSOLE_IP="192.168.122.10"
+# ── Configuration (from hosts_map.yml + env overrides) ────────────────────────
+# shellcheck source=config.sh
+source "${_SCRIPT_DIR}/config.sh"
 
 remote_toshiba() { ssh -o ConnectTimeout=5 -o BatchMode=yes \
     "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" "$@"; }
 
 remote_saconsole() { ssh -o ConnectTimeout=5 -o BatchMode=yes \
     -o ProxyJump="${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" \
-    you@"${SACONSOLE_IP}" "$@"; }
+    "${SACONSOLE_USER}@${SACONSOLE_IP}" "$@"; }
 
 echo ""
 echo "ESACP KVM Platform (Mighty → toshiba) — Sync Check"
@@ -110,15 +108,15 @@ grep -q "community.sops.sops" "${ANSIBLE_DIR}/ansible.cfg" 2>/dev/null \
 # ── 3. SSH keys ───────────────────────────────────────────────────────────────
 hdr "3. SSH keys"
 
-[[ -f "${HOME}/.ssh/hasan_mighty" ]] \
-    && ok "~/.ssh/hasan_mighty present (KVM Ansible key)" \
-    || fail "~/.ssh/hasan_mighty missing — Ansible KVM plays will fail"
+[[ -f "${SSH_KEY}" ]] \
+    && ok "${SSH_KEY} present (KVM Ansible key)" \
+    || fail "${SSH_KEY} missing — Ansible KVM plays will fail"
 
-# Check toshy SSH alias is configured
+# Check hypervisor SSH alias is configured
 ssh -o ConnectTimeout=1 -o BatchMode=yes -o StrictHostKeyChecking=no \
     "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" true 2>/dev/null \
-    && ok "SSH alias 'toshiba' resolves and key auth works" \
-    || fail "Cannot reach toshiba via SSH alias — check ~/.ssh/config and authorized_keys"
+    && ok "SSH alias '${HYPERVISOR_ALIAS}' resolves and key auth works" \
+    || fail "Cannot reach ${HYPERVISOR_ALIAS} via SSH — check ~/.ssh/config and authorized_keys"
 
 # ── 4. SOPS decryption ────────────────────────────────────────────────────────
 hdr "4. SOPS / age"
@@ -166,14 +164,8 @@ fi
 hdr "7. VMs on toshiba"
 
 if [[ "${TOSHIBA_UP}" == true ]]; then
-    TOSHIBA_VMS=$(python3 - "${PROJ_ROOT}/hosts_map.yml" <<'PYEOF'
-import yaml, sys
-d = yaml.safe_load(open(sys.argv[1]))
-for name, h in d.get('groups', {}).get('kvm', {}).items():
-    if h.get('hypervisor') == 'toshiba':
-        print(name)
-PYEOF
-)
+    # ESACP_KVM_VMS already derived from hosts_map.yml via config.sh
+    TOSHIBA_VMS="${ESACP_KVM_VMS}"
     for vm in ${TOSHIBA_VMS}; do
         STATE=$(remote_toshiba "virsh --connect qemu:///system domstate ${vm} 2>/dev/null" \
             | tr -d '\n' || echo "unknown")
@@ -380,7 +372,7 @@ done
 # ── 13. GitHub MCP server ─────────────────────────────────────────────────────
 hdr "13. GitHub MCP server"
 
-GITHUB_MCP_BIN="/usr/local/bin/github-mcp-server"
+GITHUB_MCP_BIN="${ESACP_GITHUB_MCP_BIN:-/usr/local/bin/github-mcp-server}"
 if [[ -x "${GITHUB_MCP_BIN}" ]]; then
     _ghver=$("${GITHUB_MCP_BIN}" --version 2>/dev/null | awk '/Version:/{print $2}')
     ok "github-mcp-server ${_ghver} present"

--- a/prototypes/cytoscape/tests/topology-ops.spec.js
+++ b/prototypes/cytoscape/tests/topology-ops.spec.js
@@ -267,8 +267,8 @@ test.describe('Rebuild', () => {
     ) || []
     expect(deployId).toBeTruthy()
 
-    // Wait for provisioning to complete (up to 25 min)
-    await waitForJob(page, deployId, 1_500_000)
+    // Wait for provisioning to complete (up to 35 min)
+    await waitForJob(page, deployId, 2_100_000)
 
     // Inspect — verify services are healthy
     await selectNode(page, hostname)


### PR DESCRIPTION
## Summary

- **Playwright timeout**: bumped rebuild test timeout from 25→35 min to match other long-running tests
- **#9 config.sh**: created `platforms/kvm/parse_hosts_map.py` (YAML→shell vars) + `platforms/kvm/config.sh` (shared config sourced by all 5 KVM scripts). Replaces hardcoded usernames, SSH aliases, IPs, and key paths with values derived from `hosts_map.yml` + env-overridable defaults
- **#68 verified**: refresh skip gates confirmed working on already-provisioned dev03 — stages 4, 5, 7, 8, 9 all skip correctly. Issue closed.

### Scripts updated
- `bootstrap_saconsole.sh` — removed hardcoded toshy/hasan/you/IPs
- `bootstrap_targets.sh` — targets+IPs derived from hosts_map.yml
- `destroy_vms.sh` — VM list, IPs, seed ISO names all derived dynamically
- `rebuild_lab.sh` — summary uses WG IPs from config
- `sync_check.sh` — SSH key, hypervisor alias, saconsole user parameterised; inline Python replaced

## Test plan
- [x] `bash platforms/kvm/sync_check.sh` — same 46 passes as before (4 failures = dev01/dev02 shut off, expected)
- [x] `python3 platforms/kvm/parse_hosts_map.py hosts_map.yml` — outputs correct shell assignments
- [x] `bash -n` syntax check on all 6 scripts — all pass
- [x] `POST /api/refresh/dev03` — stages 7+8 skip via idempotency gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)