### PR TITLE
refactor: eliminate hardcoded saconsole VM name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Controllers are bootstrap-only. saconsole manages all sibling VMs after handoff.
 
 ```
 hosts_map.yml              # Authoritative host directory — single source of truth
+tools/host_identity.py     # Python constants resolved from hosts_map.yml (HUB_KEY, HUB_VM_NAME, etc.)
 tools/generate_inventory.py # Derives ansible/inventory/kvm.yml
 config/wireguard/          # SOPS/age-encrypted WireGuard keys
 platforms/kvm/             # Bootstrap + differentiation scripts + cloud-init templates

--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -3,8 +3,8 @@
 ## site-kvm.yml Plays (5 total)
 
 1. `base-all` — base config for all KVM hosts
-2. `saconsole` — docker + observability + desktop + control_plane + mcp_grafana
-3. Authorise saconsole pubkey on targets
+2. `hub` — docker + observability + desktop + control_plane + mcp_grafana
+3. Authorise hub pubkey on targets
 4. `targets` — node_exporter + docker + mariadb + nginx_ui
 5. `controller WireGuard` — runs on `hosts: localhost`, `connection: local`; does NOT inherit `group_vars/kvm.yml`; hub endpoint hardcoded in Play 5 vars: `wg_hub_endpoint: "toshy.iridium.blue"`
 
@@ -24,7 +24,7 @@
 ## MariaDB Role
 
 - Uses `bytebase/dbhub:0.18.0` (NOT `MariaDB/mcp` — its main branch pulls PyTorch/CUDA ~3.5GB, breaks 20GB VMs)
-- Deployed to `/opt/mariadb/`; MariaDB port 3306 Docker-internal only (not exposed); mysqld_exporter port 9104 UFW-restricted to saconsole (10.10.0.1)
+- Deployed to `/opt/mariadb/`; MariaDB port 3306 Docker-internal only (not exposed); mysqld_exporter port 9104 UFW-restricted to hub (10.10.0.1)
 - Credentials in `/opt/mariadb/.env` (mode 0600); compose file templated: `ansible/roles/mariadb/templates/docker-compose.mariadb.yml.j2`
 - dbhub: SSE transport on port 9001 (internal 8080, `--transport http`); DSN passed via `--dsn mariadb://...` in compose command
 - **mysqld_exporter v0.15.x**: `DATA_SOURCE_NAME` env var removed — use `--config.my-cnf=<absolute-path>`; file mode must be `0644` (runs as `nobody`). (GH #45)
@@ -39,7 +39,7 @@
 
 ## mcp_grafana Role
 
-- `grafana/mcp-grafana:0.11.3` on saconsole; deploys to `/opt/mcp-grafana/`; SSE port 8000
+- `grafana/mcp-grafana:0.11.3` on hub; deploys to `/opt/mcp-grafana/`; SSE port 8000
 - Declares `observability_network` as `external: true` → reaches `grafana:3000` by container name
 - Start observability stack BEFORE mcp-grafana or the network won't exist
 - Endpoint: `http://10.10.0.1:8000/sse` (WireGuard peers only)

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -7,6 +7,16 @@
 # Private keys and PSKs are in config/wireguard/keys.sops.yml (SOPS/age encrypted).
 wg_port: 51820
 wg_subnet: "10.10.0.0/24"
+
+# Hub identity — derived from hosts_map.yml (wg_role: hub).
+# Used by roles and playbooks instead of hardcoding "saconsole" or "10.10.0.1".
+hub_key: "saconsole"
+hub_vm_name: "saconsole"
+hub_hostname: "saconsole"
+hub_display_name: "Hub Console"
+hub_virbr0_ip: "192.168.122.10"
+hub_wg_ip: "10.10.0.1"
+
 wg_pubkey_controller: "j94APdOpRArs3J78vcnRVJC5ALIFy/W9qLFacKbwGzk="
 wg_pubkey_saconsole:  "nn916J0YAufbwZNOKvWs2VX6sV4BKuTqE//985lIiRw="
 wg_pubkey_dev01: "LUOR6yrc7mymKuMyXGKmSluGyNu03iedCWe2RHoVK0k="
@@ -28,8 +38,8 @@ admin_users:
       - docker
 
 # Operator SSH public key (WSL controller key).
-# handoff_console.sh copies ~/.ssh/id_ed25519.pub → saconsole:~/.ssh/operator.pub
-# so Ansible (running on saconsole) can install it on every managed host.
+# handoff_console.sh copies ~/.ssh/id_ed25519.pub → hub:~/.ssh/operator.pub
+# so Ansible (running on the hub) can install it on every managed host.
 # Gracefully absent when running Ansible directly from WSL (file won't exist there).
 operator_ssh_key: "{{ lookup('file', lookup('env', 'HOME') + '/.ssh/operator.pub', errors='ignore') | default('') }}"
 

--- a/ansible/group_vars/kvm.yml
+++ b/ansible/group_vars/kvm.yml
@@ -9,8 +9,8 @@ ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') }}/.ssh/hasan_mighty"
 ansible_python_interpreter: /usr/bin/python3
 
 # ── WireGuard ──────────────────────────────────────────────────────────────
-# wg_hub_endpoint: the virbr0 IP of saconsole — stable, internal to the KVM host.
-wg_hub_endpoint: "192.168.122.10"
+# wg_hub_endpoint: the virbr0 IP of the hub VM — stable, internal to the KVM host.
+wg_hub_endpoint: "{{ hub_virbr0_ip }}"
 
 # WireGuard network and keys are in group_vars/all.yml
 # (moved there so the controller group also receives them)

--- a/ansible/inventory/kvm.yml
+++ b/ansible/inventory/kvm.yml
@@ -10,21 +10,29 @@ all:
           ansible_host: 192.168.122.10
           wg_ip: 10.10.0.1
           wg_role: hub
+          vm_name: saconsole
+          display_name: Hub Console
           ansible_ssh_common_args: -o ProxyJump=hasan@toshiba
         dev01: &id002
           ansible_host: 192.168.122.21
           wg_ip: 10.10.0.13
           wg_role: spoke
+          vm_name: dev01
+          display_name: Dev 01
           ansible_ssh_common_args: -o ProxyJump=hasan@toshiba
         dev02: &id003
           ansible_host: 192.168.122.20
           wg_ip: 10.10.0.12
           wg_role: spoke
+          vm_name: dev02
+          display_name: Dev 02
           ansible_ssh_common_args: -o ProxyJump=hasan@toshiba
         dev03: &id004
           ansible_host: 192.168.122.22
           wg_ip: 10.10.0.14
           wg_role: spoke
+          vm_name: dev03
+          display_name: Dev 03
           ansible_ssh_common_args: -o ProxyJump=hasan@toshiba
     development:
       hosts:
@@ -49,4 +57,6 @@ all:
           ansible_host: localhost
           wg_ip: 10.10.0.2
           wg_role: spoke
+          vm_name: local
+          display_name: local
           ansible_connection: local

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 # Ansible Galaxy collection requirements
-# Installed on saconsole by the control_plane role.
+# Installed on the hub by the control_plane role.
 # Also installable manually on any controller:
 #   ansible-galaxy collection install -r ansible/requirements.yml
 

--- a/ansible/roles/control_plane/tasks/main.yml
+++ b/ansible/roles/control_plane/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
-# control_plane role — saconsole as Ansible controller + Cytoscape UI host
+# control_plane role — hub VM as Ansible controller + Cytoscape UI host
 #
 # After this role runs:
 #   - ESACP repo is cloned at /opt/esacp
 #   - Ansible + SOPS + required collections are installed
 #   - SOPS age key is deployed for secret decryption
-#   - saconsole has an SSH keypair at ~/.ssh/id_ed25519
-#   - saconsole_ssh_pubkey fact is registered for use by sibling plays
+#   - Hub has an SSH keypair at ~/.ssh/id_ed25519
+#   - hub_ssh_pubkey fact is registered for use by sibling plays
 #   - Node.js is installed; Cytoscape app is built to /opt/esacp/prototypes/cytoscape/dist/
 #   - nginx serves the Cytoscape app on port {{ cytoscape_port }}
 #
-# Applied to saconsole only (Play 3 in site-vbox.yml).
-# Play 4 reads saconsole_ssh_pubkey from hostvars and pushes it to targets.
+# Applied to the hub only (Play 2 in site-kvm.yml).
+# Play 3 reads hub_ssh_pubkey from hostvars and pushes it to targets.
 
 # ── Ansible + SOPS ────────────────────────────────────────────────────────────
 
@@ -76,24 +76,24 @@
 
 # ── SSH keypair ───────────────────────────────────────────────────────────────
 
-- name: Generate saconsole SSH keypair
+- name: Generate hub SSH keypair
   become_user: "{{ ansible_user }}"
   command:
     cmd: >
       ssh-keygen -t ed25519
       -f /home/{{ ansible_user }}/.ssh/id_ed25519
       -N ''
-      -C saconsole-control-plane
+      -C {{ hub_key }}-control-plane
     creates: "/home/{{ ansible_user }}/.ssh/id_ed25519"
 
-- name: Read saconsole public key
+- name: Read hub public key
   slurp:
     src: "/home/{{ ansible_user }}/.ssh/id_ed25519.pub"
-  register: saconsole_pubkey_raw
+  register: hub_pubkey_raw
 
-- name: Register saconsole public key as host fact
+- name: Register hub public key as host fact
   set_fact:
-    saconsole_ssh_pubkey: "{{ saconsole_pubkey_raw.content | b64decode | trim }}"
+    hub_ssh_pubkey: "{{ hub_pubkey_raw.content | b64decode | trim }}"
 
 # ── Node.js ───────────────────────────────────────────────────────────────────
 

--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -2,7 +2,7 @@
 # mariadb role — Deploy MariaDB + mysqld_exporter via Docker Compose
 #
 # MariaDB listens on Docker-internal port 3306 (not exposed to host).
-# mysqld_exporter listens on host port 9104; UFW restricts to saconsole WG IP.
+# mysqld_exporter listens on host port 9104; UFW restricts to hub WG IP.
 
 - name: Create MariaDB deploy directory
   file:
@@ -39,13 +39,13 @@
   no_log: true
   notify: recreate mariadb stack
 
-- name: Allow mysqld_exporter scraping from saconsole (WireGuard only)
+- name: Allow mysqld_exporter scraping from hub (WireGuard only)
   ufw:
     rule: allow
     port: "{{ mysqld_exporter_port | string }}"
     proto: tcp
-    from_ip: "10.10.0.1"
-    comment: "mysqld_exporter — saconsole WireGuard only"
+    from_ip: "{{ hub_wg_ip }}"
+    comment: "mysqld_exporter — hub WireGuard only"
 
 # ── Pull registry images and start stack ─────────────────────────────────────
 # bytebase/dbhub is a published image — no local build required.
@@ -85,13 +85,13 @@
   retries: 30
   delay: 5
 
-- name: Allow MariaDB MCP access from saconsole (WireGuard only)
+- name: Allow MariaDB MCP access from hub (WireGuard only)
   ufw:
     rule: allow
     port: "{{ mariadb_mcp_port | string }}"
     proto: tcp
-    from_ip: "10.10.0.1"
-    comment: "mariadb-mcp SSE — saconsole WireGuard only"
+    from_ip: "{{ hub_wg_ip }}"
+    comment: "mariadb-mcp SSE — hub WireGuard only"
 
 - name: Flush handlers
   meta: flush_handlers

--- a/ansible/roles/mariadb/templates/docker-compose.mariadb.yml.j2
+++ b/ansible/roles/mariadb/templates/docker-compose.mariadb.yml.j2
@@ -4,7 +4,7 @@
 #
 # MariaDB port 3306 is NOT exposed to the host — mysqld_exporter reaches it via
 # the internal Docker network. Only port {{ mysqld_exporter_port }} (mysqld_exporter)
-# is bound to the host, restricted to saconsole via UFW.
+# is bound to the host, restricted to the hub via UFW.
 
 services:
   mariadb:

--- a/ansible/roles/mcp_grafana/tasks/main.yml
+++ b/ansible/roles/mcp_grafana/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# mcp_grafana role — Deploy grafana/mcp-grafana in SSE mode on saconsole
+# mcp_grafana role — Deploy grafana/mcp-grafana in SSE mode on the hub
 #
 # Joins the observability_network Docker network so it can reach grafana:3000
 # by container name, without needing port exposure between containers.

--- a/ansible/roles/nginx_ui/tasks/main.yml
+++ b/ansible/roles/nginx_ui/tasks/main.yml
@@ -3,7 +3,7 @@
 #
 # nginx-ui bundles nginx inside the image (no separate nginx container needed).
 # Port {{ nginx_ui_http_port }}: nginx HTTP (allow from WireGuard subnet)
-# Port {{ nginx_ui_api_port }}: nginx-ui admin API + MCP SSE endpoint (allow from saconsole WG only)
+# Port {{ nginx_ui_api_port }}: nginx-ui admin API + MCP SSE endpoint (allow from hub WG only)
 #
 # MCP endpoint: http://<target-wg-ip>:{{ nginx_ui_api_port }}/mcp?node_secret=<NGINX_UI_NODE_SECRET>
 # First-run setup is headless via NGINX_UI_NODE_SKIP_INSTALLATION env var.
@@ -46,13 +46,13 @@
     from_ip: "10.10.0.0/24"
     comment: "nginx HTTP — WireGuard subnet"
 
-- name: Allow nginx-ui admin/MCP from saconsole (WireGuard only)
+- name: Allow nginx-ui admin/MCP from hub (WireGuard only)
   ufw:
     rule: allow
     port: "{{ nginx_ui_api_port | string }}"
     proto: tcp
-    from_ip: "10.10.0.1"
-    comment: "nginx-ui admin/MCP — saconsole WireGuard only"
+    from_ip: "{{ hub_wg_ip }}"
+    comment: "nginx-ui admin/MCP — hub WireGuard only"
 
 - name: Pull nginx-ui image
   command: docker-compose -f {{ nginx_ui_deploy_dir }}/docker-compose.yml pull

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -3,7 +3,7 @@
 #
 # Installs the binary directly (no Docker) so target1 can be monitored
 # without requiring a full container stack.
-# Port 9100 is restricted via UFW to saconsole's WireGuard IP only.
+# Port 9100 is restricted via UFW to the hub's WireGuard IP only.
 
 - name: Set node_exporter version
   set_fact:
@@ -52,13 +52,13 @@
     mode: '0644'
   notify: restart node_exporter
 
-- name: Open node_exporter port in UFW (saconsole WireGuard IP only)
+- name: Open node_exporter port in UFW (hub WireGuard IP only)
   ufw:
     rule: allow
     port: "9100"
     proto: tcp
-    from_ip: "10.10.0.1"
-    comment: "node_exporter — saconsole WireGuard only"
+    from_ip: "{{ hub_wg_ip }}"
+    comment: "node_exporter — hub WireGuard only"
 
 - name: Enable and start node_exporter
   systemd:

--- a/ansible/roles/wireguard/tasks/main.yml
+++ b/ansible/roles/wireguard/tasks/main.yml
@@ -6,7 +6,7 @@
 #   wg_role  — "hub" or "spoke"
 #
 # Required group vars (group_vars/kvm.yml):
-#   wg_port, wg_pubkey_controller, wg_pubkey_saconsole, wg_pubkey_target1
+#   wg_port, wg_pubkey_controller, wg_pubkey_<hub_key>, wg_pubkey_dev01, ...
 #
 # Private keys / PSKs are read from config/wireguard/keys.sops.yml at play time.
 

--- a/ansible/roles/wireguard/templates/wg0.conf.j2
+++ b/ansible/roles/wireguard/templates/wg0.conf.j2
@@ -12,17 +12,17 @@ ListenPort = {{ wg_port }}
 # ── Peer: {{ host }} ───────────────────────────────────────────────────────
 [Peer]
 PublicKey           = {{ wg_keys[_key].public_key }}
-PresharedKey        = {{ wg_keys.preshared_keys[_key + '_saconsole'] }}
+PresharedKey        = {{ wg_keys.preshared_keys[_key + '_' + hub_key] }}
 AllowedIPs          = {{ hostvars[host]['wg_ip'] }}/32
 # No Endpoint — {{ host }} initiates the connection to the hub.
 
 {% endfor %}
 {% else %}
 {% set _key = 'controller' if inventory_hostname in ['controller', 'localhost'] else inventory_hostname %}
-# ── Peer: saconsole hub ────────────────────────────────────────────────────
+# ── Peer: {{ hub_display_name }} (hub) ────────────────────────────────────
 [Peer]
-PublicKey           = {{ wg_keys.saconsole.public_key }}
-PresharedKey        = {{ wg_keys.preshared_keys[_key + '_saconsole'] }}
+PublicKey           = {{ wg_keys[hub_key].public_key }}
+PresharedKey        = {{ wg_keys.preshared_keys[_key + '_' + hub_key] }}
 AllowedIPs          = 10.10.0.0/24
 Endpoint            = {{ wg_hub_endpoint }}:{{ wg_port }}
 PersistentKeepalive = 25

--- a/ansible/site-bootstrap.yml
+++ b/ansible/site-bootstrap.yml
@@ -2,11 +2,11 @@
 # site-bootstrap.yml — Minimal WSL-side bootstrap.
 #
 # Installs WireGuard (and nothing else) on all three VMs.
-# Called by build_lab.sh before handing control to saconsole.
+# Called by build_lab.sh before handing control to the hub.
 #
 # What this does:
 #   - Waits for dpkg lock (unattended-upgrades runs at first boot)
-#   - Grants passwordless sudo (saconsole will Ansible targets without a password)
+#   - Grants passwordless sudo (hub will Ansible targets without a password)
 #   - Installs + configures WireGuard (wg0 up, keys from keys.sops.yml)
 #
 # What this deliberately does NOT do:

--- a/ansible/site-kvm.yml
+++ b/ansible/site-kvm.yml
@@ -3,8 +3,8 @@
 #
 # Play order:
 #   1. All KVM VMs:    common, ssh, firewall, fail2ban, wireguard
-#   2. saconsole:      docker, observability, desktop, control_plane, mcp_grafana
-#   3. targets:        authorise saconsole SSH pubkey (set by control_plane in Play 2)
+#   2. Hub ({{ hub_key }}): docker, observability, desktop, control_plane, mcp_grafana
+#   3. targets:        authorise hub SSH pubkey (set by control_plane in Play 2)
 #   4. targets:        node_exporter, docker, mariadb, nginx_ui
 #   5. Controller:     wireguard spoke config (connection: local)
 #
@@ -26,9 +26,9 @@
     - role: wireguard
       tags: [wireguard]
 
-# ── Play 2: saconsole — observability + desktop + control plane + MCP ─────
-- name: Observability + control plane — saconsole
-  hosts: saconsole
+# ── Play 2: Hub — observability + desktop + control plane + MCP ───────────
+- name: Observability + control plane — hub
+  hosts: "{{ hub_key }}"
   become: yes
   roles:
     - docker
@@ -39,30 +39,30 @@
     - role: acme_sh
       tags: [acme_sh]
 
-# ── Play 3: Authorise saconsole SSH pubkey on targets ─────────────────────
-# control_plane (Play 2) generates saconsole's keypair and registers
-# saconsole_ssh_pubkey as a host fact. This play pushes it to targets so
-# saconsole can Ansible-provision and manage them directly.
+# ── Play 3: Authorise hub SSH pubkey on targets ──────────────────────────
+# control_plane (Play 2) generates the hub's keypair and registers
+# hub_ssh_pubkey as a host fact. This play pushes it to targets so
+# the hub can Ansible-provision and manage them directly.
 #
-# When running --limit targets (e.g. from bootstrap_targets.sh), saconsole's
+# When running --limit targets (e.g. from bootstrap_targets.sh), the hub's
 # play does not execute and the fact is not in memory. Pass the pubkey via
-# --extra-vars "saconsole_override_pubkey=..." to satisfy this task.
-# Safe to skip when running --limit saconsole alone.
-- name: Authorise saconsole on targets
+# --extra-vars "hub_override_pubkey=..." to satisfy this task.
+# Safe to skip when running --limit <hub_key> alone.
+- name: Authorise hub on targets
   hosts: targets
   become: yes
   tasks:
-    - name: Add saconsole public key to authorized_keys
+    - name: Add hub public key to authorized_keys
       authorized_key:
         user: "{{ ansible_user }}"
-        key: "{{ saconsole_override_pubkey | default(hostvars['saconsole']['saconsole_ssh_pubkey'] | default('')) }}"
+        key: "{{ hub_override_pubkey | default(hostvars[hub_key]['hub_ssh_pubkey'] | default('')) }}"
         state: present
       when: >
-        saconsole_override_pubkey is defined
-        or (hostvars['saconsole']['saconsole_ssh_pubkey'] is defined
-            and hostvars['saconsole']['saconsole_ssh_pubkey'] != '')
+        hub_override_pubkey is defined
+        or (hostvars[hub_key]['hub_ssh_pubkey'] is defined
+            and hostvars[hub_key]['hub_ssh_pubkey'] != '')
 
-# ── Play 4: Target services — target1 + target2 ───────────────────────────
+# ── Play 4: Target services ──────────────────────────────────────────────
 - name: Target services — targets
   hosts: targets
   become: yes
@@ -81,8 +81,8 @@
     inventory_hostname: controller   # used by wg0.conf.j2 peer selection
     wg_ip: "10.10.0.2"
     wg_role: spoke
-    # Controller reaches saconsole via toshiba's LAN IP (port-forwarded to
-    # saconsole's virbr0 192.168.122.10:51820). Mighty's own virbr0 owns
+    # Controller reaches the hub via toshiba's LAN IP (port-forwarded to
+    # hub virbr0 {{ hub_virbr0_ip }}:51820). Mighty's own virbr0 owns
     # 192.168.122.0/24 so it cannot reach that IP directly.
     wg_hub_endpoint: "toshy.iridium.blue"
   roles:

--- a/config/wireguard/generate_keys.sh
+++ b/config/wireguard/generate_keys.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # generate_keys.sh — WireGuard key generation for ESACP Stage 2.1
 #
-# Generates keypairs for: controller (${HOSTNAME}), saconsole, target1, target2
-# Generates preshared keys for: controller↔saconsole, target1↔saconsole, target2↔saconsole
+# Generates keypairs for: controller, hub (saconsole key), target1, target2
+# Generates preshared keys for: controller↔hub, target1↔hub, target2↔hub
 #
 # Output: config/wireguard/keys.sops.yml  (age-encrypted via SOPS, safe to commit)
 #

--- a/docker/observability/CLAUDE.md
+++ b/docker/observability/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Stack
 
-All services in Docker at `/opt/observability/` on saconsole.
+All services in Docker at `/opt/observability/` on the hub.
 
 | Service | Port | Notes |
 |---|---|---|

--- a/docker/observability/docker-compose.yml
+++ b/docker/observability/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   # Node Exporter - Host Metrics
   # network_mode: host gives the container the host's network namespace so that:
-  #   (a) nodename in node_uname_info matches the VM hostname (saconsole), not a container ID
+  #   (a) nodename in node_uname_info matches the VM hostname, not a container ID
   #   (b) wg0 and all other host interfaces are visible to the collector
   # Prometheus reaches it via host.docker.internal (see extra_hosts on prometheus service).
   node_exporter:

--- a/docker/observability/prometheus/alerts/infrastructure.yml
+++ b/docker/observability/prometheus/alerts/infrastructure.yml
@@ -80,7 +80,7 @@ groups:
           component: tls
         annotations:
           summary: "TLS cert expiring soon: {{ $labels.domain }}"
-          description: "Certificate for {{ $labels.domain }} expires in {{ $value | printf \"%.0f\" }} days. Automated renewal may have failed — check /tmp/acme-renew.log on saconsole."
+          description: "Certificate for {{ $labels.domain }} expires in {{ $value | printf \"%.0f\" }} days. Automated renewal may have failed — check /tmp/acme-renew.log on the hub."
 
       # Critical: less than 3 days left — service will break imminently
       - alert: TLSCertExpiryCritical

--- a/docker/observability/prometheus/prometheus.yml
+++ b/docker/observability/prometheus/prometheus.yml
@@ -29,7 +29,7 @@ scrape_configs:
     static_configs:
       - targets: ['host.docker.internal:9100']
         labels:
-          host: 'saconsole'
+          host: 'hub'  # Ansible template uses {{ inventory_hostname }}
 
   # cAdvisor - Container metrics
   - job_name: 'cadvisor'

--- a/docs/SessionLogs/2026-04-14-2100-next-agenda.md
+++ b/docs/SessionLogs/2026-04-14-2100-next-agenda.md
@@ -1,0 +1,33 @@
+# Agenda — Next Session
+
+**Objective:** Merge #176, then pick next issue from backlog
+
+**Pre-requisites:** Review PR #176 on GitHub.
+
+---
+
+## Step 1: Merge #176
+
+- Review the PR diff on GitHub
+- Merge to main
+- Verify `sync_check.sh` still passes (hub identity variables resolve correctly)
+
+## Step 2: Acceptance smoke test
+
+- Source `platforms/kvm/config.sh` and verify `HUB_KEY`, `HUB_VM_NAME`, `HUB_VIRBR0_IP` are set
+- Run `python3 -c "from tools.host_identity import HUB_KEY; print(HUB_KEY)"`
+- Confirm Cytoscape UI loads correctly (`bash doCytoscape.sh`)
+
+## Step 3: Pick next issue
+
+Open issues to consider:
+- #172 — hardcoded IPs (virbr0, WireGuard)
+- #173 — hardcoded domains (iridium.blue)
+- #174 — hardcoded passwords in config.py
+- #175 — hypervisor fallback assumptions
+- #48, #50, #65, #138, #153, #156–#158, #168
+
+## Constraints
+
+- 1:1:1 — one issue per session
+- Close #171 after merge confirmation

--- a/docs/SessionLogs/2026-04-14-2100-session-minutes.md
+++ b/docs/SessionLogs/2026-04-14-2100-session-minutes.md
@@ -1,0 +1,65 @@
+# Session Minutes — 2026-04-14 2100 UTC
+
+**Objective:** Implement #171 — eliminate hardcoded "saconsole" VM name
+
+**Branch:** `refactor/171-decouple-saconsole-identity`
+**PR:** #176
+
+## Work completed
+
+All 6 steps from the implementation plan executed in a single session:
+
+### Step 1 — Schema + resolution layer
+- Extended `hosts_map.yml` with `vm_name`, `display_name` fields for all KVM hosts
+- Updated `parse_hosts_map.py` with role-based hub lookup (`--field` flag, `ESACP_HUB_*` variables)
+- Created `tools/host_identity.py` — Python constants resolved from `hosts_map.yml`
+- Created `platforms/kvm/hub_identity.sh` — shell helper sourcing `config.sh`
+- Updated `config.sh` to export `HUB_KEY`, `HUB_VM_NAME`, `HUB_VIRBR0_IP` etc.
+- Regenerated `ansible/inventory/kvm.yml` with `vm_name`/`display_name` fields
+
+### Step 2 — Ansible migration
+- Added `hub_key`/`hub_vm_name`/`hub_hostname`/`hub_display_name`/`hub_virbr0_ip`/`hub_wg_ip` to `group_vars/all.yml`
+- Updated `site-kvm.yml` plays 2+3 to use `{{ hub_key }}` instead of literal `saconsole`
+- Renamed `saconsole_ssh_pubkey` fact to `hub_ssh_pubkey` in `control_plane` role
+- All 6 roles now use `{{ hub_wg_ip }}` instead of hardcoded `10.10.0.1`
+- `wg0.conf.j2` uses `{{ hub_key }}` for PSK key lookups
+- `group_vars/kvm.yml` uses `{{ hub_virbr0_ip }}` for `wg_hub_endpoint`
+
+### Step 3 — Python code migration
+- `job_worker.py` — replaced `SACONSOLE_IP`/`SACONSOLE_SSH` with `HUB_IP`/`HUB_SSH` from `host_identity`
+- `esacp.py` — RAM decisions use `hub_vm(config)`, PSK validation is dynamic, pubkey listing is dynamic
+- `ssh.py` — renamed `saconsole_ssh_run` to `hub_ssh_run` (backward-compat alias preserved)
+- `saconsole_wg_hub.py` — renamed function to `update_hub_wg` (alias preserved)
+- `tls_cert.py` — renamed to use `hub_ssh_run`, updated messages
+- `verify.py` — renamed to `check_hub_wg_peer`, `_ssh_hub`
+- `destroy_helpers.py`, `diagnose.py`, `api.py` — comment/docstring updates
+- Orchestration files (`fake_attack.py`, `provision_kvm.py`, `validate_observability.py`) — parameterized
+
+### Step 4 — Shell scripts + decomposition
+- `bootstrap_saconsole.sh` → renamed to `bootstrap_hub.sh`, all references parameterized
+- `rebuild_lab.sh`, `destroy_vms.sh`, `sync_check.sh`, `bootstrap_targets.sh`, `prepare_hypervisor.sh`, `persist_iptables_toshiba.sh`, `create_vms.sh`, `create_seeds.sh` — all updated
+- `platforms/packer/build.sh` — updated
+- `provision_targets.sh` — updated
+
+### Step 5 — Frontend + observability
+- Cytoscape `registry.js` — `SACONSOLE` URL constant renamed to `HUB_URL`; `saconsole_containers` → `hub_containers`
+- Cytoscape `main.js` — comment updates; node IDs stay (= hosts_map key)
+- Docker compose and Prometheus reference configs — comments updated
+- Alert descriptions updated
+
+### Step 6 — Cleanup
+- Grep sweep: zero `saconsole` literals in active code outside expected locations
+- Expected remaining: hosts_map keys, SOPS key names, inventory entries, backward-compat aliases, VBox retired code, doc examples
+- All affected CLAUDE.md files updated (root, tools, platforms/kvm, ansible, docker/observability, cytoscape)
+
+## Stats
+
+- **57 files changed**, 597 insertions, 401 deletions
+- 2 new files: `tools/host_identity.py`, `platforms/kvm/hub_identity.sh`
+- 1 rename: `bootstrap_saconsole.sh` → `bootstrap_hub.sh`
+
+## Deferred
+
+- Full `rebuild_lab.sh` end-to-end acceptance test (requires lab rebuild — separate session)
+- `saconsole_wg_hub.py` file rename (would break imports; alias sufficient for now)
+- `bootstrap_hub.sh` decomposition into ≤50-line functions (297 lines — known debt)

--- a/hosts_map.yml
+++ b/hosts_map.yml
@@ -23,7 +23,9 @@ groups:
   # ── KVM guests (Xubuntu workstation, Platform 2) ──────────────────────────
   kvm:
     saconsole:
+      vm_name: saconsole
       hostname: saconsole
+      display_name: "Hub Console"
       nickname: sac
       virbr0_ip: "192.168.122.10"
       wg_ip: "10.10.0.1"
@@ -38,7 +40,9 @@ groups:
         - lab
 
     dev01:
+      vm_name: dev01
       hostname: dev01
+      display_name: "Dev 01"
       nickname: D1IRBL
       virbr0_ip: "192.168.122.21"
       wg_ip: "10.10.0.13"
@@ -54,7 +58,9 @@ groups:
         - lab
 
     dev02:
+      vm_name: dev02
       hostname: dev02
+      display_name: "Dev 02"
       nickname: D2IRBL
       virbr0_ip: "192.168.122.20"
       wg_ip: "10.10.0.12"
@@ -70,7 +76,9 @@ groups:
         - lab
 
     dev03:
+      vm_name: dev03
       hostname: dev03
+      display_name: "Dev 03"
       nickname: D3IRBL
       virbr0_ip: "192.168.122.22"
       wg_ip: "10.10.0.14"

--- a/orchestration/fake_attack.py
+++ b/orchestration/fake_attack.py
@@ -4,11 +4,11 @@ fake_attack.py — Generate controlled SSH failures to exercise the fail2ban →
 
 Attack flow:
     1. SSH to target1 (127.0.0.1:2222 via NAT)
-    2. From target1, fire ATTACK_COUNT invalid-user SSH attempts at saconsole (10.10.0.1)
-    3. fail2ban on saconsole bans 10.10.0.3 (port 22 only — monitoring unaffected)
-    4. BAN entry written to /var/log/fail2ban.log on saconsole
+    2. From target1, fire ATTACK_COUNT invalid-user SSH attempts at the hub
+    3. fail2ban on the hub bans target1's WG IP (port 22 only — monitoring unaffected)
+    4. BAN entry written to /var/log/fail2ban.log on the hub
     5. Promtail ships it to Loki  →  job=fail2ban stream exists
-    6. Script unbans 10.10.0.3 on saconsole
+    6. Script unbans target1 on the hub
 
 Run from the project root after provisioning and before validation:
 
@@ -31,11 +31,13 @@ console = Console()
 
 TARGET1_NAT_HOST  = "127.0.0.1"
 TARGET1_NAT_PORT  = 2222
-SACONSOLE_LAN_IP  = "192.168.40.50"
-SACONSOLE_WG_IP   = "10.10.0.1"
+from tools.host_identity import HUB_WG_IP
+
+HUB_LAN_IP       = "192.168.40.50"   # VBox bridged LAN IP — update for KVM
+HUB_WG           = HUB_WG_IP
 TARGET1_WG_IP     = "10.10.0.3"
 
-ATTACKER_USER     = "fake_attacker"   # must not exist on saconsole
+ATTACKER_USER     = "fake_attacker"   # must not exist on the hub
 SSH_USER          = "you"
 SSH_KEY           = os.path.expanduser("~/.ssh/id_ed25519")
 
@@ -68,10 +70,10 @@ def remote_run(host, port, user, key, command):
 # ── Steps ─────────────────────────────────────────────────────────────────────
 
 def ensure_not_pre_banned():
-    """If target1's WireGuard IP is already banned on saconsole, unban it first
+    """If target1's WireGuard IP is already banned on hub, unban it first
     so the attack generates a fresh log entry that Promtail can ship."""
     out, _, _ = remote_run(
-        SACONSOLE_LAN_IP, 22, SSH_USER, SSH_KEY,
+        HUB_LAN_IP, 22, SSH_USER, SSH_KEY,
         "sudo fail2ban-client status sshd",
     )
     if TARGET1_WG_IP in out:
@@ -80,7 +82,7 @@ def ensure_not_pre_banned():
             f"we generate a fresh log entry.[/yellow]"
         )
         remote_run(
-            SACONSOLE_LAN_IP, 22, SSH_USER, SSH_KEY,
+            HUB_LAN_IP, 22, SSH_USER, SSH_KEY,
             f"sudo fail2ban-client set sshd unbanip {TARGET1_WG_IP}",
         )
         time.sleep(2)
@@ -88,8 +90,8 @@ def ensure_not_pre_banned():
 
 def generate_attacks():
     """Open a session to target1 and fire ATTACK_COUNT invalid-user SSH attempts
-    at saconsole's WireGuard IP.  The user 'fake_attacker' does not exist on
-    saconsole, so each attempt produces an 'Invalid user' entry in auth.log
+    at hub's WireGuard IP.  The user 'fake_attacker' does not exist on
+    hub, so each attempt produces an 'Invalid user' entry in auth.log
     which fail2ban picks up."""
     console.print(
         f"[cyan]Connecting to target1 "
@@ -99,7 +101,7 @@ def generate_attacks():
 
     console.print(
         f"[cyan]Firing {ATTACK_COUNT} SSH failures  "
-        f"target1 ({TARGET1_WG_IP}) → saconsole ({SACONSOLE_WG_IP})…[/cyan]"
+        f"target1 ({TARGET1_WG_IP}) → hub ({HUB_WG})…[/cyan]"
     )
     for i in range(1, ATTACK_COUNT + 1):
         # BatchMode=yes — never prompt for password.
@@ -110,7 +112,7 @@ def generate_attacks():
             f"-o StrictHostKeyChecking=no "
             f"-o BatchMode=yes "
             f"-o ConnectTimeout=5 "
-            f"{ATTACKER_USER}@{SACONSOLE_WG_IP} 2>/dev/null; true"
+            f"{ATTACKER_USER}@{HUB_WG} 2>/dev/null; true"
         )
         _, stdout, _ = client.exec_command(cmd)
         stdout.channel.recv_exit_status()
@@ -121,16 +123,16 @@ def generate_attacks():
 
 
 def wait_for_ban():
-    """Poll saconsole's fail2ban status until target1's WireGuard IP appears
+    """Poll hub's fail2ban status until target1's WireGuard IP appears
     in the banned list."""
     console.print(
-        f"[cyan]Polling saconsole for ban of {TARGET1_WG_IP} "
+        f"[cyan]Polling hub for ban of {TARGET1_WG_IP} "
         f"(up to {BAN_POLL_TIMEOUT}s)…[/cyan]"
     )
     deadline = time.time() + BAN_POLL_TIMEOUT
     while time.time() < deadline:
         out, _, _ = remote_run(
-            SACONSOLE_LAN_IP, 22, SSH_USER, SSH_KEY,
+            HUB_LAN_IP, 22, SSH_USER, SSH_KEY,
             "sudo fail2ban-client status sshd",
         )
         if TARGET1_WG_IP in out:
@@ -147,10 +149,10 @@ def wait_for_ban():
 
 
 def unban(ip):
-    """Remove the ban for ip from saconsole's sshd jail."""
-    console.print(f"[cyan]Unbanning {ip} on saconsole…[/cyan]")
+    """Remove the ban for ip from hub's sshd jail."""
+    console.print(f"[cyan]Unbanning {ip} on hub…[/cyan]")
     out, _, _ = remote_run(
-        SACONSOLE_LAN_IP, 22, SSH_USER, SSH_KEY,
+        HUB_LAN_IP, 22, SSH_USER, SSH_KEY,
         f"sudo fail2ban-client set sshd unbanip {ip}",
     )
     console.print(f"[green]✓ Unban response: {out.strip()}[/green]")
@@ -164,7 +166,7 @@ def main():
         "Exercises: failed SSH login → fail2ban ban → /var/log/fail2ban.log "
         "→ Promtail → Loki\n"
         f"Attacker : target1 ({TARGET1_WG_IP}) via NAT ({TARGET1_NAT_HOST}:{TARGET1_NAT_PORT})\n"
-        f"Victim   : saconsole ({SACONSOLE_WG_IP})",
+        f"Victim   : hub ({HUB_WG})",
         style="blue",
     ))
 
@@ -178,7 +180,7 @@ def main():
 
         banned = wait_for_ban()
         if not banned:
-            console.print("[red]Aborting — ban not confirmed. Check fail2ban on saconsole.[/red]")
+            console.print("[red]Aborting — ban not confirmed. Check fail2ban on hub.[/red]")
             sys.exit(1)
 
         console.print(

--- a/orchestration/provision_kvm.py
+++ b/orchestration/provision_kvm.py
@@ -14,7 +14,7 @@ The provisioner detects whether a VM is mid-autoinstall and waits automatically:
 
 Usage:
     python3 orchestration/provision_kvm.py                     # provision both VMs
-    python3 orchestration/provision_kvm.py --target saconsole  # single VM
+    python3 orchestration/provision_kvm.py --target <hub_key>  # single VM
     python3 orchestration/provision_kvm.py --target target1
     python3 orchestration/provision_kvm.py --check             # dry run (Ansible check mode)
     python3 orchestration/provision_kvm.py --tags wireguard    # run specific Ansible tags
@@ -45,10 +45,12 @@ PLAYBOOK      = "site-kvm.yml"
 SNAPSHOT_FRESH    = "Fresh Install"
 SNAPSHOT_BASELINE = "Stage 2.1 Baseline"
 
+from tools.host_identity import HUB_KEY, HUB_WG_IP
+
 KVM_VMS = {
-    "saconsole": {
+    HUB_KEY: {
         "description": "Ubuntu Server 24.04 — WireGuard hub + observability stack",
-        "wg_ip":       "10.10.0.1",
+        "wg_ip":       HUB_WG_IP,
     },
     "target1": {
         "description": "Ubuntu Server 24.04 — monitored host",
@@ -335,9 +337,9 @@ def main() -> int:
     table.add_column("Host", style="cyan")
     table.add_column("Service")
     table.add_column("Address")
-    table.add_row("saconsole", "Grafana",     "http://10.10.0.1:3000")
-    table.add_row("saconsole", "Prometheus",  "http://10.10.0.1:9090")
-    table.add_row("saconsole", "Alertmanager","http://10.10.0.1:9093")
+    table.add_row(HUB_KEY, "Grafana",     f"http://{HUB_WG_IP}:3000")
+    table.add_row(HUB_KEY, "Prometheus",  f"http://{HUB_WG_IP}:9090")
+    table.add_row(HUB_KEY, "Alertmanager",f"http://{HUB_WG_IP}:9093")
     table.add_row("target1",   "node_exporter metrics", "http://10.10.0.3:9100/metrics")
     console.print(table)
 

--- a/orchestration/validate_observability.py
+++ b/orchestration/validate_observability.py
@@ -85,7 +85,7 @@ def find_obs_host(hosts_map: dict, name: Optional[str]) -> tuple[str, str]:
       Collect all ansible_managed wg_role=hub hosts from every group, then
       return the first one reachable on port 22 (SSH). This works correctly
       across platforms: on KVM the virbr0 IP is probed; on VBox the hostname
-      ('saconsole') resolves via /etc/hosts to the bridged LAN IP.
+      resolves via /etc/hosts to the bridged LAN IP.
       Falls back to the first candidate if none respond (stack may be down).
     """
     def ip_for(attrs: dict) -> str:
@@ -508,7 +508,7 @@ def main() -> int:
     metrics.append(check_metric(
         prom, "cAdvisor: container_cpu_usage_seconds_total present",
         'count(container_cpu_usage_seconds_total{name!=""})'))
-    # saconsole's node_exporter runs on host.docker.internal:9100 (network_mode: host)
+    # Hub's node_exporter runs on host.docker.internal:9100 (network_mode: host)
     metrics.append(check_metric(
         prom, f"wg0 visible on {obs_hostname}",
         f'node_network_info{{device="wg0",instance="host.docker.internal:9100"}}'))

--- a/platforms/kvm/CLAUDE.md
+++ b/platforms/kvm/CLAUDE.md
@@ -8,7 +8,7 @@
   - libvirt pool `esacp` → `/mnt/esacp-disk/var/lib/libvirt/images/` (active ✅)
 - **`--os-variant`**: toshiba osinfo-db tops out at `ubuntu20.04` — use it for all `virt-install` calls here
 - **virsh**: plain `virsh` = user session. Always use `virsh --connect qemu:///system` or `sudo virsh`
-- **saconsole manages siblings** via `qemu+ssh://<hypervisor-alias>/system`
+- **hub manages siblings** via `qemu+ssh://<hypervisor-alias>/system`
 
 ## Shared Configuration — config.sh
 
@@ -20,12 +20,12 @@ Override any value via `ESACP_*` env vars (e.g. `ESACP_HYPERVISOR_ALIAS=toshy`).
 
 ## Bootstrap Scripts
 
-- `rebuild_lab.sh` — one-command full rebuild: destroy → bootstrap_saconsole → bootstrap_targets (Phase 3 SSHes to saconsole via ProxyJump)
-- `bootstrap_saconsole.sh` — idempotent 9-phase: seed ISO → upload → VM create → autoinstall wait → "Fresh Install" snapshot → Ansible → "Stage 2.2 Baseline" snapshot → handoff
+- `rebuild_lab.sh` — one-command full rebuild: destroy → bootstrap_hub → bootstrap_targets (Phase 3 SSHes to hub via ProxyJump)
+- `bootstrap_hub.sh` — idempotent 9-phase: seed ISO → upload → VM create → autoinstall wait → "Fresh Install" snapshot → Ansible → "Stage 2.2 Baseline" snapshot → handoff
   - Play 5 (controller WireGuard spoke) requires toshiba UDP 51820 port-forward first
-- `bootstrap_targets.sh` — runs FROM saconsole after `control_plane` role applied; injects saconsole pubkey via envsubst; direct virbr0 SSH (no ProxyJump)
-  - saconsole's `~/.ssh/id_ed25519` is the only key authorised in targets' cloud-init — controller key has no access
-  - Requires `cloud-image-utils` on saconsole (in saconsole/user-data packages)
+- `bootstrap_targets.sh` — runs FROM hub after `control_plane` role applied; injects hub pubkey via envsubst; direct virbr0 SSH (no ProxyJump)
+  - hub's `~/.ssh/id_ed25519` is the only key authorised in targets' cloud-init — controller key has no access
+  - Requires `cloud-image-utils` on hub (in hub/user-data packages)
 - `destroy_vms.sh` — tear down VMs on toshiba; also removes seed ISOs + clears known_hosts
 - `prepare_hypervisor.sh` — pre-bootstrap: check + apply controller prereqs; check hypervisor state
 - **Disk pool collision**: pre-existing `.qcow2` files with same name will be REUSED by virt-install, not created fresh. Always destroy VMs with `--remove-all-storage` before rebuilding. Confirm with `virsh --connect qemu:///system vol-list esacp | grep target`.
@@ -91,7 +91,7 @@ Step 10 SCPs deploy keys + passphrase + ce_sri secrets (P12 cert, generated `ce_
 
 - **known_hosts must be cleared at script START** (before any SSH attempt) on VM rebuild — not reactively after the error. Clear by hostname AND IP.
 - **virsh snapshot names with spaces via SSH**: pass as single double-quoted string directly — do NOT use `bash -c` wrapper. `ssh host "virsh ... 'Name With Spaces' --atomic"` (not `ssh host bash -c "..."`).
-- **Remote-hosted VMs SSH key split**: target1/target2 use saconsole's pubkey; ERPNext VMs (dev01, dev02, target3+) use hasan_mighty pubkey via cloud-init template.
+- **Remote-hosted VMs SSH key split**: target1/target2 use hub's pubkey; ERPNext VMs (dev01, dev02, target3+) use hasan_mighty pubkey via cloud-init template.
 - **`hypervisor` field in hosts_map.yml**: optional per-host field routing `esacp.py buildVM` to the remote KVM host via SSH. `generate_inventory.py` injects `ansible_ssh_common_args: "-o ProxyJump=..."` for all remote-hosted hosts.
 - **Secrets**: `ansible/group_vars/all.sops.yml` holds Telegram bot token, Grafana admin password. Requires SOPS + age key (`~/.config/sops/age/keys.txt`). See `SETUP_GUIDE.md`.
 

--- a/platforms/kvm/bootstrap_hub.sh
+++ b/platforms/kvm/bootstrap_hub.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
-# bootstrap_saconsole.sh — Idempotent bootstrap of saconsole on a remote KVM hypervisor
+# bootstrap_hub.sh — Idempotent bootstrap of the hub VM on a remote KVM hypervisor
 #
 # Phases:
 #   1. Preflight checks
-#   2. Build saconsole seed ISO (local, cloud-localds)
+#   2. Build hub seed ISO (local, cloud-localds)
 #   3. Upload seed ISO to hypervisor
-#   4. Create saconsole VM on hypervisor (virt-install via SSH)
+#   4. Create hub VM on hypervisor (virt-install via SSH)
 #   5. Wait for autoinstall → first boot → SSH ready
 #   6. Snapshot "Fresh Install"
-#   7. Ansible provision saconsole (via ProxyJump through hypervisor)
+#   7. Ansible provision hub (via ProxyJump through hypervisor)
 #   8. Snapshot "Stage 2.2 Baseline"
-#   9. Handoff: install saconsole's SSH pubkey on hypervisor
+#   9. Handoff: install hub's SSH pubkey on hypervisor
 #
 # Usage (from project root):
-#   bash platforms/kvm/bootstrap_saconsole.sh
+#   bash platforms/kvm/bootstrap_hub.sh
 #
 # Prerequisites:
 #   - cloud-image-utils (cloud-localds) installed on this controller
@@ -22,7 +22,7 @@
 #   - SOPS age key at ~/.config/sops/age/keys.txt (for Ansible secrets)
 #
 # Idempotency: safe to re-run at any phase. Each step checks current state
-# before acting. Delete saconsole VM + seed ISO to start from scratch.
+# before acting. Delete hub VM + seed ISO to start from scratch.
 
 set -euo pipefail
 
@@ -51,11 +51,11 @@ remote() {
 }
 
 vm_exists() {
-    remote virsh --connect qemu:///system dominfo saconsole &>/dev/null
+    remote virsh --connect qemu:///system dominfo ${HUB_VM_NAME} &>/dev/null
 }
 
 vm_state() {
-    remote virsh --connect qemu:///system domstate saconsole 2>/dev/null \
+    remote virsh --connect qemu:///system domstate ${HUB_VM_NAME} 2>/dev/null \
         | tr -d '\n' \
         || echo "unknown"
 }
@@ -67,17 +67,17 @@ snapshot_exists() {
     # joins all argv[] with spaces before the remote shell parses them, so
     # `ssh host bash -c "cmd"` became `bash -c cmd` (cmd = first word only).
     ssh "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" \
-        "virsh --connect qemu:///system snapshot-list saconsole --name 2>/dev/null" \
+        "virsh --connect qemu:///system snapshot-list ${HUB_VM_NAME} --name 2>/dev/null" \
         | grep -qxF "$1"
 }
 
 # SSH options used for all direct connections FROM THIS CONTROLLER TO SACONSOLE.
-# UserKnownHostsFile=/dev/null: cloud-init regenerates saconsole's SSH host keys
+# UserKnownHostsFile=/dev/null: cloud-init regenerates the hub's SSH host keys
 # on first boot AFTER autoinstall completes. The key seen in Phase 5 (ssh_ready)
 # differs from the key seen in Phase 9 (handoff). StrictHostKeyChecking=no alone
 # is not enough — SSH still rejects a *changed* key even with that option set.
 # Using /dev/null bypasses known_hosts entirely for these bootstrap connections.
-SACONSOLE_SSH_OPTS=(
+HUB_SSH_OPTS=(
     -o StrictHostKeyChecking=no
     -o UserKnownHostsFile=/dev/null
     -o LogLevel=ERROR
@@ -89,8 +89,8 @@ SACONSOLE_SSH_OPTS=(
 
 ssh_ready() {
     ssh \
-        "${SACONSOLE_SSH_OPTS[@]}" \
-        "${SACONSOLE_USER}@${SACONSOLE_IP}" \
+        "${HUB_SSH_OPTS[@]}" \
+        "${HUB_USER}@${HUB_VIRBR0_IP}" \
         "echo ok" &>/dev/null
 }
 
@@ -102,7 +102,7 @@ take_snapshot() {
     fi
     log "  Creating snapshot '${name}' ..."
     ssh "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" \
-        "virsh --connect qemu:///system snapshot-create-as saconsole '${name}' --atomic"
+        "virsh --connect qemu:///system snapshot-create-as ${HUB_VM_NAME} '${name}' --atomic"
     log "  ✅  '${name}'"
 }
 
@@ -134,13 +134,13 @@ log "Hypervisor : ${HYPERVISOR_ALIAS} (${HYPERVISOR_USER}@${HYPERVISOR_LAN_IP})"
 log "Images dir : ${HYPERVISOR_ALIAS}:${REMOTE_IMAGES_DIR}"
 log "✅  Preflight OK"
 
-# ── Phase 2: Build saconsole seed ISO ─────────────────────────────────────────
+# ── Phase 2: Build hub seed ISO ─────────────────────────────────────────
 
-step "Phase 2: Build saconsole seed ISO"
+step "Phase 2: Build hub seed ISO"
 
-SEED_ISO="${SCRIPT_DIR}/saconsole-seed.iso"
-USER_DATA="${SCRIPT_DIR}/cloud-init/saconsole/user-data"
-META_DATA="${SCRIPT_DIR}/cloud-init/saconsole/meta-data"
+SEED_ISO="${SCRIPT_DIR}/${HUB_KEY}-seed.iso"
+USER_DATA="${SCRIPT_DIR}/cloud-init/${HUB_KEY}/user-data"
+META_DATA="${SCRIPT_DIR}/cloud-init/${HUB_KEY}/meta-data"
 
 [[ -f "${USER_DATA}" ]] || die "Missing: ${USER_DATA}"
 [[ -f "${META_DATA}" ]] || die "Missing: ${META_DATA}"
@@ -158,7 +158,7 @@ fi
 
 step "Phase 3: Upload seed ISO to ${HYPERVISOR_ALIAS}"
 
-REMOTE_SEED="${REMOTE_IMAGES_DIR}/saconsole-seed.iso"
+REMOTE_SEED="${REMOTE_IMAGES_DIR}/${HUB_KEY}-seed.iso"
 LOCAL_MTIME=$(stat -c %Y "${SEED_ISO}")
 REMOTE_MTIME=$(remote "stat -c %Y '${REMOTE_SEED}' 2>/dev/null || echo 0")
 
@@ -172,12 +172,12 @@ fi
 
 # ── Phase 4: Create VM on hypervisor ──────────────────────────────────────────
 
-step "Phase 4: Create saconsole VM on ${HYPERVISOR_ALIAS}"
+step "Phase 4: Create hub VM on ${HYPERVISOR_ALIAS}"
 
 REMOTE_ISO="${REMOTE_IMAGES_DIR}/${UBUNTU_ISO_NAME}"
 
 if vm_exists; then
-    log "VM 'saconsole' already exists on ${HYPERVISOR_ALIAS} — skipping creation."
+    log "VM '${HUB_VM_NAME}' already exists on ${HYPERVISOR_ALIAS} — skipping creation."
 else
     remote "test -f '${REMOTE_ISO}'" \
         || die "Ubuntu ISO not found on ${HYPERVISOR_ALIAS}: ${REMOTE_ISO}"
@@ -189,13 +189,13 @@ else
     #
     # --os-variant ubuntu20.04: toshiba's osinfo-db (Ubuntu 20.04 stock) tops out at
     #   ubuntu20.04 — ubuntu22.04 and ubuntu24.04 are both absent.
-    # --disk pool=esacp: stores saconsole.qcow2 in the esacp pool
+    # --disk pool=esacp: stores ${HUB_VM_NAME}.qcow2 in the esacp pool
     #   (/mnt/esacp-disk/var/lib/libvirt/images) — system disk is 98% full.
     # --noautoconsole: returns immediately; autoinstall runs headlessly.
     ssh "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" bash <<REMOTE
 virt-install \
     --connect qemu:///system \
-    --name saconsole \
+    --name ${HUB_VM_NAME} \
     --ram 4096 \
     --vcpus 2 \
     --disk pool=esacp,size=20,format=qcow2 \
@@ -213,7 +213,7 @@ fi
 
 # ── Phase 5: Wait for first boot + SSH ────────────────────────────────────────
 
-step "Phase 5: Wait for saconsole to be ready"
+step "Phase 5: Wait for hub to be ready"
 
 if ssh_ready; then
     log "SSH already available — VM is fully up."
@@ -227,8 +227,8 @@ else
         STATE=$(vm_state)
         case "${STATE}" in
             "shut off")
-                log "VM shut off — autoinstall complete. Starting saconsole ..."
-                remote virsh --connect qemu:///system start saconsole
+                log "VM shut off — autoinstall complete. Starting hub ..."
+                remote virsh --connect qemu:///system start ${HUB_VM_NAME}
                 sleep 5
                 break
                 ;;
@@ -239,7 +239,7 @@ else
                     break
                 fi
                 if [[ ${SECONDS} -ge ${DEADLINE} ]]; then
-                    die "Autoinstall timed out after ${AUTOINSTALL_TIMEOUT}s."$'\n'"  Debug: ssh ${HYPERVISOR_ALIAS} 'virt-viewer saconsole'"
+                    die "Autoinstall timed out after ${AUTOINSTALL_TIMEOUT}s."$'\n'"  Debug: ssh ${HYPERVISOR_ALIAS} 'virt-viewer ${HUB_VM_NAME}'"
                 fi
                 log "  VM running (autoinstall in progress) — waiting 30s ..."
                 sleep 30
@@ -256,7 +256,7 @@ else
     SSH_DEADLINE=$(( SECONDS + SSH_POLL_TIMEOUT ))
     until ssh_ready; do
         if [[ ${SECONDS} -ge ${SSH_DEADLINE} ]]; then
-            die "SSH not ready after ${SSH_POLL_TIMEOUT}s."$'\n'"  Try: ssh -J ${HYPERVISOR_ALIAS} -i ${SSH_KEY} ${SACONSOLE_USER}@${SACONSOLE_IP}"
+            die "SSH not ready after ${SSH_POLL_TIMEOUT}s."$'\n'"  Try: ssh -J ${HYPERVISOR_ALIAS} -i ${SSH_KEY} ${HUB_USER}@${HUB_VIRBR0_IP}"
         fi
         log "  Waiting for SSH ..."
         sleep 5
@@ -270,23 +270,23 @@ log "✅  SSH ready."
 step "Phase 6: Snapshot '${SNAPSHOT_FRESH}'"
 take_snapshot "${SNAPSHOT_FRESH}"
 
-# ── Phase 7: Ansible provision (saconsole only) ───────────────────────────────
+# ── Phase 7: Ansible provision (hub only) ───────────────────────────────
 
-step "Phase 7: Ansible provision saconsole"
+step "Phase 7: Ansible provision hub"
 log "ProxyJump : ${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}"
-log "Limit     : saconsole (Play 4 / controller WireGuard is a separate step)"
+log "Limit     : hub (Play 4 / controller WireGuard is a separate step)"
 
 export ANSIBLE_CONFIG="${ANSIBLE_DIR}/ansible.cfg"
 export ANSIBLE_PRIVATE_KEY_FILE="${SSH_KEY}"
 
 # ansible_ssh_common_args adds the ProxyJump to all SSH connections from Ansible.
 # It is appended to ssh_args in ansible.cfg — both apply simultaneously.
-# --limit saconsole skips Play 3 (target1) and Play 4 (localhost/controller).
+# --limit ${HUB_KEY} skips Play 3 (target1) and Play 4 (localhost/controller).
 cd "${ANSIBLE_DIR}"
 ansible-playbook \
     -i inventory/kvm.yml \
     site-kvm.yml \
-    --limit saconsole \
+    --limit ${HUB_KEY} \
     --extra-vars "ansible_ssh_common_args='-J ${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}'"
 
 log "✅  Ansible provision complete."
@@ -296,93 +296,93 @@ log "✅  Ansible provision complete."
 step "Phase 8: Snapshot '${SNAPSHOT_BASELINE}'"
 take_snapshot "${SNAPSHOT_BASELINE}"
 
-# ── Phase 9: Handoff — saconsole SSH pubkey → hypervisor ──────────────────────
+# ── Phase 9: Handoff — hub SSH pubkey → hypervisor ──────────────────────
 
 step "Phase 9: Handoff"
 
-# Generate a keypair on saconsole if one doesn't exist yet.
-log "Generating SSH keypair on saconsole (if absent) ..."
+# Generate a keypair on hub if one doesn't exist yet.
+log "Generating SSH keypair on hub (if absent) ..."
 ssh \
-    "${SACONSOLE_SSH_OPTS[@]}" \
-    "${SACONSOLE_USER}@${SACONSOLE_IP}" \
+    "${HUB_SSH_OPTS[@]}" \
+    "${HUB_USER}@${HUB_VIRBR0_IP}" \
     "test -f ~/.ssh/id_ed25519 \
-        || ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519 -C 'saconsole@esacp'"
+        || ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519 -C '${HUB_KEY}@esacp'"
 
-# Retrieve saconsole's public key.
-SACONSOLE_PUBKEY=$(ssh \
-    "${SACONSOLE_SSH_OPTS[@]}" \
-    "${SACONSOLE_USER}@${SACONSOLE_IP}" \
+# Retrieve hub's public key.
+HUB_PUBKEY=$(ssh \
+    "${HUB_SSH_OPTS[@]}" \
+    "${HUB_USER}@${HUB_VIRBR0_IP}" \
     "cat ~/.ssh/id_ed25519.pub")
 
 # Install pubkey on hypervisor (idempotent: grep before append).
 remote bash <<REMOTE
 mkdir -p ~/.ssh && chmod 700 ~/.ssh
-grep -qxF '${SACONSOLE_PUBKEY}' ~/.ssh/authorized_keys 2>/dev/null \
-    || echo '${SACONSOLE_PUBKEY}' >> ~/.ssh/authorized_keys
+grep -qxF '${HUB_PUBKEY}' ~/.ssh/authorized_keys 2>/dev/null \
+    || echo '${HUB_PUBKEY}' >> ~/.ssh/authorized_keys
 chmod 600 ~/.ssh/authorized_keys
 REMOTE
 
-log "✅  saconsole SSH pubkey installed on ${HYPERVISOR_ALIAS}."
-log "    saconsole can now connect: qemu+ssh://${HYPERVISOR_USER}@${ESACP_HYPERVISOR}/system"
+log "✅  Hub SSH pubkey installed on ${HYPERVISOR_ALIAS}."
+log "    Hub can now connect: qemu+ssh://${HYPERVISOR_USER}@${ESACP_HYPERVISOR}/system"
 
-# Add hypervisor to saconsole's /etc/hosts.
-# A fresh saconsole uses 8.8.8.8/1.1.1.1 (from cloud-init) and cannot
+# Add hypervisor to hub's /etc/hosts.
+# A fresh hub uses 8.8.8.8/1.1.1.1 (from cloud-init) and cannot
 # resolve the local hostname. bootstrap_targets.sh uses
 # HYPERVISOR_ALIAS throughout — without this, all its SSH and
 # virsh calls fail with "Temporary failure in name resolution".
-log "Adding ${ESACP_HYPERVISOR} → ${HYPERVISOR_LAN_IP} to saconsole /etc/hosts ..."
+log "Adding ${ESACP_HYPERVISOR} → ${HYPERVISOR_LAN_IP} to hub /etc/hosts ..."
 ssh \
-    "${SACONSOLE_SSH_OPTS[@]}" \
-    "${SACONSOLE_USER}@${SACONSOLE_IP}" \
+    "${HUB_SSH_OPTS[@]}" \
+    "${HUB_USER}@${HUB_VIRBR0_IP}" \
     "grep -qF '${ESACP_HYPERVISOR}' /etc/hosts 2>/dev/null \
          || echo '${HYPERVISOR_LAN_IP} ${ESACP_HYPERVISOR}' | sudo tee -a /etc/hosts > /dev/null"
-log "✅  ${ESACP_HYPERVISOR} in saconsole /etc/hosts."
+log "✅  ${ESACP_HYPERVISOR} in hub /etc/hosts."
 
-# Seed hypervisor's host key into saconsole's known_hosts.
-# bootstrap_targets.sh runs FROM saconsole and SSHes to the hypervisor with
-# BatchMode=yes — on a fresh saconsole the known_hosts is empty and
+# Seed hypervisor's host key into hub's known_hosts.
+# bootstrap_targets.sh runs FROM the hub and SSHes to the hypervisor with
+# BatchMode=yes — on a fresh hub the known_hosts is empty and
 # BatchMode refuses the unknown key instead of prompting.
 # Base64 transfer avoids quoting/newline issues with multi-line key content.
-log "Seeding ${HYPERVISOR_ALIAS} host key into saconsole known_hosts ..."
+log "Seeding ${HYPERVISOR_ALIAS} host key into hub known_hosts ..."
 HYPER_KEYS_B64=$(ssh-keyscan -H "${ESACP_HYPERVISOR}" "${HYPERVISOR_LAN_IP}" 2>/dev/null \
     | base64 -w0 || true)
 ssh \
-    "${SACONSOLE_SSH_OPTS[@]}" \
-    "${SACONSOLE_USER}@${SACONSOLE_IP}" \
+    "${HUB_SSH_OPTS[@]}" \
+    "${HUB_USER}@${HUB_VIRBR0_IP}" \
     "mkdir -p ~/.ssh
      echo '${HYPER_KEYS_B64}' | base64 -d >> ~/.ssh/known_hosts
      chmod 600 ~/.ssh/known_hosts"
-log "✅  toshiba host key seeded into saconsole known_hosts."
+log "✅  toshiba host key seeded into hub known_hosts."
 
-# Remove stale saconsole pubkeys from toshiba's authorized_keys.
+# Remove stale hub pubkeys from toshiba's authorized_keys.
 # Each rebuild generates a new keypair and appends the new pubkey.
-# Keep only the current saconsole's pubkey to avoid accumulation.
-log "Replacing stale saconsole pubkeys on ${HYPERVISOR_ALIAS} ..."
+# Keep only the current hub's pubkey to avoid accumulation.
+log "Replacing stale hub pubkeys on ${HYPERVISOR_ALIAS} ..."
 remote bash <<REMOTE
 mkdir -p ~/.ssh && chmod 700 ~/.ssh
-# Remove all lines from previous saconsole builds (comment = saconsole@esacp
-# or saconsole-control-plane), then append the current one.
-grep -v 'saconsole' ~/.ssh/authorized_keys > /tmp/ak_clean 2>/dev/null || true
-echo '${SACONSOLE_PUBKEY}' >> /tmp/ak_clean
+# Remove all lines from previous hub builds (comment = ${HUB_KEY}@esacp
+# or ${HUB_KEY}-control-plane), then append the current one.
+grep -v '${HUB_KEY}' ~/.ssh/authorized_keys > /tmp/ak_clean 2>/dev/null || true
+echo '${HUB_PUBKEY}' >> /tmp/ak_clean
 mv /tmp/ak_clean ~/.ssh/authorized_keys
 chmod 600 ~/.ssh/authorized_keys
 REMOTE
-log "✅  toshiba authorized_keys updated (current saconsole pubkey only)."
+log "✅  toshiba authorized_keys updated (current hub pubkey only)."
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 
 step "Done"
 cat <<SUMMARY
 
-  saconsole is provisioned and running on ${HYPERVISOR_ALIAS}.
+  Hub is provisioned and running on ${HYPERVISOR_ALIAS}.
 
   Snapshots : '${SNAPSHOT_FRESH}', '${SNAPSHOT_BASELINE}'
-  Handoff   : saconsole SSH pubkey → ${HYPERVISOR_ALIAS} authorized_keys
+  Handoff   : Hub SSH pubkey → ${HYPERVISOR_ALIAS} authorized_keys
 
   ── Next steps ──────────────────────────────────────────────────────────────
 
   1. Port-forward WireGuard on ${HYPERVISOR_ALIAS} so this controller's spoke
-     can reach saconsole hub at ${HYPERVISOR_LAN_IP}:51820:
+     can reach hub at ${HYPERVISOR_LAN_IP}:51820:
 
        sudo iptables -t nat -A PREROUTING -i <LAN-iface> -p udp --dport 51820 \\
            -j DNAT --to-destination ${SACONSOLE_IP}:51820

--- a/platforms/kvm/bootstrap_targets.sh
+++ b/platforms/kvm/bootstrap_targets.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
 # bootstrap_targets.sh — Bootstrap target1 and target2 on the remote KVM hypervisor
 #
-# Runs FROM saconsole after the control_plane role has been applied.
-# saconsole reaches targets directly on toshiba's virbr0 (192.168.122.0/24) —
-# no ProxyJump required (saconsole and its sibling targets share the same virbr0).
+# Runs FROM the hub after the control_plane role has been applied.
+# The hub reaches targets directly on toshiba's virbr0 (192.168.122.0/24) —
+# no ProxyJump required (the hub and its sibling targets share the same virbr0).
 #
 # Phases:
 #   1. Preflight checks
-#   2. Read saconsole SSH pubkey
-#   3. Build seed ISOs (target1, target2) with saconsole's pubkey injected
+#   2. Read hub SSH pubkey
+#   3. Build seed ISOs (target1, target2) with the hub's pubkey injected
 #   4. Upload seed ISOs to hypervisor
 #   5. Create VMs on hypervisor
 #   6. Wait for autoinstall → first boot → SSH ready (both VMs)
 #   7. Snapshot "Fresh Install" (both VMs)
-#   8. Ansible provision targets (from saconsole — direct virbr0 connection)
+#   8. Ansible provision targets (from hub — direct virbr0 connection)
 #   9. Snapshot "Stage 2.2 Targets Baseline" (both VMs)
 #
-# Usage (from /opt/esacp on saconsole):
+# Usage (from /opt/esacp on the hub):
 #   bash platforms/kvm/bootstrap_targets.sh
 #
 # Prerequisites:
-#   - control_plane role applied to saconsole (provides: Ansible, repo, SSH keypair)
+#   - control_plane role applied to the hub (provides: Ansible, repo, SSH keypair)
 #   - cloud-image-utils installed: sudo apt install cloud-image-utils
-#   - SSH access from saconsole to hypervisor (via saconsole's ~/.ssh/id_ed25519)
+#   - SSH access from hub to hypervisor (via hub's ~/.ssh/id_ed25519)
 #   - SOPS age key at ~/.config/sops/age/keys.txt
 
 set -euo pipefail
@@ -33,7 +33,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=config.sh
 source "${SCRIPT_DIR}/config.sh"
 
-# Saconsole-specific overrides: SSH key is saconsole's own keypair, not controller's
+# Hub-specific overrides: SSH key is the hub's own keypair, not controller's
 SSH_KEY="${HOME}/.ssh/id_ed25519"
 
 UBUNTU_ISO_NAME="ubuntu-22.04.2-live-server-amd64.iso"
@@ -172,7 +172,7 @@ command -v ansible-playbook &>/dev/null \
 
 ssh -o ConnectTimeout=5 -o BatchMode=yes \
     "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" "echo ok" &>/dev/null \
-    || die "Cannot reach hypervisor '${HYPERVISOR_ALIAS}' — has the handoff step run in bootstrap_saconsole.sh?"
+    || die "Cannot reach hypervisor '${HYPERVISOR_ALIAS}' — has the handoff step run in bootstrap_hub.sh?"
 
 remote "test -d '${REMOTE_IMAGES_DIR}'" \
     || die "${HYPERVISOR_ALIAS}:${REMOTE_IMAGES_DIR} not found — is the LUKS disk mounted?"
@@ -185,9 +185,9 @@ remote "test -f '${REMOTE_IMAGES_DIR}/${UBUNTU_ISO_NAME}'" \
 
 log "Preflight OK"
 
-# ── Phase 2: Read saconsole SSH pubkey ─────────────────────────────────────────
+# ── Phase 2: Read hub SSH pubkey ─────────────────────────────────────────
 
-step "Phase 2: Read saconsole SSH pubkey"
+step "Phase 2: Read hub SSH pubkey"
 
 export CONTROLLER_PUBKEY
 CONTROLLER_PUBKEY=$(cat "${SSH_KEY}.pub")
@@ -210,7 +210,7 @@ for vm in "${TARGETS[@]}"; do
     [[ -f "${TEMPLATE_DIR}/meta-data" ]] \
         || die "Missing cloud-init template: ${TEMPLATE_DIR}/meta-data"
 
-    # Inject saconsole's SSH pubkey into the user-data template
+    # Inject the hub's SSH pubkey into the user-data template
     envsubst < "${TEMPLATE_DIR}/user-data" > "${RENDERED_USERDATA}"
 
     if [[ -f "${SEED_ISO}" \
@@ -298,7 +298,7 @@ done
 # ── Phase 8: Ansible provision targets ────────────────────────────────────────
 
 step "Phase 8: Ansible provision targets"
-log "Limit   : targets (Plays 1, 3, 4 — base config + saconsole pubkey + services)"
+log "Limit   : targets (Plays 1, 3, 4 — base config + hub pubkey + services)"
 log "SSH key : ${SSH_KEY}"
 
 export ANSIBLE_CONFIG="${ANSIBLE_DIR}/ansible.cfg"
@@ -312,12 +312,12 @@ for vm in "${TARGETS[@]}"; do
 done
 
 cd "${ANSIBLE_DIR}"
-# --limit targets runs: Play 1 (base config), Play 3 (authorise saconsole), Play 4 (services).
-# Play 2 (saconsole-only) and Play 5 (controller/localhost) are skipped automatically.
+# --limit targets runs: Play 1 (base config), Play 3 (authorise hub), Play 4 (services).
+# Play 2 (hub-only) and Play 5 (controller/localhost) are skipped automatically.
 #
-# Play 3 depends on hostvars['saconsole']['saconsole_ssh_pubkey']. Since we run
-# --limit targets, saconsole's play does not execute and the fact is not populated.
-# We pass the pubkey explicitly via saconsole_override_pubkey — Play 3 checks for
+# Play 3 depends on hostvars[hub_key]['hub_ssh_pubkey']. Since we run
+# --limit targets, the hub's play does not execute and the fact is not populated.
+# We pass the pubkey explicitly via hub_override_pubkey — Play 3 checks for
 # this var before falling back to hostvars. See site-kvm.yml Play 3 comment.
 #
 # Use a temp YAML vars file so the SSH public key (which contains spaces) is
@@ -325,7 +325,7 @@ cd "${ANSIBLE_DIR}"
 TMPVARS=$(mktemp /tmp/ansible-vars-XXXXXX.yml)
 trap "rm -f ${TMPVARS}" EXIT
 cat > "${TMPVARS}" << ENDVARS
-saconsole_override_pubkey: "$(cat ${SSH_KEY}.pub)"
+hub_override_pubkey: "$(cat ${SSH_KEY}.pub)"
 ansible_ssh_private_key_file: "${SSH_KEY}"
 ENDVARS
 

--- a/platforms/kvm/config.sh
+++ b/platforms/kvm/config.sh
@@ -28,7 +28,12 @@ REMOTE_IMAGES_DIR="${ESACP_REMOTE_IMAGES_DIR:-/mnt/esacp-disk/var/lib/libvirt/im
 VM_USER="${ESACP_VM_USER:-you}"
 SSH_KEY="${ESACP_SSH_KEY:-${HOME}/.ssh/hasan_mighty}"
 
-# ── Convenience aliases ──────────────────────────────────────────────────────
-SACONSOLE_IP="${ESACP_SACONSOLE_VIRBR0_IP}"
-SACONSOLE_USER="${VM_USER}"
+# ── Hub identity (derived from wg_role=hub in hosts_map.yml) ─────────────────
+HUB_KEY="${ESACP_HUB_KEY}"
+HUB_VM_NAME="${ESACP_HUB_VM_NAME}"
+HUB_HOSTNAME="${ESACP_HUB_HOSTNAME}"
+HUB_DISPLAY_NAME="${ESACP_HUB_DISPLAY_NAME}"
+HUB_VIRBR0_IP="${ESACP_HUB_VIRBR0_IP}"
+HUB_WG_IP="${ESACP_HUB_WG_IP}"
+HUB_USER="${VM_USER}"
 ANSIBLE_DIR="${PROJ_ROOT}/ansible"

--- a/platforms/kvm/create_seeds.sh
+++ b/platforms/kvm/create_seeds.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# create_seeds.sh — Build cloud-init seed ISOs for saconsole and target1
+# create_seeds.sh — Build cloud-init seed ISOs for hub and target1
 #
 # Each seed ISO is mounted as a second CDROM during virt-install.
 # The Ubuntu subiquity installer detects the CIDATA volume and reads
@@ -9,7 +9,7 @@
 #   bash platforms/kvm/create_seeds.sh
 #
 # Prerequisites: cloud-image-utils (cloud-localds)
-# Output: platforms/kvm/saconsole-seed.iso, platforms/kvm/target1-seed.iso
+# Output: platforms/kvm/<hub_key>-seed.iso, platforms/kvm/target1-seed.iso
 
 set -euo pipefail
 

--- a/platforms/kvm/create_vms.sh
+++ b/platforms/kvm/create_vms.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# create_vms.sh — Create saconsole and target1 KVM VMs
+# create_vms.sh — Create hub and target1 KVM VMs
 #
-# saconsole (Ubuntu Server 24.04.4):
+# Hub (Ubuntu Server 24.04.4):
 #   Uses --location method with --extra-args. Fully automated, no manual step.
 #
 # target1 (Ubuntu Server 24.04.4):
 #   Uses --location method with --extra-args. Fully automated, no manual step.
 #
 # Usage (from project root):
-#   bash platforms/kvm/create_vms.sh [saconsole|target1|both]
+#   bash platforms/kvm/create_vms.sh [hub|target1|both]
 #
 # Default: both
 #
@@ -28,11 +28,11 @@ IMAGES_DIR="/var/lib/libvirt/images"
 # Resolve symlinks so QEMU (libvirt-qemu user) can access the files without
 # needing search permission on /home/hasan.
 # Both VMs use the Ubuntu Server 24.04.4 ISO.
-SACONSOLE_ISO="$(readlink -f "${PROJ_ROOT}/ubuntu-24.04.4-live-server-amd64.iso")"
+HUB_ISO="$(readlink -f "${PROJ_ROOT}/ubuntu-24.04.4-live-server-amd64.iso")"
 TARGET1_ISO="$(readlink -f "${PROJ_ROOT}/ubuntu-24.04.4-live-server-amd64.iso")"
 
 # Seed ISOs must live in IMAGES_DIR so QEMU can read them.
-SACONSOLE_SEED="${IMAGES_DIR}/saconsole-seed.iso"
+HUB_SEED="${IMAGES_DIR}/${HUB_KEY:-saconsole}-seed.iso"
 TARGET1_SEED="${IMAGES_DIR}/target1-seed.iso"
 
 # ── Preflight ────────────────────────────────────────────────────────────────
@@ -70,28 +70,28 @@ vm_exists() {
     virsh dominfo "$1" &>/dev/null
 }
 
-# ── saconsole ────────────────────────────────────────────────────────────────
+# ── hub ────────────────────────────────────────────────────────────────
 
-create_saconsole() {
-    if vm_exists saconsole; then
-        echo "VM 'saconsole' already exists — skipping. Delete it first to recreate:"
-        echo "  virsh destroy saconsole; virsh undefine saconsole --remove-all-storage"
+create_hub() {
+    if vm_exists "${HUB_VM_NAME:-saconsole}"; then
+        echo "VM '${HUB_VM_NAME:-saconsole}' already exists — skipping. Delete it first to recreate:"
+        echo "  virsh destroy ${HUB_VM_NAME:-saconsole}; virsh undefine ${HUB_VM_NAME:-saconsole} --remove-all-storage"
         return
     fi
 
-    check_iso "${SACONSOLE_ISO}" "Ubuntu Server ISO"
-    check_seed "${SACONSOLE_SEED}" "saconsole"
+    check_iso "${HUB_ISO}" "Ubuntu Server ISO"
+    check_seed "${HUB_SEED}" "${HUB_KEY:-saconsole}"
 
-    echo "Creating saconsole VM (fully automated)..."
+    echo "Creating hub VM (fully automated)..."
     # Ubuntu Server 24.04.4 live ISO; kernel/initrd under casper/.
     # The seed ISO is labeled 'cidata'; cloud-init auto-detects it (ds=nocloud).
     virt-install \
-        --name saconsole \
+        --name "${HUB_VM_NAME:-saconsole}" \
         --ram 4096 \
         --vcpus 2 \
-        --disk "path=${IMAGES_DIR}/saconsole.qcow2,size=20,format=qcow2" \
-        --location "${SACONSOLE_ISO},kernel=casper/vmlinuz,initrd=casper/initrd" \
-        --disk "path=${SACONSOLE_SEED},device=cdrom,readonly=on" \
+        --disk "path=${IMAGES_DIR}/${HUB_VM_NAME:-saconsole}.qcow2,size=20,format=qcow2" \
+        --location "${HUB_ISO},kernel=casper/vmlinuz,initrd=casper/initrd" \
+        --disk "path=${HUB_SEED},device=cdrom,readonly=on" \
         --network network=default \
         --os-variant ubuntu22.04 \
         --extra-args "autoinstall ds=nocloud" \
@@ -99,8 +99,8 @@ create_saconsole() {
         --noautoconsole
 
     echo ""
-    echo "✅  saconsole VM created and autoinstall running."
-    echo "    Monitor: virt-viewer saconsole"
+    echo "✅  Hub VM created and autoinstall running."
+    echo "    Monitor: virt-viewer ${HUB_VM_NAME:-saconsole}"
     echo "    The VM will power off when installation is complete."
 }
 
@@ -141,11 +141,11 @@ create_target1() {
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 
 case "${TARGET}" in
-    saconsole) create_saconsole ;;
+    hub) create_hub ;;
     target1)   create_target1 ;;
-    both)      create_saconsole; create_target1 ;;
+    both)      create_hub; create_target1 ;;
     *)
-        echo "Usage: $0 [saconsole|target1|both]"
+        echo "Usage: $0 [hub|target1|both]"
         exit 1
         ;;
 esac

--- a/platforms/kvm/destroy_vms.sh
+++ b/platforms/kvm/destroy_vms.sh
@@ -31,8 +31,8 @@ for _vm in "${ESACP_VMS[@]}"; do
 done
 unset _vm _tag
 
-# Seed ISOs: saconsole + targets (targets use <vm>-<hypervisor>-seed.iso naming)
-LOCAL_SEED_ISOS=(saconsole-seed.iso)
+# Seed ISOs: hub + targets (targets use <vm>-<hypervisor>-seed.iso naming)
+LOCAL_SEED_ISOS=(${HUB_KEY}-seed.iso)
 for _vm in ${ESACP_KVM_TARGETS}; do
     LOCAL_SEED_ISOS+=("${_vm}-${ESACP_HYPERVISOR}-seed.iso")
 done

--- a/platforms/kvm/hub_identity.sh
+++ b/platforms/kvm/hub_identity.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# hub_identity.sh — Export hub VM identity variables for shell scripts.
+#
+# Sources config.sh (which runs parse_hosts_map.py) and re-exports the
+# hub-specific variables.  Shell scripts that previously hardcoded
+# "saconsole" should source this file instead.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/hub_identity.sh"
+#
+# Exported variables:
+#   HUB_KEY, HUB_VM_NAME, HUB_HOSTNAME, HUB_DISPLAY_NAME
+#   HUB_VIRBR0_IP, HUB_WG_IP, HUB_USER
+
+# Guard against double-sourcing
+[[ -n "${_ESACP_HUB_IDENTITY_LOADED:-}" ]] && return 0
+_ESACP_HUB_IDENTITY_LOADED=1
+
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
+# All variables are already set by config.sh from parse_hosts_map.py output.
+# This file exists as the documented entry point for scripts that only need
+# hub identity, and as the single place to add hub-specific derived values.

--- a/platforms/kvm/parse_hosts_map.py
+++ b/platforms/kvm/parse_hosts_map.py
@@ -6,12 +6,21 @@ Usage:
 
 Outputs variables consumed by platforms/kvm/config.sh:
     ESACP_HYPERVISOR          — hypervisor hostname (from first KVM host's field)
-    ESACP_KVM_VMS             — space-separated list of all KVM VM hostnames
+    ESACP_KVM_VMS             — space-separated list of all KVM VM keys
     ESACP_KVM_TARGETS         — space-separated list of KVM hosts with vm_role
-    ESACP_SACONSOLE_VIRBR0_IP — saconsole's virbr0 IP
-    ESACP_SACONSOLE_WG_IP     — saconsole's WireGuard IP
-    ESACP_VM_VIRBR0_IP_<HOST> — per-VM virbr0 IP  (HOST uppercased)
-    ESACP_VM_WG_IP_<HOST>     — per-VM WireGuard IP (HOST uppercased)
+    ESACP_HUB_KEY             — hosts_map key for the wg_role=hub host
+    ESACP_HUB_VM_NAME         — libvirt domain name of the hub
+    ESACP_HUB_HOSTNAME        — OS hostname of the hub
+    ESACP_HUB_DISPLAY_NAME    — UI display label for the hub
+    ESACP_HUB_VIRBR0_IP       — hub's virbr0 IP
+    ESACP_HUB_WG_IP           — hub's WireGuard IP
+    ESACP_VM_VIRBR0_IP_<KEY>  — per-VM virbr0 IP  (KEY uppercased)
+    ESACP_VM_WG_IP_<KEY>      — per-VM WireGuard IP (KEY uppercased)
+    ESACP_VM_NAME_<KEY>       — per-VM libvirt domain name (KEY uppercased)
+
+Optional field lookup mode:
+    platforms/kvm/parse_hosts_map.py hosts_map.yml --field vm_name --role hub
+    → prints the single value (e.g. "saconsole")
 """
 
 import sys
@@ -20,37 +29,67 @@ from pathlib import Path
 import yaml
 
 
+def _find_by_role(kvm: dict, role: str) -> tuple[str, dict]:
+    """Return (key, attrs) for the first KVM host matching wg_role."""
+    for key, attrs in kvm.items():
+        if attrs.get("wg_role") == role:
+            return key, attrs
+    return "", {}
+
+
 def main() -> None:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <hosts_map.yml>", file=sys.stderr)
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <hosts_map.yml> [--field FIELD --role ROLE]",
+              file=sys.stderr)
         sys.exit(1)
 
     hosts_map = yaml.safe_load(Path(sys.argv[1]).read_text())
     kvm = hosts_map.get("groups", {}).get("kvm", {})
 
+    # ── Field lookup mode ────────────────────────────────────────────────────
+    if "--field" in sys.argv:
+        idx = sys.argv.index("--field")
+        field = sys.argv[idx + 1]
+        role = "hub"
+        if "--role" in sys.argv:
+            role = sys.argv[sys.argv.index("--role") + 1]
+        _key, attrs = _find_by_role(kvm, role)
+        print(attrs.get(field, ""))
+        return
+
+    # ── Full variable export mode ────────────────────────────────────────────
     all_vms: list[str] = []
     targets: list[str] = []
     hypervisor = ""
 
-    for hostname, attrs in kvm.items():
-        all_vms.append(hostname)
-        tag = hostname.upper().replace("-", "_")
+    hub_key, hub_attrs = _find_by_role(kvm, "hub")
+
+    for key, attrs in kvm.items():
+        all_vms.append(key)
+        tag = key.upper().replace("-", "_")
 
         virbr0 = attrs.get("virbr0_ip", "")
         wg_ip = attrs.get("wg_ip", "")
+        vm_name = attrs.get("vm_name", key)
 
         print(f'ESACP_VM_VIRBR0_IP_{tag}="{virbr0}"')
         print(f'ESACP_VM_WG_IP_{tag}="{wg_ip}"')
-
-        if hostname == "saconsole":
-            print(f'ESACP_SACONSOLE_VIRBR0_IP="{virbr0}"')
-            print(f'ESACP_SACONSOLE_WG_IP="{wg_ip}"')
+        print(f'ESACP_VM_NAME_{tag}="{vm_name}"')
 
         if attrs.get("vm_role"):
-            targets.append(hostname)
+            targets.append(key)
 
         if not hypervisor and attrs.get("hypervisor"):
             hypervisor = attrs["hypervisor"]
+
+    # Hub identity variables (role-based, not name-based)
+    if hub_key:
+        print(f'ESACP_HUB_KEY="{hub_key}"')
+        print(f'ESACP_HUB_VM_NAME="{hub_attrs.get("vm_name", hub_key)}"')
+        print(f'ESACP_HUB_HOSTNAME="{hub_attrs.get("hostname", hub_key)}"')
+        print(f'ESACP_HUB_DISPLAY_NAME="{hub_attrs.get("display_name", hub_key)}"')
+        print(f'ESACP_HUB_VIRBR0_IP="{hub_attrs.get("virbr0_ip", "")}"')
+        print(f'ESACP_HUB_WG_IP="{hub_attrs.get("wg_ip", "")}"')
 
     print(f'ESACP_HYPERVISOR="{hypervisor}"')
     print(f'ESACP_KVM_VMS="{" ".join(all_vms)}"')

--- a/platforms/kvm/persist_iptables_toshiba.sh
+++ b/platforms/kvm/persist_iptables_toshiba.sh
@@ -3,7 +3,7 @@
 #
 # Run this DIRECTLY ON TOSHIBA (not from Mighty).
 # Applies and persists the two iptables rules required for Mighty's WireGuard
-# spoke to reach saconsole's hub (192.168.122.10:51820) via toshiba.
+# spoke to reach the hub (${HUB_VIRBR0_IP}:51820) via toshiba.
 #
 # Usage: bash platforms/kvm/persist_iptables_toshiba.sh
 # Requires: sudo, iptables-persistent (installed automatically if absent)
@@ -22,7 +22,7 @@ fi
 
 echo "==> Applying iptables rules..."
 
-# DNAT: incoming WireGuard UDP on WAN → saconsole
+# DNAT: incoming WireGuard UDP on WAN → hub
 sudo iptables -t nat -C PREROUTING \
   -i "${WAN_IF}" -p udp --dport "${WG_PORT}" \
   -j DNAT --to-destination "${SACONSOLE_IP}:${WG_PORT}" 2>/dev/null \
@@ -30,7 +30,7 @@ sudo iptables -t nat -C PREROUTING \
   -i "${WAN_IF}" -p udp --dport "${WG_PORT}" \
   -j DNAT --to-destination "${SACONSOLE_IP}:${WG_PORT}"
 
-# FORWARD: allow forwarded WireGuard UDP to saconsole (must be before libvirt chains)
+# FORWARD: allow forwarded WireGuard UDP to hub (must be before libvirt chains)
 sudo iptables -C FORWARD \
   -i "${WAN_IF}" -o virbr0 -p udp \
   -d "${SACONSOLE_IP}" --dport "${WG_PORT}" -j ACCEPT 2>/dev/null \

--- a/platforms/kvm/prepare_hypervisor.sh
+++ b/platforms/kvm/prepare_hypervisor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # prepare_hypervisor.sh — Check and prepare a bare KVM hypervisor host + controller
 #
-# Run from the project root on the CONTROLLER before running bootstrap_saconsole.sh.
+# Run from the project root on the CONTROLLER before running bootstrap_hub.sh.
 # Controller-side tools are auto-installed where possible.
 # Hypervisor-side checks report pass/fail with exact fix commands — they do not
 # apply changes over SSH (no sudo over BatchMode).
@@ -15,7 +15,7 @@
 #   3. Hypervisor state    (via SSH — check + fix guidance only)
 #   4. Post-bootstrap      (iptables port-forward — guidance only)
 #
-# After all checks pass, bootstrap_saconsole.sh preflight will succeed.
+# After all checks pass, bootstrap_hub.sh preflight will succeed.
 
 set -uo pipefail
 
@@ -23,7 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJ_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ANSIBLE_DIR="${PROJ_ROOT}/ansible"
 
-# ── Configuration (must match bootstrap_saconsole.sh) ─────────────────────────
+# ── Configuration (must match bootstrap_hub.sh) ─────────────────────────
 
 HYPERVISOR_ALIAS="toshy"
 HYPERVISOR_USER="hasan"
@@ -333,8 +333,8 @@ fi  # end hypervisor_reachable block
 
 hdr "4. Post-bootstrap — WireGuard port-forward"
 echo ""
-echo "  After bootstrap_saconsole.sh completes, Mighty's WireGuard spoke needs"
-echo "  to reach saconsole (192.168.122.10:51820) through the hypervisor."
+echo "  After bootstrap_hub.sh completes, Mighty's WireGuard spoke needs"
+echo "  to reach the hub (${HUB_VIRBR0_IP}:51820) through the hypervisor."
 echo "  Run these two iptables rules on the hypervisor (replace wlp2s0 with"
 echo "  the actual LAN interface: \`ip route get 1 | awk '{print \$5; exit}'\`):"
 echo ""
@@ -357,12 +357,12 @@ echo "════════════════════════�
 echo ""
 
 if [[ ${FAIL} -gt 0 ]]; then
-    echo "❌  Fix all failures before running bootstrap_saconsole.sh."
+    echo "❌  Fix all failures before running bootstrap_hub.sh."
     exit 1
 elif [[ ${MANUAL_COUNT} -gt 0 ]]; then
     echo "👤  Complete [MANUAL] steps above, then re-run to confirm."
     exit 0
 else
-    echo "✅  Controller and hypervisor ready. Run bootstrap_saconsole.sh."
+    echo "✅  Controller and hypervisor ready. Run bootstrap_hub.sh."
     exit 0
 fi

--- a/platforms/kvm/rebuild_lab.sh
+++ b/platforms/kvm/rebuild_lab.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# rebuild_lab.sh — Full KVM lab rebuild: destroy → saconsole → targets.
+# rebuild_lab.sh — Full KVM lab rebuild: destroy → hub → targets.
 #
 # Chains three phases:
 #   1. destroy_vms.sh         — tear down all 3 VMs on toshiba, clear artifacts
-#   2. bootstrap_saconsole.sh — 9-phase saconsole bootstrap (from this controller)
-#   3. bootstrap_targets.sh   — 9-phase targets bootstrap (from saconsole via SSH)
+#   2. bootstrap_hub.sh — 9-phase hub bootstrap (from this controller)
+#   3. bootstrap_targets.sh   — 9-phase targets bootstrap (from hub via SSH)
 #
-# bootstrap_targets.sh runs FROM saconsole because:
-#   - Ansible uses saconsole's ~/.ssh/id_ed25519 to reach targets
+# bootstrap_targets.sh runs FROM the hub because:
+#   - Ansible uses the hub's ~/.ssh/id_ed25519 to reach targets
 #     (the only SSH key injected into targets via cloud-init)
-#   - saconsole SSHes to toshiba as hasan@toshiba using that same key
-#     (installed on toshiba in Phase 9 of bootstrap_saconsole.sh)
+#   - the hub SSHes to toshiba as hasan@toshiba using that same key
+#     (installed on toshiba in Phase 9 of bootstrap_hub.sh)
 #
 # Sends a Telegram notification on success or failure.
 #
@@ -63,18 +63,18 @@ _PHASE="destroy_vms"
 hdr "Phase 1 — Destroy VMs"
 bash "${SCRIPT_DIR}/destroy_vms.sh"
 
-# ── Phase 2: Bootstrap saconsole (from this controller) ───────────────────────
+# ── Phase 2: Bootstrap hub (from this controller) ───────────────────────
 
-_PHASE="bootstrap_saconsole"
-hdr "Phase 2 — Bootstrap saconsole"
-bash "${SCRIPT_DIR}/bootstrap_saconsole.sh"
+_PHASE="bootstrap_hub"
+hdr "Phase 2 — Bootstrap hub"
+bash "${SCRIPT_DIR}/bootstrap_hub.sh"
 
-# ── Phase 3: Bootstrap targets (from saconsole) ────────────────────────────────
+# ── Phase 3: Bootstrap targets (from hub) ────────────────────────────────
 #
 # ServerAliveInterval keeps the connection live during the ~60-minute provision.
 
 _PHASE="bootstrap_targets"
-hdr "Phase 3 — Bootstrap targets (from saconsole)"
+hdr "Phase 3 — Bootstrap targets (from hub)"
 ssh \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \

--- a/platforms/kvm/snapshot.py
+++ b/platforms/kvm/snapshot.py
@@ -97,7 +97,7 @@ def main() -> None:
         "action",
         choices=["create", "revert", "list", "delete", "start", "state"],
     )
-    parser.add_argument("vm", help="VM domain name (e.g. saconsole, target1)")
+    parser.add_argument("vm", help="VM domain name (e.g. dev01, dev02)")
     parser.add_argument("snapshot_name", nargs="?", help="Snapshot name (not needed for list/start/state)")
 
     args = parser.parse_args()

--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -18,8 +18,8 @@
 #   7.  VMs on toshiba (derived from hosts_map.yml)
 #   8.  WireGuard — local interface + handshake
 #   9.  WireGuard mesh — ping all peers (derived from hosts_map.yml)
-#   9b. WireGuard hub peer drift — saconsole live peers vs inventory spokes
-#  10.  Observability stack (saconsole)
+#   9b. WireGuard hub peer drift — hub live peers vs inventory spokes
+#  10.  Observability stack (hub)
 #  11.  ERPNext sites — HTTPS reachability (derived from hosts_map.yml)
 #  12.  MCP endpoints — all SSE servers in ~/.claude/settings.json
 #  13.  GitHub MCP server (binary + settings.json + token)
@@ -44,7 +44,7 @@ source "${_SCRIPT_DIR}/config.sh"
 remote_toshiba() { ssh -o ConnectTimeout=5 -o BatchMode=yes \
     "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" "$@"; }
 
-remote_saconsole() { ssh -o ConnectTimeout=5 -o BatchMode=yes \
+remote_hub() { ssh -o ConnectTimeout=5 -o BatchMode=yes \
     -o ProxyJump="${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" \
     "${SACONSOLE_USER}@${SACONSOLE_IP}" "$@"; }
 
@@ -198,16 +198,16 @@ if [[ -n "${WG_DUMP}" ]]; then
     NOW=$(date +%s)
     AGE=$(( NOW - HS_TS ))
     if [[ ${HS_TS} -eq 0 ]]; then
-        warn "wg0: no handshake yet with saconsole hub"
+        warn "wg0: no handshake yet with hub"
         fix "Check toshiba iptables DNAT rule for UDP 51820 is still in place"
     elif [[ ${AGE} -lt 180 ]]; then
-        ok "wg0: handshake with saconsole ${AGE}s ago (healthy)"
+        ok "wg0: handshake with hub ${AGE}s ago (healthy)"
     elif [[ ${AGE} -lt 600 ]]; then
         warn "wg0: last handshake ${AGE}s ago — stale (expected <180s with keepalive=25s)"
         fix "Check toshiba iptables port-forward: sudo iptables -t nat -L PREROUTING -n"
     else
         fail "wg0: no handshake in ${AGE}s — WireGuard tunnel is down"
-        fix "Check toshiba iptables port-forward and saconsole wg0 status"
+        fix "Check toshiba iptables port-forward and hub wg0 status"
     fi
 else
     warn "Could not read wg0 dump (sudo may be required) — skipping handshake age check"
@@ -236,8 +236,8 @@ for label_ip in ${WG_PEERS}; do
     fi
 done
 
-# ── 9b. WireGuard hub peer drift — saconsole live peers vs inventory spokes ───
-hdr "9b. WireGuard hub peer drift (saconsole)"
+# ── 9b. WireGuard hub peer drift — hub live peers vs inventory spokes ───
+hdr "9b. WireGuard hub peer drift"
 
 # Count expected spokes from hosts_map.yml (all hosts with wg_role=spoke, any group)
 EXPECTED_SPOKES=$(python3 - "${PROJ_ROOT}/hosts_map.yml" <<'PYEOF'
@@ -254,18 +254,18 @@ print(len(seen))
 PYEOF
 )
 
-# Count live peers on saconsole hub
-LIVE_PEERS=$(remote_saconsole "sudo wg show wg0 2>/dev/null | grep -c '^peer:'" 2>/dev/null || echo "0")
+# Count live peers on hub
+LIVE_PEERS=$(remote_hub "sudo wg show wg0 2>/dev/null | grep -c '^peer:'" 2>/dev/null || echo "0")
 
 if [[ "${LIVE_PEERS}" -eq "${EXPECTED_SPOKES}" ]]; then
-    ok "saconsole hub has ${LIVE_PEERS} WG peers — matches inventory (${EXPECTED_SPOKES} spokes)"
+    ok "hub has ${LIVE_PEERS} WG peers — matches inventory (${EXPECTED_SPOKES} spokes)"
 else
-    fail "saconsole hub has ${LIVE_PEERS} WG peers — inventory expects ${EXPECTED_SPOKES} spokes"
-    fix "Re-run: cd ansible && ansible-playbook -i inventory/kvm.yml site-kvm.yml --limit saconsole --tags wireguard"
+    fail "hub has ${LIVE_PEERS} WG peers — inventory expects ${EXPECTED_SPOKES} spokes"
+    fix "Re-run: cd ansible && ansible-playbook -i inventory/kvm.yml site-kvm.yml --limit ${HUB_KEY} --tags wireguard"
 fi
 
-# ── 10. Observability stack — saconsole ───────────────────────────────────────
-hdr "10. Observability stack (saconsole)"
+# ── 10. Observability stack — hub ───────────────────────────────────────
+hdr "10. Observability stack (hub)"
 
 WG_HUB=$(python3 - "${PROJ_ROOT}/hosts_map.yml" <<'PYEOF'
 import yaml, sys
@@ -283,22 +283,22 @@ if [[ -n "${WG_HUB}" ]] && ping -c1 -W2 "${WG_HUB}" &>/dev/null; then
 fi
 
 if [[ "${SACONSOLE_REACHABLE}" == true ]]; then
-    OBS_CONTAINERS=$(remote_saconsole \
+    OBS_CONTAINERS=$(remote_hub \
         "docker ps --format '{{.Names}}:{{.Status}}'" 2>/dev/null || true)
 
     for svc in prometheus grafana loki promtail alertmanager node_exporter cadvisor mcp-grafana; do
         ROW=$(echo "${OBS_CONTAINERS}" | grep "^${svc}:" || true)
         if [[ -z "${ROW}" ]]; then
-            fail "saconsole: '${svc}' container not running"
-            fix "SSH to saconsole and run: docker-compose -f /opt/observability/docker-compose.yml up -d ${svc}"
+            fail "hub: '${svc}' container not running"
+            fix "SSH to hub and run: docker-compose -f /opt/observability/docker-compose.yml up -d ${svc}"
         elif echo "${ROW}" | grep -qi "unhealthy\|restarting\|exited"; then
-            warn "saconsole: '${svc}' — $(echo "${ROW}" | cut -d: -f2-)"
+            warn "hub: '${svc}' — $(echo "${ROW}" | cut -d: -f2-)"
         else
-            ok "saconsole: '${svc}' — up"
+            ok "hub: '${svc}' — up"
         fi
     done
 else
-    warn "saconsole unreachable over WireGuard — skipping observability checks"
+    warn "hub unreachable over WireGuard — skipping observability checks"
 fi
 
 # ── 11. ERPNext sites ─────────────────────────────────────────────────────────

--- a/platforms/packer/build.sh
+++ b/platforms/packer/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # build.sh — Orchestrate the ERPNext v13 Packer image build
 #
-# Runs FROM saconsole as user 'you'.
+# Runs FROM the hub as user 'you'.
 # Creates a short-lived build VM on toshiba, hands it to Packer (null builder),
 # exports the resulting qcow2, then destroys the VM.
 #
@@ -11,10 +11,10 @@
 # Usage:
 #   bash platforms/packer/build.sh [--frappe-branch version-13] [--erpnext-branch version-13]
 #
-# Prerequisites (all met after bootstrap_saconsole.sh):
-#   - packer installed on saconsole (this script checks and offers to install)
-#   - SSH access from saconsole to toshiba: ssh hasan@toshiba
-#   - cloud-image-utils on saconsole (cloud-localds)
+# Prerequisites (all met after bootstrap_hub.sh):
+#   - packer installed on the hub (this script checks and offers to install)
+#   - SSH access from the hub to toshiba: ssh hasan@toshiba
+#   - cloud-image-utils on the hub (cloud-localds)
 #   - Ubuntu 22.04 ISO on toshiba at UBUNTU_ISO_PATH
 
 set -euo pipefail
@@ -187,7 +187,7 @@ RENDERED_USERDATA="/tmp/packer-build-userdata.yml"
 [[ -d "${CLOUD_INIT_TEMPLATE}" ]] \
     || die "Cloud-init template not found: ${CLOUD_INIT_TEMPLATE}"
 
-# Inject saconsole SSH pubkey
+# Inject hub SSH pubkey
 envsubst < "${CLOUD_INIT_TEMPLATE}/user-data" > "${RENDERED_USERDATA}"
 cloud-localds "${SEED_ISO}" "${RENDERED_USERDATA}" "${CLOUD_INIT_TEMPLATE}/meta-data"
 rm -f "${RENDERED_USERDATA}"
@@ -293,7 +293,7 @@ remote "cat > '${METADATA_DIR}/erpnext-v13-latest.json'" <<METADATA
   "erpnext_branch": "${ERPNEXT_BRANCH}",
   "erp_user":       "${ERP_USER}",
   "built_at":       "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "built_by":       "saconsole:${SCRIPT_DIR}/build.sh",
+  "built_by":       "hub:${SCRIPT_DIR}/build.sh",
   "state":          "undifferentiated"
 }
 METADATA

--- a/prototypes/cytoscape/CLAUDE.md
+++ b/prototypes/cytoscape/CLAUDE.md
@@ -102,4 +102,4 @@ Test files:
 
 - **Inspect**: 3-box service grid (nginx/frappe+supervisor/mariadb), status from `GET /api/health/{hostname}` via SSH checks
 - **Refresh**: `POST /api/refresh/{hostname}` — SCPs saved `{hostname}-differentiate.sh` artifact and runs `sudo bash`
-- **Destroy**: remove live WG peer → delete snapshots → virsh destroy+undefine → clean hosts_map.yml + group_vars/all.yml + keys.sops.yml + cloud-init dir → regen inventory → Ansible wireguard on saconsole
+- **Destroy**: remove live WG peer → delete snapshots → virsh destroy+undefine → clean hosts_map.yml + group_vars/all.yml + keys.sops.yml + cloud-init dir → regen inventory → Ansible wireguard on hub

--- a/prototypes/cytoscape/src/main.js
+++ b/prototypes/cytoscape/src/main.js
@@ -122,7 +122,7 @@ const ZONE_ANCHORS = [
 // All positions are chosen to fall within their zone's quadrant boundary.
 const INITIAL_POSITIONS = {
   // Console quadrant (TL): x 60-390, y 50-380
-  // Stockroom (single ERPNext tile) on the left; controller + saconsole on the right
+  // Stockroom (single ERPNext tile) on the left; controller + hub on the right
   'tpl-erpnext': { x: 160, y: 220 },
   controller:     { x: 330, y: 150 },
   saconsole:      { x: 330, y: 280 },
@@ -507,7 +507,7 @@ async function init() {
 
   _repositionUnknownNodes()  // place API-loaded nodes not in INITIAL_POSITIONS
   attachHandlers()
-  // Hub (saconsole) and controller are water-troughs — permanently fixed in Console.
+  // Hub and controller are water-troughs — permanently fixed in Console.
   cy.nodes('[role = "hub"], [role = "controller"]').lock()
   _updatePromoteButton()
   _reconnectActiveJob()
@@ -852,7 +852,7 @@ function renderInfoWithActions(data) {
   const actions = document.createElement('div')
   actions.className = 'action-bar'
 
-  // saconsole (hub) is the machine that runs build.sh — it creates templates
+  // The hub is the machine that runs build.sh — it creates templates
   if (role === 'hub') {
     const btn = document.createElement('button')
     btn.className   = 'action-btn action-btn--secondary'
@@ -1024,15 +1024,15 @@ async function _syncTemplateState() {
 }
 
 // Inline confirm → build template job
-// mode: 'create' (from saconsole) | 'update' (from template tile)
+// mode: 'create' (from hub) | 'update' (from template tile)
 function _startBuildTemplate(mode = 'update') {
   if (activeJob) return
 
   const isCreate   = mode === 'create'
   const title      = isCreate ? 'Create ERPNext v13 Template' : 'Update ERPNext v13 Template'
   const bodyCopy   = isCreate
-    ? 'Runs a ~45 min Packer build on saconsole.<br>Produces the undifferentiated base image: OS + MariaDB + bench + frappe + erpnext. No site. No apps. No data.'
-    : 'Runs a ~45 min Packer build on saconsole.<br>Replaces the current base image for all future ERPNext deployments.'
+    ? 'Runs a ~45 min Packer build on the hub.<br>Produces the undifferentiated base image: OS + MariaDB + bench + frappe + erpnext. No site. No apps. No data.'
+    : 'Runs a ~45 min Packer build on the hub.<br>Replaces the current base image for all future ERPNext deployments.'
   const confirmTxt = isCreate ? 'Confirm Create' : 'Confirm Update'
   const cancelMsg  = isCreate ? 'Create cancelled.' : 'Update cancelled.'
 
@@ -1047,7 +1047,7 @@ function _startBuildTemplate(mode = 'update') {
   confirmBtn.className   = 'action-btn'
   confirmBtn.textContent = confirmTxt
   confirmBtn.onclick = () => {
-    infoPanel.innerHTML = '<pre class="job-log">Starting ERPNext template build on saconsole…\n</pre>'
+    infoPanel.innerHTML = '<pre class="job-log">Starting ERPNext template build on the hub…\n</pre>'
     startBuildTemplate()
       .then(({ job_id }) => {
         _setTemplateState('building')
@@ -1241,7 +1241,7 @@ function _destroyTemplate() {
   confirmBtn.textContent = 'Confirm Destroy'
   confirmBtn.onclick = () => {
     deleteTemplate()
-      .then(() => hint('Template artifact deleted. Run "Create Template" from saconsole to rebuild.'))
+      .then(() => hint('Template artifact deleted. Run "Create Template" from the hub to rebuild.'))
       .catch(err => { infoPanel.innerHTML = `<p class="hint error">Destroy failed: ${err.message}</p>` })
   }
   const cancelBtn = document.createElement('button')

--- a/prototypes/cytoscape/src/registry.js
+++ b/prototypes/cytoscape/src/registry.js
@@ -4,22 +4,24 @@
 // fetch() returns the graph data for that level.
 // children keys must match node IDs returned by the parent's fetch().
 //
-// Network note: live API calls require the browser to reach saconsole's ports.
+// Network note: live API calls require the browser to reach the hub's ports.
 // From WSL/Windows (Platform 1), the KVM network is unreachable — fallback data
 // is used automatically. From Xubuntu (Platform 2), live calls will succeed
 // provided CORS headers are present. Add a Vite proxy in vite.config.js to work
 // around CORS without touching the VMs.
 
-const SACONSOLE  = 'http://192.168.122.10'
-const PROMETHEUS = `${SACONSOLE}:9090`
-const DOCKER_API = `${SACONSOLE}:8088`   // future saconsole REST bridge; not live yet
+// Hub VM URL base — derived from virbr0_ip in hosts_map.yml.
+// TODO: fetch from /api/hosts at runtime instead of hardcoding.
+const HUB_URL    = 'http://192.168.122.10'
+const PROMETHEUS = `${HUB_URL}:9090`
+const DOCKER_API = `${HUB_URL}:8088`   // future hub REST bridge; not live yet
 
 // ── Fallback static data ───────────────────────────────────────────────────
 // Realistic snapshots used when the live API is unreachable.
 
 const FALLBACK = {
 
-  saconsole_containers: {
+  hub_containers: {
     nodes: [
       { data: { id: 'grafana',       label: 'grafana',       image: 'grafana/grafana:10.2.3',            status: 'Up', state: 'running', ports: '3000' } },
       { data: { id: 'prometheus',    label: 'prometheus',    image: 'prom/prometheus:v2.48.1',           status: 'Up', state: 'running', ports: '9090' } },
@@ -133,7 +135,7 @@ function prometheusTargetsToGraph(data) {
 
 async function fetchDockerContainers() {
   // Docker daemon does not expose HTTP by default.
-  // This targets a future saconsole REST bridge at DOCKER_API.
+  // This targets a future hub REST bridge at DOCKER_API.
   // Falls back to static data when unreachable.
   try {
     const res = await fetch(`${DOCKER_API}/docker/containers`, {
@@ -145,7 +147,7 @@ async function fetchDockerContainers() {
     return dockerContainersToGraph(data)
   } catch (err) {
     console.warn('[registry] Docker API unreachable — using fallback:', err.message)
-    return FALLBACK.saconsole_containers
+    return FALLBACK.hub_containers
   }
 }
 

--- a/provision_targets.sh
+++ b/provision_targets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# provision_targets.sh — Run from saconsole to provision/update target VMs.
+# provision_targets.sh — Run from the hub to provision/update target VMs.
 #
-# Connects via WireGuard (saconsole is hub; targets at 10.10.0.3, 10.10.0.4).
+# Connects via WireGuard (hub at 10.10.0.1; targets at 10.10.0.3, 10.10.0.4).
 # Pulls latest repo changes before running Ansible.
 #
 # Usage:

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## api.py — FastAPI Control Plane (port 8088)
 
-Start: `uvicorn tools.api:app --port 8088 --reload` from project root. Will move to saconsole when promoted from prototype.
+Start: `uvicorn tools.api:app --port 8088 --reload` from project root. Will move to hub when promoted from prototype.
 
 ### Endpoints
 
@@ -14,7 +14,7 @@ Start: `uvicorn tools.api:app --port 8088 --reload` from project root. Will move
 | POST | `/api/refresh/{host}` | Re-run stages 3–9 via `macro/refresh.py` (idempotent, over WireGuard) |
 | GET | `/api/health/{host}` | SSH checks: nginx (`systemctl is-active`), app (supervisorctl RUNNING count), db (mysql SELECT 1) |
 | GET | `/api/template/status` | Metadata for latest undifferentiated ERPNext image on toshiba |
-| POST | `/api/build/template` | Start background Packer build on saconsole (one at a time) |
+| POST | `/api/build/template` | Start background Packer build on hub (one at a time) |
 | DELETE | `/api/template` | Delete template artifact from toshiba, reset to not_built |
 | POST | `/api/vm/{host}/start` | Start a shut-off VM (memory guard rejects if host RAM insufficient) |
 | POST | `/api/vm/{host}/stop` | Graceful shutdown (`virsh shutdown`); rejects hub nodes |
@@ -60,7 +60,7 @@ Extracted from api.py so both api.py and job_worker.py can use them. Contains:
 
 Non-obvious behaviours:
 - `provisionVM` Ansible output filter: shows PLAY headers, ✓ ok, ★ changed, ❌ fatal, RECAP only
-- `validateObservability` credential order: `GRAFANA_ADMIN_USER`/`GRAFANA_ADMIN_PASSWORD` env vars → SSH saconsole `/opt/observability/.env` → interactive prompt
+- `validateObservability` credential order: `GRAFANA_ADMIN_USER`/`GRAFANA_ADMIN_PASSWORD` env vars → SSH hub `/opt/observability/.env` → interactive prompt
 - `buildVM`: uses `virsh vol-create-as` + `virsh vol-upload` for seed ISO — not `sudo cp` (hangs in uvicorn threads)
 - `snapShotVM`: KVM-only, hardwired to `platforms/kvm/snapshot.py` → `virsh`
 
@@ -72,9 +72,17 @@ Subcommands:
 - `hung-procs` — list long-running bench/frappe/ce_sri processes with elapsed time
 - `proc-detail <pid>` — threads (wchan + kernel stack), file descriptors, TCP connections
 - `site-health` — quick check: currentsite.txt, gunicorn workers, supervisor services, nginx
-- `bench-log <job_id> [-n lines]` — tail a differentiation job log on saconsole
+- `bench-log <job_id> [-n lines]` — tail a differentiation job log on hub
 
 All functions are importable (`from tools.diagnose import hung_procs, site_health, ...`) for use in other scripts or `api.py` health endpoints.
+
+## host_identity.py — Hub Identity Constants
+
+Resolves host identities from `hosts_map.yml` at import time. Provides:
+- `HUB_KEY`, `HUB_VM_NAME`, `HUB_HOSTNAME`, `HUB_DISPLAY_NAME`, `HUB_VIRBR0_IP`, `HUB_WG_IP`
+- `hub_vm(config)`, `kvm_hosts(config)`, `host_field(key, field)`
+
+All Python code that previously hardcoded "saconsole" imports from here instead.
 
 ## install_specific.py — VM Differentiation (standalone, SCP'd to VM)
 
@@ -110,7 +118,7 @@ Config comes from environment variables (envars.sh sourced by differentiate.sh) 
 | Stage | Package | Orchestrator | Units |
 |---|---|---|---|
 | 1 — VM Creation | `stage_1_vm_creation/` | `run_stage_1()` | cleanup_residue, wireguard_peer, seed_iso, upload_seed, clone_template, virt_install, wait_ssh, baseline_snapshot |
-| 2 — Network | `stage_2_network/` | `run_stage_2()` | saconsole_wg_hub, cloudflare_dns, tls_cert, wireguard_spoke |
+| 2 — Network | `stage_2_network/` | `run_stage_2()` | hub_wg_hub, cloudflare_dns, tls_cert, wireguard_spoke |
 | 3 — Connectivity | `stage_3_connectivity/` | `run_stage_3()` | deploy_keys, controller_pubkey, cesri_secrets, backup, ddl_views |
 | 4 — Content Delivery | `stage_4_content_delivery/` | `run_stage_4()` | config_bundle (render + rsync) |
 | 5 — TLS | `stage_5_tls/` | `run_stage_5()` | cert install, nginx vhost, DH params |

--- a/tools/api.py
+++ b/tools/api.py
@@ -13,7 +13,7 @@ Endpoints:
     POST /api/destroy/{hostname}     → full teardown: WG + VM + hosts_map + keys + inventory
     GET  /api/health/{hostname}      → quick SSH check: { web, app, db } each green/amber/red
     GET  /api/template/status        → metadata for latest undifferentiated ERPNext image
-    POST /api/build/template         → start background Packer build on saconsole
+    POST /api/build/template         → start background Packer build on hub
     DELETE /api/template             → delete template artifact from toshiba
     POST /api/promote                → staging → production promotion (stub)
     POST /api/vm/{hostname}/start    → start a shut-off VM (memory guard)
@@ -436,8 +436,8 @@ def delete_template():
 def start_build_template():
     """Start a background job to build the undifferentiated ERPNext v13 image.
 
-    Runs platforms/packer/build.sh on saconsole via SSH.
-    saconsole creates the build VM on toshiba, runs Packer provisioners,
+    Runs platforms/packer/build.sh on the hub via SSH.
+    The hub creates the build VM on toshiba, runs Packer provisioners,
     exports the qcow2, then destroys the build VM.
     Only one build may run at a time.
     """
@@ -495,7 +495,7 @@ def start_provision_erpnext(vm: NewErpnextVM):
       5.  virt-install --import (boots in seconds, cloud-init sets identity)
       6.  Wait for SSH
       7.  Take "Baseline" snapshot → node shows provisioned=True in UI
-      8.  Ansible wireguard role on saconsole (update hub wg0.conf)
+      8.  Ansible wireguard role on hub (update hub wg0.conf)
       Differentiation (steps 9–18):
       9.  Ansible wireguard role on new VM (configure spoke wg0)
       10. Push envars.sh → /opt/ce_sri/envars.sh
@@ -507,7 +507,7 @@ def start_provision_erpnext(vm: NewErpnextVM):
       16. handleRestore.sh (DB restore + views)
       17. bench restart
       18. Snapshot "ERPNext v13 Logichem DB Restored"
-      8. Ansible wireguard role on saconsole (add new spoke)
+      8. Ansible wireguard role on hub (add new spoke)
     """
     if not re.match(r'^[a-z][a-z0-9-]*$', vm.hostname):
         raise HTTPException(400, "hostname: lowercase letters/digits/hyphens, must start with a letter")

--- a/tools/destroy_helpers.py
+++ b/tools/destroy_helpers.py
@@ -46,7 +46,7 @@ def remove_wg_peer_live(
     hosts_map: Path,
     emit: Emit,
 ) -> None:
-    """Remove the WireGuard peer from saconsole hub live (wg set ... remove)."""
+    """Remove the WireGuard peer from the hub live (wg set ... remove)."""
     with open(hosts_map) as f:
         data = yaml.safe_load(f)
     kvm = data["groups"].get("kvm", {})

--- a/tools/diagnose.py
+++ b/tools/diagnose.py
@@ -209,7 +209,7 @@ def print_site_health(checks: dict) -> None:
 # ── Job log ───────────────────────────────────────────────────────────────────
 
 def bench_log(host: str, job_id: str, lines: int = 40) -> str:
-    """Tail the differentiation job log on saconsole."""
+    """Tail the differentiation job log on the hub."""
     _, out = ssh(host, f"tail -n {lines} /tmp/job-{job_id}.log 2>/dev/null")
     return out
 
@@ -258,7 +258,7 @@ def main():
 
     p_health = sub.add_parser("site-health", help="Quick site health check")
 
-    p_log = sub.add_parser("bench-log", help="Tail a job log on saconsole")
+    p_log = sub.add_parser("bench-log", help="Tail a job log on the hub")
     p_log.add_argument("job_id")
     p_log.add_argument("-n", type=int, default=40)
 

--- a/tools/esacp.py
+++ b/tools/esacp.py
@@ -391,7 +391,9 @@ def cmd_validate_keys(args, config: dict) -> int:
             ok = False
 
     psks = decrypted.get("preshared_keys", {})
-    for psk_key in ["controller_saconsole", "target1_saconsole"]:
+    hub = hub_vm(config)
+    for spoke in [h for h in expected_hosts if h != hub]:
+        psk_key = f"{spoke}_{hub}"
         icon = "[green]✓[/green]" if psk_key in psks else "[red]✗[/red]"
         console.print(f"  {icon} preshared_key: {psk_key}")
         if psk_key not in psks:
@@ -559,7 +561,7 @@ def _toshiba_add_known_hosts(virbr0_ip: str) -> None:
 def _build_vm_toshiba(vm: str, vm_info: dict, config: dict) -> int:
     """Build a VM on the toshiba remote hypervisor."""
     virbr0_ip   = vm_info.get("virbr0_ip", "")
-    ram         = 4096 if vm == "saconsole" else 2048
+    ram         = 4096 if vm == hub_vm(config) else 2048
     remote_seed = f"{TOSHIBA_IMAGES_DIR}/{vm}-seed.iso"
 
     vm_exists = _toshiba_vm_exists(vm)
@@ -805,7 +807,7 @@ def _create_vm(vm: str, config: dict) -> bool:
 
     seed  = IMAGES_DIR / f"{vm}-seed.iso"
     disk  = IMAGES_DIR / f"{vm}.qcow2"
-    ram   = 4096 if vm == "saconsole" else 2048
+    ram   = 4096 if vm == hub_vm(config) else 2048
     vcpus = 2
 
     cmd = [
@@ -1021,7 +1023,7 @@ def _filter_ansible_line(line: str, state: dict) -> Optional[str]:
         return f"\n[bold cyan]{clean}[/bold cyan]"
 
     if state.get("in_recap"):
-        # PLAY RECAP summary line: "saconsole : ok=77  changed=11 ..."
+        # PLAY RECAP summary line: "hostname : ok=77  changed=11 ..."
         if re.match(r"\w[\w.\-]+\s*:", clean):
             return f"  [dim]{clean}[/dim]"
         return None
@@ -1243,7 +1245,7 @@ def _get_grafana_creds(config: dict) -> tuple:
         console.print("  [dim]Grafana credentials from environment[/dim]")
         return user, password
 
-    # Try reading from saconsole's .env file
+    # Try reading from the hub's .env file
     hub = hub_vm(config)
     if hub:
         hub_ip = kvm_hosts(config)[hub].get("wg_ip")
@@ -1256,7 +1258,7 @@ def _get_grafana_creds(config: dict) -> tuple:
                     console.print(f"  [dim]Grafana credentials retrieved from {hub}[/dim]")
                     return user, password
 
-    console.print("[yellow]Grafana password not found in env or on saconsole.[/yellow]")
+    console.print("[yellow]Grafana password not found in env or on hub.[/yellow]")
     password = getpass.getpass("Grafana admin password: ")
     return user, password
 
@@ -1329,13 +1331,10 @@ def cmd_display_configuration(args, config: dict) -> int:
     wg.add(f"Port    : [cyan]{hosts_map.get('wireguard_port', '—')}[/cyan]  (UDP)")
 
     pubkeys = wg.add(f"Public keys  {_src(F_ALL)}")
-    for label, key in [
-        ("controller", "wg_pubkey_controller"),
-        ("saconsole",  "wg_pubkey_saconsole"),
-        ("target1",    "wg_pubkey_target1"),
-    ]:
-        val = all_vars.get(key, "—")
-        pubkeys.add(f"{label:<12}: [dim]{val}[/dim]")
+    for varname, val in all_vars.items():
+        if varname.startswith("wg_pubkey_"):
+            label = varname.removeprefix("wg_pubkey_")
+            pubkeys.add(f"{label:<12}: [dim]{val}[/dim]")
 
     encrypted = wg.add(f"Private keys / PSKs  {_src(F_KEYS)}")
     encrypted.add("[dim](SOPS/age encrypted — run validateKeys to verify)[/dim]")
@@ -1445,7 +1444,7 @@ def main() -> int:
 
     p = sub.add_parser("destroyVM",
                        help="Destroy a KVM VM and all its storage")
-    p.add_argument("vm", help="VM name (e.g. saconsole, target1)")
+    p.add_argument("vm", help="VM name (e.g. dev01, dev02)")
 
     p = sub.add_parser("buildVM",
                        help="Build seed ISO, create VM, wait for autoinstall")

--- a/tools/generate_inventory.py
+++ b/tools/generate_inventory.py
@@ -59,6 +59,8 @@ def build_inventory(data: dict) -> dict:
                 "ansible_host": attrs.get("virbr0_ip", attrs["hostname"]),
                 "wg_ip":        attrs.get("wg_ip"),
                 "wg_role":      attrs.get("wg_role"),
+                "vm_name":      attrs.get("vm_name", logical_name),
+                "display_name": attrs.get("display_name", logical_name),
             }
             if attrs.get("ansible_connection"):
                 hv["ansible_connection"] = attrs["ansible_connection"]

--- a/tools/host_identity.py
+++ b/tools/host_identity.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Resolve host identities from hosts_map.yml at import time.
+
+Provides constants for the WireGuard hub and helper functions for
+looking up any host by key or role.  All Python code that previously
+hardcoded "saconsole" should import from here instead.
+
+Usage:
+    from tools.host_identity import HUB_KEY, HUB_VM_NAME, HUB_HOSTNAME
+    from tools.host_identity import HUB_VIRBR0_IP, HUB_WG_IP
+    from tools.host_identity import hub_vm, kvm_hosts
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).parent.parent
+HOSTS_MAP_PATH = PROJECT_ROOT / "hosts_map.yml"
+
+
+def _load_kvm() -> dict:
+    with open(HOSTS_MAP_PATH) as f:
+        data = yaml.safe_load(f)
+    return data.get("groups", {}).get("kvm", {})
+
+
+def _find_hub(kvm: dict) -> tuple[str, dict]:
+    for key, attrs in kvm.items():
+        if attrs.get("wg_role") == "hub":
+            return key, attrs
+    return "", {}
+
+
+_kvm = _load_kvm()
+_hub_key, _hub_attrs = _find_hub(_kvm)
+
+HUB_KEY: str = _hub_key
+HUB_VM_NAME: str = _hub_attrs.get("vm_name", _hub_key)
+HUB_HOSTNAME: str = _hub_attrs.get("hostname", _hub_key)
+HUB_DISPLAY_NAME: str = _hub_attrs.get("display_name", _hub_key)
+HUB_VIRBR0_IP: str = _hub_attrs.get("virbr0_ip", "")
+HUB_WG_IP: str = _hub_attrs.get("wg_ip", "")
+HUB_NICKNAME: str = _hub_attrs.get("nickname", "")
+
+
+def hub_vm(config: dict | None = None) -> str:
+    """Return the hosts_map key for the hub VM.
+
+    Accepts an optional hosts_map config dict for compatibility with
+    callers that already loaded it.  If *config* is None, uses the
+    module-level constant.
+    """
+    if config is None:
+        return HUB_KEY
+    kvm = config.get("groups", {}).get("kvm", {})
+    for key, attrs in kvm.items():
+        if attrs.get("wg_role") == "hub":
+            return key
+    return ""
+
+
+def kvm_hosts(config: dict | None = None) -> dict:
+    """Return the KVM hosts dict from hosts_map data."""
+    if config is None:
+        return _kvm
+    return config.get("groups", {}).get("kvm", {})
+
+
+def host_field(key: str, field: str, default: str = "") -> str:
+    """Look up a single field for a KVM host by its hosts_map key."""
+    return _kvm.get(key, {}).get(field, default)

--- a/tools/job_worker.py
+++ b/tools/job_worker.py
@@ -36,14 +36,16 @@ KEYS_SOPS = PROJECT_ROOT / "config" / "wireguard" / "keys.sops.yml"
 CLOUD_INIT_DIR = PROJECT_ROOT / "platforms" / "kvm" / "cloud-init"
 PLATFORMS_PACKER = PROJECT_ROOT / "platforms" / "packer"
 
+from tools.host_identity import HUB_KEY, HUB_VIRBR0_IP
+
 TOSHIBA_ALIAS = "toshiba"
 TOSHIBA_HYPERVISOR_USER = "hasan"
-SACONSOLE_IP = "192.168.122.10"
-SACONSOLE_SSH = [
+HUB_IP = HUB_VIRBR0_IP
+HUB_SSH = [
     "ssh", "-o", f"ProxyJump={TOSHIBA_ALIAS}",
     "-o", "StrictHostKeyChecking=no",
     "-i", str(Path.home() / ".ssh" / "hasan_mighty"),
-    f"you@{SACONSOLE_IP}",
+    f"you@{HUB_IP}",
 ]
 
 
@@ -150,14 +152,14 @@ def run_destroy(args: dict) -> None:
         raise RuntimeError(f"generate_inventory.py failed:\n{result.stderr}")
     emit("  [OK] inventory regenerated")
 
-    # Step 6: Update saconsole WireGuard config via Ansible
-    emit("── Update saconsole WireGuard config (Ansible) ──")
+    # Step 6: Update hub WireGuard config via Ansible
+    emit("── Update hub WireGuard config (Ansible) ──")
     proc = subprocess.Popen(
         [
             "ansible-playbook",
             "-i", "inventory/kvm.yml",
             "site-kvm.yml",
-            "--limit", "saconsole",
+            "--limit", HUB_KEY,
             "--tags", "wireguard",
         ],
         cwd=str(PROJECT_ROOT / "ansible"),
@@ -170,7 +172,7 @@ def run_destroy(args: dict) -> None:
     if proc.returncode != 0:
         emit(f"  [WARN] Ansible wireguard update failed (exit {proc.returncode})")
     else:
-        emit("  [OK] saconsole wg0.conf updated")
+        emit("  [OK] hub wg0.conf updated")
 
     # Step 7: Remove keys from keys.sops.yml
     emit("── Remove WireGuard keys ──")
@@ -208,24 +210,24 @@ def run_build_template(args: dict) -> None:
 
     emit("── ERPNext v13 template build ──")
 
-    # Sync packer directory to saconsole
-    emit("Syncing platforms/packer/ to saconsole ...")
+    # Sync packer directory to hub
+    emit("Syncing platforms/packer/ to hub ...")
     rsync = subprocess.run(
         ["rsync", "-az", "--delete",
          "-e", "ssh " + " ".join(ssh_opts),
          str(PLATFORMS_PACKER) + "/",
-         f"you@{SACONSOLE_IP}:/opt/esacp/platforms/packer/"],
+         f"you@{HUB_IP}:/opt/esacp/platforms/packer/"],
         capture_output=True, text=True,
     )
     if rsync.returncode != 0:
-        raise RuntimeError(f"rsync to saconsole failed: {rsync.stderr.strip()}")
+        raise RuntimeError(f"rsync to hub failed: {rsync.stderr.strip()}")
 
-    emit(f"Connecting to saconsole ({SACONSOLE_IP} via {TOSHIBA_ALIAS}) ...")
+    emit(f"Connecting to hub ({HUB_IP} via {TOSHIBA_ALIAS}) ...")
 
     REMOTE_LOG = "/tmp/packer-build-output.log"
     REMOTE_EXIT = "/tmp/packer-build-output.log.exit"
 
-    subprocess.run(SACONSOLE_SSH + [f"rm -f {REMOTE_LOG} {REMOTE_EXIT}"],
+    subprocess.run(HUB_SSH + [f"rm -f {REMOTE_LOG} {REMOTE_EXIT}"],
                    capture_output=True)
 
     start_cmd = (
@@ -233,16 +235,16 @@ def run_build_template(args: dict) -> None:
         f" > {REMOTE_LOG} 2>&1; echo $? > {REMOTE_EXIT}'"
         f" > /dev/null 2>&1 & echo $!"
     )
-    r = subprocess.run(SACONSOLE_SSH + [start_cmd], capture_output=True, text=True)
+    r = subprocess.run(HUB_SSH + [start_cmd], capture_output=True, text=True)
     if r.returncode != 0:
-        raise RuntimeError(f"Failed to start build on saconsole: {r.stderr.strip()}")
-    emit(f"Build detached on saconsole (PID {r.stdout.strip()}) — polling log ...")
+        raise RuntimeError(f"Failed to start build on hub: {r.stderr.strip()}")
+    emit(f"Build detached on hub (PID {r.stdout.strip()}) — polling log ...")
 
     offset = 0
     while True:
         time.sleep(5)
         r = subprocess.run(
-            SACONSOLE_SSH + [f"tail -c +{offset + 1} {REMOTE_LOG} 2>/dev/null || true"],
+            HUB_SSH + [f"tail -c +{offset + 1} {REMOTE_LOG} 2>/dev/null || true"],
             capture_output=True, text=True,
         )
         if r.stdout:
@@ -252,13 +254,13 @@ def run_build_template(args: dict) -> None:
             offset += len(r.stdout.encode("utf-8"))
 
         r = subprocess.run(
-            SACONSOLE_SSH + [f"cat {REMOTE_EXIT} 2>/dev/null || echo -1"],
+            HUB_SSH + [f"cat {REMOTE_EXIT} 2>/dev/null || echo -1"],
             capture_output=True, text=True,
         )
         exit_str = r.stdout.strip()
         if exit_str != "-1":
             r = subprocess.run(
-                SACONSOLE_SSH + [f"tail -c +{offset + 1} {REMOTE_LOG} 2>/dev/null || true"],
+                HUB_SSH + [f"tail -c +{offset + 1} {REMOTE_LOG} 2>/dev/null || true"],
                 capture_output=True, text=True,
             )
             for raw_line in r.stdout.splitlines():

--- a/tools/pipeline/stages/common/ssh.py
+++ b/tools/pipeline/stages/common/ssh.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from tools.host_identity import HUB_VIRBR0_IP
 from tools.pipeline.stages.common.types import Config
-
-SACONSOLE_IP = "192.168.122.10"
 
 
 def _ssh_base(config: Config) -> list[str]:
@@ -64,17 +63,21 @@ def rsync_to_vm(
     )
 
 
-def saconsole_ssh_run(
+def hub_ssh_run(
     config: Config, cmd: str, *, timeout: int = 15,
 ) -> subprocess.CompletedProcess[str]:
-    """Run *cmd* on saconsole via ProxyJump through the hypervisor."""
+    """Run *cmd* on the hub VM via ProxyJump through the hypervisor."""
     hyp = config.hypervisor or "toshiba"
     return subprocess.run(
         ["ssh",
          "-o", f"ProxyJump={hyp}",
          "-o", "StrictHostKeyChecking=no",
          "-i", config.ssh_key,
-         f"you@{SACONSOLE_IP}",
+         f"you@{HUB_VIRBR0_IP}",
          cmd],
         capture_output=True, text=True, timeout=timeout,
     )
+
+
+# Backward-compatible alias
+saconsole_ssh_run = hub_ssh_run

--- a/tools/pipeline/stages/stage_2_network/__init__.py
+++ b/tools/pipeline/stages/stage_2_network/__init__.py
@@ -1,4 +1,4 @@
-"""Stage 2: Network — saconsole WG hub, Cloudflare DNS, TLS cert, WG spoke.
+"""Stage 2: Network — hub WG config, Cloudflare DNS, TLS cert, WG spoke.
 
 Orchestrates Steps 8–9 of the provision pipeline.  Extracted from
 ``_run_provision_erpnext`` in api.py.
@@ -11,7 +11,7 @@ from tools.pipeline.stages.common.types import Config, Emit
 
 from .cloudflare_dns import upsert_cloudflare_dns
 from .verify import all_passed, verify_stage_2
-from .saconsole_wg_hub import update_saconsole_wg_hub
+from .saconsole_wg_hub import update_hub_wg
 from .tls_cert import ensure_tls_cert
 from .wireguard_spoke import configure_wireguard_spoke
 
@@ -44,9 +44,9 @@ def run_stage_2(config: Config, emit: Emit) -> None:
         emit("[OK] Stage 2 already satisfied — skipping")
         return
 
-    # ── Update saconsole WireGuard hub ──
-    emit(step_header("Update saconsole WireGuard (Ansible)"))
-    r = update_saconsole_wg_hub(config, emit)
+    # ── Update hub WireGuard ──
+    emit(step_header("Update hub WireGuard (Ansible)"))
+    r = update_hub_wg(config, emit)
     if not r.success:
         emit(f"  [WARN] {r.message}")
     else:
@@ -60,7 +60,7 @@ def run_stage_2(config: Config, emit: Emit) -> None:
     tag = "[CHANGED]" if r.changed else "[OK]"
     emit(f"  {tag} {r.message}")
 
-    # ── Distribute TLS cert from saconsole to VM ──
+    # ── Distribute TLS cert from hub to VM ──
     emit(step_header("Distribute TLS wildcard cert to VM"))
     r = ensure_tls_cert(config, emit)
     if not r.success:

--- a/tools/pipeline/stages/stage_2_network/saconsole_wg_hub.py
+++ b/tools/pipeline/stages/stage_2_network/saconsole_wg_hub.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Update saconsole WireGuard hub configuration via Ansible."""
+"""Update the hub WireGuard configuration via Ansible."""
 
 from __future__ import annotations
 
 import subprocess
 from pathlib import Path
 
+from tools.host_identity import HUB_KEY
 from tools.pipeline.stages.common.types import Config, Emit, TaskResult
 
 
@@ -18,10 +19,10 @@ def _stream_lines(pipe) -> list[str]:
     return lines
 
 
-def update_saconsole_wg_hub(config: Config, emit: Emit) -> TaskResult:
-    """Run ``ansible-playbook --limit saconsole --tags wireguard``.
+def update_hub_wg(config: Config, emit: Emit) -> TaskResult:
+    """Run ``ansible-playbook --limit <hub_key> --tags wireguard``.
 
-    Tells saconsole about the new peer so the hub accepts WG handshakes.
+    Tells the hub about the new peer so it accepts WG handshakes.
     """
     ansible_dir = Path(config.project_root) / "ansible"
     proc = subprocess.Popen(
@@ -29,7 +30,7 @@ def update_saconsole_wg_hub(config: Config, emit: Emit) -> TaskResult:
             "ansible-playbook",
             "-i", "inventory/kvm.yml",
             "site-kvm.yml",
-            "--limit", "saconsole",
+            "--limit", HUB_KEY,
             "--tags", "wireguard",
         ],
         cwd=str(ansible_dir),
@@ -42,4 +43,8 @@ def update_saconsole_wg_hub(config: Config, emit: Emit) -> TaskResult:
     if proc.returncode != 0:
         return TaskResult(False, False,
                           f"Ansible wireguard hub failed (exit {proc.returncode})")
-    return TaskResult(True, True, "saconsole WireGuard hub updated")
+    return TaskResult(True, True, "Hub WireGuard updated")
+
+
+# Backward-compatible alias
+update_saconsole_wg_hub = update_hub_wg

--- a/tools/pipeline/stages/stage_2_network/tls_cert.py
+++ b/tools/pipeline/stages/stage_2_network/tls_cert.py
@@ -1,8 +1,8 @@
-"""Distribute wildcard TLS cert from saconsole to target VM."""
+"""Distribute wildcard TLS cert from the hub to target VM."""
 
 from __future__ import annotations
 
-from tools.pipeline.stages.common.ssh import saconsole_ssh_run, ssh_run
+from tools.pipeline.stages.common.ssh import hub_ssh_run, ssh_run
 from tools.pipeline.stages.common.types import Config, Emit, TaskResult
 
 ACME_CERT_HOME = "/opt/acme-certs"
@@ -23,16 +23,16 @@ def _cert_exists_on_vm(config: Config) -> bool:
     return r.returncode == 0 and "y" in r.stdout
 
 
-def _cert_exists_on_saconsole(config: Config) -> bool:
-    r = saconsole_ssh_run(config,
-                          f"test -f {CERT_DIR}/fullchain.pem && echo found")
+def _cert_exists_on_hub(config: Config) -> bool:
+    r = hub_ssh_run(config,
+                    f"test -f {CERT_DIR}/fullchain.pem && echo found")
     return "found" in r.stdout
 
 
 def _push_pem(config: Config, pem_name: str, tmp_name: str) -> None:
-    read = saconsole_ssh_run(config, f"cat {CERT_DIR}/{pem_name}")
+    read = hub_ssh_run(config, f"cat {CERT_DIR}/{pem_name}")
     if read.returncode != 0:
-        raise RuntimeError(f"Failed to read {pem_name} from saconsole")
+        raise RuntimeError(f"Failed to read {pem_name} from hub")
     import subprocess
     write = subprocess.run(
         ["ssh", *config.ssh_opts, "-i", config.ssh_key,
@@ -45,12 +45,12 @@ def _push_pem(config: Config, pem_name: str, tmp_name: str) -> None:
 
 
 def ensure_tls_cert(config: Config, emit: Emit) -> TaskResult:
-    """Copy wildcard PEM files from saconsole → VM /tmp/."""
+    """Copy wildcard PEM files from the hub → VM /tmp/."""
     if _cert_exists_on_vm(config):
         return TaskResult(True, False, "TLS cert already on VM")
-    if not _cert_exists_on_saconsole(config):
-        emit("  [WARN] Cert not on saconsole — skipping (HTTP-only)")
-        return TaskResult(True, False, "No cert on saconsole")
+    if not _cert_exists_on_hub(config):
+        emit("  [WARN] Cert not on hub — skipping (HTTP-only)")
+        return TaskResult(True, False, "No cert on hub")
     try:
         for pem_name, tmp_name in PEM_MAP:
             _push_pem(config, pem_name, tmp_name)

--- a/tools/pipeline/stages/stage_2_network/verify.py
+++ b/tools/pipeline/stages/stage_2_network/verify.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import yaml
 
+from tools.host_identity import HUB_VIRBR0_IP
+
 
 def _ssh_vm(virbr0_ip: str, hypervisor: str, ssh_key: str,
             cmd: str, timeout: int = 15):
@@ -27,23 +29,22 @@ def _ssh_vm(virbr0_ip: str, hypervisor: str, ssh_key: str,
     )
 
 
-def _ssh_saconsole(hypervisor: str, ssh_key: str,
-                   cmd: str, timeout: int = 15):
+def _ssh_hub(hypervisor: str, ssh_key: str,
+             cmd: str, timeout: int = 15):
     return subprocess.run(
         ["ssh",
          "-o", f"ProxyJump={hypervisor}",
          "-o", "StrictHostKeyChecking=no",
          "-i", ssh_key,
-         "you@192.168.122.10", cmd],
+         f"you@{HUB_VIRBR0_IP}", cmd],
         capture_output=True, text=True, timeout=timeout,
     )
 
 
-def check_saconsole_wg_peer(
+def check_hub_wg_peer(
     hostname: str, project_root: str, hypervisor: str, ssh_key: str,
 ) -> tuple[bool, str]:
-    """saconsole's wg show lists the peer public key for this host."""
-    # Read the expected pubkey from group_vars
+    """Hub's wg show lists the peer public key for this host."""
     gv = Path(project_root) / "ansible" / "group_vars" / "all.yml"
     with open(gv) as f:
         data = yaml.safe_load(f)
@@ -51,12 +52,12 @@ def check_saconsole_wg_peer(
     if not pubkey:
         return False, f"No wg_pubkey_{hostname} in group_vars — can't verify hub"
 
-    r = _ssh_saconsole(hypervisor, ssh_key, "sudo wg show wg0")
+    r = _ssh_hub(hypervisor, ssh_key, "sudo wg show wg0")
     if r.returncode != 0:
-        return False, f"Cannot run wg show on saconsole: {r.stderr.strip()}"
+        return False, f"Cannot run wg show on hub: {r.stderr.strip()}"
     if pubkey in r.stdout:
-        return True, f"saconsole hub has peer {hostname} ({pubkey[:12]}…)"
-    return False, f"saconsole hub missing peer for {hostname}"
+        return True, f"Hub has peer {hostname} ({pubkey[:12]}…)"
+    return False, f"Hub missing peer for {hostname}"
 
 
 def check_cloudflare_dns(hostname: str, wg_ip: str) -> tuple[bool, str]:
@@ -127,7 +128,7 @@ def verify_stage_2(
     if ssh_key is None:
         ssh_key = str(Path.home() / ".ssh" / "hasan_mighty")
     return [
-        check_saconsole_wg_peer(hostname, project_root, hypervisor, ssh_key),
+        check_hub_wg_peer(hostname, project_root, hypervisor, ssh_key),
         check_cloudflare_dns(hostname, wg_ip),
         check_tls_cert_on_vm(virbr0_ip, hypervisor, ssh_key),
         check_vm_wg_interface(virbr0_ip, hypervisor, ssh_key),


### PR DESCRIPTION
## Summary

- Introduce role-based identity resolution so all code references the hub VM by `wg_role=hub` rather than the literal string "saconsole"
- New resolution layer: `tools/host_identity.py` (Python), `platforms/kvm/hub_identity.sh` (shell), `parse_hosts_map.py` emits `ESACP_HUB_*` variables
- 57 files changed across `tools/`, `platforms/`, `ansible/`, `orchestration/`, `prototypes/cytoscape/`, `docker/observability/`, and `config/`

Fixes #171

## What changed

| Layer | Changes |
|---|---|
| Schema | `hosts_map.yml` gains `vm_name`, `display_name` fields; inventory regenerated |
| Ansible | `group_vars/all.yml` defines `hub_key`/`hub_wg_ip` etc.; `site-kvm.yml` uses `{{ hub_key }}`; all 6 roles use `{{ hub_wg_ip }}` |
| Python | `host_identity.py` provides constants; `job_worker`, `ssh.py`, pipeline stages import from it; backward-compat aliases preserved |
| Shell | `bootstrap_saconsole.sh` → `bootstrap_hub.sh`; all KVM scripts parameterized via `$HUB_VM_NAME`/`$HUB_KEY` |
| Frontend | Cytoscape URL constant renamed; registry uses `hub_containers` key |
| Observability | Docker/Prometheus reference configs use role-based names |

## What stays unchanged

- `hosts_map.yml` key `saconsole` (logical identity)
- `keys.sops.yml` peer identity keys (tied to WireGuard key material)
- `platforms/vbox/` (retired, reference only)
- `docs/` (historical record)
- Ansible inventory hostnames (derived from hosts_map key)

## Test plan

- [x] `parse_hosts_map.py` outputs correct `ESACP_HUB_*` variables
- [x] `host_identity.py` imports resolve correctly
- [x] `config.sh` exports `HUB_KEY`, `HUB_VM_NAME`, `HUB_VIRBR0_IP`
- [x] `generate_inventory.py` propagates `vm_name`/`display_name` to inventory
- [x] Grep sweep: no `saconsole` literals in active code outside expected locations
- [ ] `rebuild_lab.sh` end-to-end (deferred — requires full lab rebuild)
- [ ] `sync_check.sh` all green for running VMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)