### PR TITLE
fix(ansible): hub hosts directive uses inventory group

### DIFF
--- a/ansible/inventory/kvm.yml
+++ b/ansible/inventory/kvm.yml
@@ -55,6 +55,9 @@ all:
         dev02: *id003
         dev03: *id004
         target5: *id005
+    hub:
+      hosts:
+        saconsole: *id001
     targets:
       hosts:
         dev01: *id002

--- a/ansible/site-kvm.yml
+++ b/ansible/site-kvm.yml
@@ -3,7 +3,7 @@
 #
 # Play order:
 #   1. All KVM VMs:    common, ssh, firewall, fail2ban, wireguard
-#   2. Hub ({{ hub_key }}): docker, observability, desktop, control_plane, mcp_grafana
+#   2. Hub (hub group): docker, observability, desktop, control_plane, mcp_grafana
 #   3. targets:        authorise hub SSH pubkey (set by control_plane in Play 2)
 #   4. targets:        node_exporter, docker, mariadb, nginx_ui
 #   5. Controller:     wireguard spoke config (connection: local)
@@ -28,7 +28,7 @@
 
 # ── Play 2: Hub — observability + desktop + control plane + MCP ───────────
 - name: Observability + control plane — hub
-  hosts: "{{ hub_key }}"
+  hosts: hub
   become: yes
   roles:
     - docker

--- a/tools/generate_inventory.py
+++ b/tools/generate_inventory.py
@@ -74,6 +74,11 @@ def build_inventory(data: dict) -> dict:
             for grp in attrs.get("ansible_groups", []):
                 group_members.setdefault(grp, []).append(hostname)
 
+            # Auto-group: hosts with wg_role=hub go into the 'hub' group
+            # so site-kvm.yml can use 'hosts: hub' (parsed before group_vars).
+            if attrs.get("wg_role") == "hub":
+                group_members.setdefault("hub", []).append(hostname)
+
     # Build inventory structure
     inventory: dict = {"all": {"children": {}}}
 


### PR DESCRIPTION
## Summary

- `generate_inventory.py` auto-creates a `hub` inventory group from hosts with `wg_role=hub`
- `site-kvm.yml` Play 2 uses `hosts: hub` instead of `hosts: "{{ hub_key }}"` — inventory groups are available at parse time, variables from group_vars are not
- Regenerated `ansible/inventory/kvm.yml` with the new group

fixes #179

## Test plan

- [x] `ansible-playbook --syntax-check` passes (previously failed with `'hub_key' is undefined`)
- [ ] Full provision pipeline run (next session with a live VM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)