### PR TITLE
fix(pipeline): generic provision snapshot includes "Baseline"

### DIFF
--- a/tools/pipeline/macro/provision_generic.py
+++ b/tools/pipeline/macro/provision_generic.py
@@ -77,7 +77,7 @@ def _take_final_snapshot(
     hostname: str, hypervisor: str, emit: Emit,
 ) -> None:
     """Take the post-provision snapshot on the hypervisor."""
-    snap_name = "ERPNext v13 Generic — Wizard Ready"
+    snap_name = "ERPNext v13 Generic Baseline"
     r = subprocess.run(
         [
             "ssh", hypervisor,


### PR DESCRIPTION
## Summary

- Renamed generic provision final snapshot from "ERPNext v13 Generic — Wizard Ready" to "ERPNext v13 Generic Baseline"
- The verify logic and Cytoscape UI check for `"Baseline"` substring to determine provisioned status — the old name didn't match

## Test plan

- [x] Verified `api.py` / `verify.py` use `"Baseline" in` substring check — new name matches
- [x] Confirmed target5 currently shows `provisioned=True` via `/api/hosts`
- [ ] Next generic provision will use the corrected name (verified by snapshot-list after provision)

fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)