### PR TITLE
fix: sync topology graph with API on poll (#168)

### DIFF
--- a/prototypes/cytoscape/CLAUDE.md
+++ b/prototypes/cytoscape/CLAUDE.md
@@ -30,7 +30,7 @@ Nodes reflect libvirt power state (`vm_state` from `/api/hosts`):
 - **Shut off** (provisioned): grey dotted border (`#556677`), faded icon (`background-opacity: 0.15`), muted label (`#8899aa`), `[shut off]` suffix
 - **Unprovisioned**: amber dashed border (`#f0a020`), warm amber label (`#e8c060`), full icon, `[unprovisioned]` suffix — takes precedence over shut-off styling
 - Shut-off selector requires `[?provisioned]` so it never overrides unprovisioned nodes
-- `_refreshVmState()` polls `/api/hosts` every 30s and patches node data in-place (no re-layout)
+- `_refreshVmState()` polls `/api/hosts` every 30s: patches existing nodes, adds new nodes for hosts that appeared, and removes nodes for hosts that disappeared (full topology sync, no re-layout)
 - **Provisioning/Refreshing/Destroying** (active job): blue dashed border (`#4488dd`), cyan label (`#66aaff`), `[provisioning...]`/`[refreshing...]`/`[destroying...]` suffix — overrides unprovisioned amber. Driven by `job_status` node data set by `_attachJobPoller()`.
 - **Clicking a provisioning node** shows live job log in the info panel via `_showNodeJobLog()` — fetches full log snapshot from `/api/jobs/{id}`, primary poller continues to append new lines. Clicking away and back re-fetches the snapshot.
 - `_refreshVmState()` skips label rebuild for nodes with `job_status === 'running'`

--- a/prototypes/cytoscape/src/main.js
+++ b/prototypes/cytoscape/src/main.js
@@ -527,26 +527,86 @@ async function init() {
 async function _refreshVmState() {
   try {
     const data = await fetchHosts()
+    const apiIds = new Set()
+
     for (const h of data.hosts) {
-      const node = cy.$(`#${h.id ?? h.hostname}`)
-      if (node.empty()) continue
+      const hostId = h.id ?? h.hostname
+      apiIds.add(hostId)
+      const node = cy.$(`#${hostId}`)
+
+      if (node.empty()) {
+        // Host appeared in API but has no graph node — add it
+        const zone    = h.wg_role === 'hub' ? 'console' : (h.ansible_groups ?? []).includes('production') ? 'production' : (h.ansible_groups ?? []).includes('staging') ? 'staging' : 'development'
+        const zoneId  = _zoneIdFor(zone)
+        const vmRole  = normalizeVmRole(h.vm_role, zoneId)
+        const pos     = INITIAL_POSITIONS[hostId] ?? nextPositionForZone(cy, zoneId)
+        const vmState = h.vm_state ?? null
+        let label     = h.hostname
+        if (h.provisioned === false)       label = `${h.hostname}\n[unprovisioned]`
+        else if (h.provisioned === null)   label = `${h.hostname}\n[unknown]`
+        else if (vmState === 'shut off')   label = `${h.hostname}\n[shut off]`
+
+        cy.add({
+          group: 'nodes',
+          data: {
+            id:             hostId,
+            label,
+            role:           h.wg_role ?? 'spoke',
+            vm_role:        vmRole,
+            platform:       h.backend ?? 'kvm',
+            wg_ip:          h.wg_ip      ?? '',
+            virbr0_ip:      h.virbr0_ip  ?? '',
+            provisioned:    !!h.provisioned,
+            vm_state:       vmState,
+            ansible_groups: h.ansible_groups ?? [],
+            zone_id:        zoneId,
+            nickname:       h.nickname   ?? '',
+            erp_user:       h.erp_user   ?? '',
+            erp_url:        h.erp_url    ?? '',
+            hypervisor:     h.hypervisor ?? '',
+          },
+          position: pos,
+        })
+
+        const hub = cy.nodes('[role = "hub"]').first()
+        if (hub.length && h.wg_role !== 'hub') {
+          cy.add({
+            group: 'edges',
+            data: { id: `wg-${hostId}`, source: hub.id(), target: hostId, label: 'WireGuard', type: 'wireguard' },
+          })
+        }
+        continue
+      }
+
       const prev = node.data('vm_state')
       const next = h.vm_state ?? null
-      if (prev === next) continue
+      const prevProv = node.data('provisioned')
+      const nextProv = !!h.provisioned
+      if (prev === next && prevProv === nextProv) continue
 
       node.data('vm_state', next)
+      node.data('provisioned', nextProv)
 
       // Rebuild label to reflect new state — but never overwrite a provisioning label
       if (node.data('job_status') === 'running') continue
-      const hostname = h.hostname ?? h.id
-      const provisioned = h.provisioned
+      const hostname = h.hostname ?? hostId
       let label = hostname
-      if (provisioned === false)       label = `${hostname}\n[unprovisioned]`
-      else if (provisioned === null)   label = `${hostname}\n[unknown]`
-      else if (next === 'shut off')    label = `${hostname}\n[shut off]`
+      if (h.provisioned === false)       label = `${hostname}\n[unprovisioned]`
+      else if (h.provisioned === null)   label = `${hostname}\n[unknown]`
+      else if (next === 'shut off')      label = `${hostname}\n[shut off]`
       node.data('label', label)
-      node.data('provisioned', !!provisioned)
     }
+
+    // Remove graph nodes for hosts no longer in the API
+    cy.nodes().not('.phantom').not('.template-node').forEach(node => {
+      if (node.id() === 'controller') return
+      if (!apiIds.has(node.id())) {
+        cy.remove(node.connectedEdges())
+        cy.remove(node)
+      }
+    })
+
+    _updatePromoteButton()
   } catch {
     // API unreachable — leave current state unchanged
   }


### PR DESCRIPTION
## Summary
- `_refreshVmState()` now adds new nodes and removes stale nodes during the 30s poll, instead of only patching existing ones
- After destroy+rebuild, the graph updates automatically without a manual page refresh
- Also tracks `provisioned` state changes (not just `vm_state`)

## Test plan
- [ ] Destroy a dev VM via the UI, confirm node disappears within 30s (no page refresh)
- [ ] Rebuild/provision a VM, confirm node appears within 30s
- [ ] Verify existing power-state transitions (running ↔ shut off) still update correctly
- [ ] Acceptance test deferred to next destroy+rebuild session

🤖 Generated with [Claude Code](https://claude.com/claude-code)