### PR TITLE
chore: Phase 2 session closure — verify script, gitignore, session logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ test-results/
 
 # Obsolete/superseded guides
 old_*.md
+
+# Scratch ideas (not for repo)
+docs/Ideas/

--- a/docs/SessionLogs/2026-04-16-1901-next-agenda.md
+++ b/docs/SessionLogs/2026-04-16-1901-next-agenda.md
@@ -1,0 +1,114 @@
+# Agenda — Next Session
+
+**Objective:** Phase 7 — Dispatcher layer: thin `esacp.py` / `api.py` / `job_worker.py` (#195)
+
+**Plan (authoritative):** `~/.claude/plans/synthetic-mapping-pretzel.md` → Phase 7. Load at session start.
+
+**Branch:** `fix/195-dispatcher-layer` (create fresh from `main`)
+
+---
+
+## Pre-session ritual
+
+1. **Switch to `main`, pull.** Verify HEAD includes the closure PR from 2026-04-16 19:01.
+2. **`bash platforms/kvm/sync_check.sh`** — expect the same 4 WG-ping failures against unprovisioned dev VMs (not blockers).
+3. **`gh pr list --state open` + `gh issue list --state open --repo martinhbramwell/ESACP`** — confirm no unmerged PR for any "DONE" phase. Per [`feedback_pr_merge_before_session_close.md`](../../memory/feedback_pr_merge_before_session_close.md).
+4. **Load the plan file** — Phase 7 section is the authoritative acceptance spec.
+5. **Run `tools/verify_host_registration.py`** — Phase 2 smoke test, confirms uvicorn serves the current code before you start touching it.
+
+---
+
+## Current state (grep-verified 2026-04-16 19:01)
+
+| File | Lines | Target | Gap |
+|---|---|---|---|
+| `tools/esacp.py` | **811** | ≤150 | −661 |
+| `tools/api.py` | **742** | ≤300 | −442 |
+| `tools/job_worker.py` | **227** | ≤100 | −127 |
+
+### `esacp.py` — per-command breakdown (after Phase 4 merge)
+
+```
+cmd_display_configuration   115   pure Rich tree render; must decompose
+cmd_provision_vm             85   Ansible invocation + snapshots
+cmd_confirm_prerequisites    62   preflight checks; check_tools/check_files already in pipeline
+cmd_destroy_vm               56   virsh + network cleanup
+cmd_provision                48   already thin (delegates to macro/provision.py)
+cmd_destroy                  30   thin after Phase 4 — delegates to macro/destroy.py ✓
+cmd_validate_observability   27   thin (Phase 6)
+cmd_clear_known_hosts        24
+cmd_build_vm                 24   thin (delegates to orchestration/build_vm.py)
+cmd_validate_keys            21
+cmd_verify_vpn               20   thin (Phase 6)
+cmd_snapshot_vm              16   ⚠️  subprocess violation, #206 — defer per plan
+```
+
+**Thin commands ready to move as-is** (9): provision, destroy, validate_observability, clear_known_hosts, build_vm, validate_keys, verify_vpn, snapshot_vm (with #206 note), confirm_prerequisites.
+
+**Medium/fat commands needing thought** (3): provision_vm (85), destroy_vm (56), display_configuration (115).
+
+### `api.py` shape after Phase 2 merge
+
+Host-registration dedup landed (PR #207); `/api/hosts/add`, `/api/provision/erpnext`, `/api/provision/erpnext-generic` each collapsed to a few lines. Remaining endpoints still live inline in `api.py` — Phase 7 splits them into `tools/api/routes/*.py` + extracts Pydantic models into `tools/api_models.py`.
+
+---
+
+## Scope — what Phase 7 creates / reduces
+
+1. `tools/cli/` — one file per `esacp.py` subcommand (~12 files, each ≤80 lines). Each file: parse args, call ONE pipeline primitive, format output. No `subprocess.run`, no business logic.
+2. `tools/api_models.py` — Pydantic request/response models lifted out of `api.py`.
+3. `tools/api/routes/` — route modules grouped by resource (hosts, provision, destroy, power, jobs, health, template). `api.py` becomes FastAPI app wiring + exception handlers + middleware + `_spawn_job` only.
+4. `tools/esacp.py` reduced to argparse parser + dispatch dict (import from `tools.cli`).
+5. `tools/job_worker.py` reduced to argv parsing + single dispatch + status-file I/O.
+
+---
+
+## Open design questions at session start
+
+1. **Shared-helpers home** for `tools/cli/*.py` files. Options:
+   - `tools/cli/_common.py` — local helpers (presentation, config loaders).
+   - Leave helpers in `esacp.py` and let `cli/*.py` import from `tools.esacp` — circular.
+   - Promote to `tools/host_identity.py` — expands that module's scope.
+   **Recommend `_common.py`**; presentation lives in `cli/`, pipeline stays Rich-free.
+
+2. **Dispatch table placement** — dict in `tools/esacp.py` mapping subcommand → callable imported from `tools.cli`. Keeps `esacp.py` readable without import-order magic.
+
+3. **`cmd_display_configuration` (115 lines)** — pure CLI presentation, but exceeds the 80-line cap for `tools/cli/*.py`. Decompose into `cli/display_configuration.py` (≤30-line entry) + `cli/display/config_tree.py` (≤80-line tree helpers).
+
+4. **api.py route grouping** — one file per resource seems natural. Size budget: each ≤80. Shared helpers (like `_spawn_job`) stay in `api.py` or move to `tools/api/jobs.py`.
+
+5. **`cmd_snapshot_vm`** — subprocess call to `platforms/kvm/snapshot.py`. Known violation tracked in **#206**. Per plan, defer a proper `tools/pipeline/orchestration/snapshot.py` extraction to Phase 8/#196 or a standalone follow-up; Phase 7 either (a) moves the subprocess call into `cli/snapshot_vm.py` and accepts the grep-test exception, or (b) inlines the `subprocess` import through an imported primitive wrapper. **Recommend (a) + document in PR body.**
+
+---
+
+## Commit cadence
+
+User preference: **fewer, larger commits**. Proposed:
+
+1. **Commit 1 — CLI refactor.** Skeleton + `_common.py` + migrate all 12 `esacp.py` commands into `tools/cli/` + update `esacp.py` dispatch dict. `esacp.py` drops to ≤150.
+2. **Commit 2 — API split.** Extract `tools/api_models.py` + create `tools/api/routes/*.py`. `api.py` drops to ≤300.
+3. **Commit 3 — `job_worker.py` trim + `tools/CLAUDE.md` updates.** Remove local logic that duplicates a macro. Document the new `cli/` and `api/routes/` structures.
+
+---
+
+## Acceptance criteria (from plan)
+
+1. `wc -l tools/esacp.py` ≤ 150.
+2. `wc -l tools/api.py` ≤ 300.
+3. `wc -l tools/job_worker.py` ≤ 100.
+4. Every `tools/cli/*.py` ≤ 80. Every `tools/api/routes/*.py` ≤ 80.
+5. `grep -rn 'subprocess.run' tools/esacp.py tools/api.py tools/job_worker.py tools/cli/` returns only `_spawn_job` in `api.py` **plus the documented `cli/snapshot_vm.py` exception (#206)**.
+6. `./tools/esacp.py --help` lists all subcommands; each loads help without error.
+7. Cytoscape e2e: provision a dev VM through the UI, destroy it, power-cycle. All endpoints pass through the thinned dispatchers.
+8. Pre-commit ratchet green.
+
+---
+
+## Sign-off condition for the session
+
+- PR merged, #195 closed with commit + merge hashes. Do **not** write "DONE" anywhere until `gh pr view 208 --json mergedAt` is non-null.
+- All `wc -l` targets met; ratchet green.
+- Every subcommand `--help` loads without error.
+- Acceptance script committed **in the same PR** (lesson from Phase 2, see session minutes 2026-04-16 19:01).
+- Session minutes written.
+- Next-session agenda drafted for Phase 8 (#196).

--- a/docs/SessionLogs/2026-04-16-1901-session-minutes.md
+++ b/docs/SessionLogs/2026-04-16-1901-session-minutes.md
@@ -1,0 +1,140 @@
+# Session Minutes — 2026-04-16 19:01
+
+**Intended objective:** Phase 7 — Dispatcher layer (#195)
+**Actual work completed:** Phase 4 recovery (PR #203 landed) + Phase 2 (PR #207 landed)
+**Branches merged this session:**
+- `fix/192-destroy-macro` → main (PR #203, commit `0134de1`)
+- `fix/190-host-registration` → main (PR #207, commit `f877e91`)
+**Plan file:** `~/.claude/plans/synthetic-mapping-pretzel.md`
+
+---
+
+## Pre-session state
+
+- `sync_check.sh`: 42 pass / 11 warn / 4 fail (four expected ping failures against unprovisioned dev VMs — `feedback_one_vm_at_a_time.md`; not blockers).
+- `docs/Ideas/` untracked (content drafts, not engineering). Added to `.gitignore` this session.
+- Prior agenda (`2026-04-16-1620-next-agenda.md`) targeted Phase 7 with Phase 8 deferral for `cmd_destroy`.
+
+---
+
+## What actually happened (in order)
+
+### 1. Phase 7 survey surfaced a regression
+
+Planning Phase 7's `cmd_destroy` migration required routing to `tools/pipeline/macro/destroy.py`. That file did not exist in `HEAD`, despite memory claiming Phase 4 (#192) was DONE. Investigation found:
+
+- PR #203 **open**, never merged. `b9f2256` (Phase 4 commit) was on `origin/fix/192-destroy-macro` only — not an ancestor of `main`.
+- `tools/destroy_helpers.py` (208 lines) still live on main, still imported by `esacp.py` and `job_worker.py`.
+- `MEMORY.md` had written "Phase 4 (#192) DONE (PR #203)" before the merge completed. Phases 5 and 6 branches were then cut from a main that lacked Phase 4.
+- User reaction: "Yet another incomprehensible mess!"
+
+### 2. Root-cause rule captured before moving on
+
+Added [`feedback_pr_merge_before_session_close.md`](../../memory/feedback_pr_merge_before_session_close.md) and linked it from `MEMORY.md`:
+
+> A phase/issue/session is not complete until its PR's `mergedAt` is non-null.
+> "PR opened" ≠ "done". Only merged-to-main counts.
+
+### 3. Phase 4 recovery — rebase-and-merge
+
+User delegated technical decisions ("these are details I should not have to worry about"). Execution:
+
+1. Fetched `origin/fix/192-destroy-macro` to scratch branch.
+2. Rebased onto `origin/main`. Two conflicts:
+   - `tools/job_worker.py`: both halves of the conflict block were **dead code** after the rebase — Phase 5's `build_template` orchestration obsoleted `HUB_SSH/PLATFORMS_PACKER`, Phase 4's `macro/destroy.py` obsoleted `HOSTS_MAP/GROUP_VARS_ALL/KEYS_SOPS/CLOUD_INIT_DIR`. Kept only `from tools.host_identity import ZONE_DOMAINS`.
+   - `tools/size_baselines.json`: merge of monolith-size entries. Took HEAD's real sizes (api 907, esacp 883, etc.) plus Phase 4's new orchestration primitives; the ratchet auto-shrinks on commit.
+3. Reverted 4 test-artifact files that the #192 branch carried (`hosts_map.yml`, `ansible/inventory/kvm.yml`, `ansible/group_vars/all.yml`, `config/wireguard/keys.sops.yml`) to `origin/main`'s state.
+4. Sanity-checked: `py_compile` OK, `from tools.pipeline.macro.destroy import run` importable, GPG-signed commit preserved.
+5. `git push --force-with-lease=fix/192-destroy-macro:b9f2256 …` — only force-push this session, on a private feature branch with a lease guard; main never force-pushed.
+6. PR #203 re-verified `CLEAN + MERGEABLE`, merged via standard merge commit. #192 autoclosed from the `fixes #192` trailer.
+
+### 4. Nine-phase status sanity check — Phase 2 never started
+
+User asked for the whole-operation status table, noticed **Phase 2 (#190) — host registration primitive** was `⏳ not started`. It had been leapfrogged: execution went 1 → 3 → 4 → 5 → 6 without looping back. This matters for Phase 7: if Phase 7 split the duplicated registration logic into route modules first, Phase 2's dedup would then have to chase it across three new files.
+
+Decision: **do Phase 2 before Phase 7**, in this same session.
+
+### 5. Phase 2 — host registration primitive
+
+Cut `fix/190-host-registration` from `main` (which now includes Phase 4). Refactor:
+
+- `tools/pipeline/orchestration/host_registration.py` (74) — `register_host()` + `HostRegistrationError` / `HostConflictError`.
+- `tools/pipeline/orchestration/host_registration_block.py` (35) — YAML block builder + `ZONE_GROUPS` + `MARKER`, split out so `host_registration.py` stays under the 80-line pipeline cap.
+- `tools/pipeline/orchestration/vm_state_query.py` (54) — moved from `api._query_provisioned`.
+- `tools/pipeline/orchestration/host_cleanup_check.py` (52) — `check_cleanup_needed()` + `HostAlreadyProvisionedError`.
+
+`api.py` endpoints (`/api/hosts/add`, `/api/provision/erpnext`, `/api/provision/erpnext-generic`) each collapsed to a register-or-cleanup-check + `_spawn_job` call. FastAPI `@app.exception_handler` maps primitive exceptions to HTTP 400/409. `re` import removed.
+
+Result: **`api.py` 907 → 742 (−165)**, matches the plan's ~170-line target. PR #207 merged (commit `f877e91`), #190 autoclosed.
+
+### 6. Acceptance — post-merge (wrong order, recorded for next time)
+
+Wrote `tools/verify_host_registration.py` (stdlib-only, hits live uvicorn on :8088) and ran it against the reloaded server. 4/4 pass:
+
+| Case | HTTP | Body excerpt |
+|---|---|---|
+| Invalid hostname (`BadName`) | 400 | `hostname: lowercase letters/digits/hyphens, must start with a letter` |
+| Duplicate hostname (`dev01`) | 409 | `'dev01' already exists in the kvm group` |
+| Duplicate virbr0 IP | 409 | `virbr0 IP 192.168.122.21 already used by 'dev01'` |
+| Duplicate WireGuard IP | 409 | `WireGuard IP 10.10.0.13 already used by 'dev01'` |
+
+The already-provisioned → 409 path on `/api/provision/erpnext` was not e2e-tested (would need a real VM with a `Baseline` snapshot); primitive source and handler registration were code-reviewed instead.
+
+**Protocol miss:** the verify script was written *after* PR #207 merged. It should have been part of the PR. Captured as a closure concern below.
+
+---
+
+## Design decisions made during the session
+
+1. **Phase 4 recovery via rebase, not re-implementation** — the #192 commit was valid work; rebasing preserved its authorship and avoided duplicated effort. Conflicts were minimal (job_worker was pure dead-code deletion on both sides; baselines are auto-ratcheted anyway).
+
+2. **Exception handlers, not try/except in routes** — `@app.exception_handler(HostRegistrationError)` etc. lifts the 400/409/500 mapping out of every route handler. Primitives stay transport-agnostic (raise `ValueError` subclasses); FastAPI handles the HTTP encoding.
+
+3. **Split YAML-block builder into its own module** — `register_host` naturally runs to ~95 lines with docstrings + the f-string block. Splitting the block builder into `host_registration_block.py` (35 lines) keeps both files under the 80-line pipeline cap without compromising readability. The issue text said "3 primitives"; delivered 4 files (3 primitives + 1 helper).
+
+4. **Acceptance via live uvicorn + stdlib urllib, not TestClient** — `httpx` wasn't available (system Python is PEP-668 protected). The running uvicorn has `--reload`, so it picked up the merged code automatically. Plain `urllib.request.urlopen` is all the test needs.
+
+---
+
+## Acceptance evidence
+
+### Phase 4 (PR #203)
+| Criterion | Result |
+|---|---|
+| `tools/pipeline/macro/destroy.py` on main (75 lines) | ✅ |
+| `tools/destroy_helpers.py` deleted | ✅ |
+| `cmd_destroy` in esacp.py → thin wrapper (30 lines) | ✅ |
+| GPG-signed, merge-committed, #192 autoclosed | ✅ |
+
+### Phase 2 (PR #207)
+| Criterion | Result |
+|---|---|
+| `api.py` shrinks by ~170 lines | ✅ 907 → 742 (−165) |
+| Each new file ≤80 | ✅ 74 / 35 / 54 / 52 |
+| Exception-handler mapping | ✅ 400, 409×2, 409 — verified live |
+| No `subprocess.run` / YAML mutation left inline in api.py | ✅ |
+| Pre-commit ratchet | ✅ auto-updated baselines |
+| FastAPI app imports, 22 routes (unchanged) | ✅ |
+
+---
+
+## Housekeeping / closure
+
+- `docs/Ideas/` added to `.gitignore` (content drafts, not engineering).
+- `tools/verify_host_registration.py` tracked in the closure PR so future regressions can be caught.
+- Local branches retained per `feedback_keep_merged_branches`: `fix/190-host-registration`, `fix/192-destroy-macro`.
+- `MEMORY.md` corrected: Phase 2 + Phase 4 both marked DONE, open-issues list trimmed (#190, #192 removed; #206 present).
+
+---
+
+## State at end of session
+
+- `main` at the closure PR merge commit.
+- **All Gen 3 pipeline extractions done.** Monolith sizes: `api.py` 742, `esacp.py` 811, `job_worker.py` 227. Targets: ≤300 / ≤150 / ≤100. Remaining work is pure dispatcher thinning (Phases 7, 8, 9).
+- Open Gen 3 issues: #195 (Phase 7 — next), #196 (Phase 8), #197 (Phase 9).
+- Other open issues: #48, #50, #65, #138, #153, #156, #157, #181, #187, #188, #202, #206.
+- **New open issue filed this session:** #206 — snapshot_vm subprocess violation (Phase 7 deferral).
+
+## Rules added this session
+
+- [`feedback_pr_merge_before_session_close.md`](../../memory/feedback_pr_merge_before_session_close.md) — "PR opened" ≠ "done". Only merged-to-main counts.

--- a/tools/verify_host_registration.py
+++ b/tools/verify_host_registration.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Acceptance tests for Phase 2 host-registration primitives (#190).
+
+Hits a live uvicorn (uvicorn tools.api:app --port 8088 --reload) via stdlib
+urllib — no httpx dependency. All four cases exercise error paths that
+reject BEFORE any hosts_map.yml write, so the repo's live configuration
+stays untouched.
+
+Exit 0 on full pass, 1 on any failure.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+BASE = "http://localhost:8088"
+
+
+def post(path: str, payload: dict) -> tuple[int, str]:
+    req = urllib.request.Request(
+        f"{BASE}{path}",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+
+failures: list[str] = []
+
+
+def expect(case: str, status_got: int, body_got: str, status: int, needle: str) -> None:
+    ok = status_got == status and needle in body_got
+    mark = "✅" if ok else "❌"
+    print(f"  {mark}  {case}: got {status_got}, body={body_got[:160]}")
+    if not ok:
+        failures.append(f"{case} — expected {status} containing {needle!r}")
+
+
+print("── Phase 2 acceptance: host-registration primitives ──")
+
+# 1. Invalid hostname → 400
+s, b = post("/api/hosts/add", {
+    "hostname": "BadName", "virbr0_ip": "192.168.122.99", "wg_ip": "10.10.0.99",
+})
+expect("invalid hostname (regex)", s, b, 400, "lowercase letters")
+
+# 2. Duplicate hostname → 409
+s, b = post("/api/hosts/add", {
+    "hostname": "dev01", "virbr0_ip": "192.168.122.99", "wg_ip": "10.10.0.99",
+})
+expect("duplicate hostname", s, b, 409, "already exists")
+
+# 3. Duplicate virbr0 IP → 409
+s, b = post("/api/hosts/add", {
+    "hostname": "newvm99", "virbr0_ip": "192.168.122.21", "wg_ip": "10.10.0.99",
+})
+expect("duplicate virbr0 IP", s, b, 409, "virbr0 IP 192.168.122.21")
+
+# 4. Duplicate WireGuard IP → 409
+s, b = post("/api/hosts/add", {
+    "hostname": "newvm99", "virbr0_ip": "192.168.122.99", "wg_ip": "10.10.0.13",
+})
+expect("duplicate WireGuard IP", s, b, 409, "WireGuard IP 10.10.0.13")
+
+print()
+if failures:
+    print(f"FAIL — {len(failures)} test(s) failed:")
+    for f in failures:
+        print(f"  • {f}")
+    sys.exit(1)
+print("PASS — all 4 acceptance tests OK.")


### PR DESCRIPTION
## Summary

- \`tools/verify_host_registration.py\` — Phase 2 (#190) acceptance script (stdlib-only, live uvicorn). 4/4 error-path tests pass against the merged code.
- \`.gitignore\` — adds \`docs/Ideas/\` (content drafts outside engineering).
- \`docs/SessionLogs/2026-04-16-1901-session-minutes.md\` — records Phase 4 recovery (PR #203) + Phase 2 (PR #207) and the new PR-merge-before-session-close rule.
- \`docs/SessionLogs/2026-04-16-1901-next-agenda.md\` — Phase 7 (#195) agenda with current file sizes and design questions.

No runtime code changes. Ratchet green.

## Test plan
- [x] Pre-commit ratchet passes (docs + tools/ files under limits)
- [x] \`tools/verify_host_registration.py\` runs cleanly against live uvicorn — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)