### PR TITLE
fix(wireguard): reconcile hub runtime state against wg0.conf (#210)

### DIFF
--- a/ansible/roles/wireguard/tasks/main.yml
+++ b/ansible/roles/wireguard/tasks/main.yml
@@ -94,6 +94,18 @@
     state: started
     daemon_reload: yes
 
+# Reconcile live kernel WG state against wg0.conf. The `template` task above
+# detects change by file content, so a destroy that removes peers from the live
+# interface via `wg set ... peer remove` (without mutating inventory) leaves the
+# file correct and the handler silent — drift persists across play reruns.
+# `wg syncconf` applies the diff to the kernel without interrupting traffic. (#210)
+- name: Reconcile wg0 runtime state with wg0.conf (hub only)
+  shell: "wg syncconf wg0 <(wg-quick strip wg0)"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: wg_role == 'hub'
+
 - name: Verify WireGuard interface is up
   command: wg show wg0
   register: wg_status


### PR DESCRIPTION
## Summary

Fixes #210 — the hub WG peer drift that survives `--tags wireguard` reruns.

**Root cause:** the `template` task in `ansible/roles/wireguard/tasks/main.yml` detects change by file content alone. When a destroy (or any direct `wg set ... peer remove`) mutates live `wg0` without touching inventory/sops, the rendered `wg0.conf` is byte-identical to the on-disk file → `restart wg0` handler silent → live state drift persists across reruns.

**Fix:** one task added after the `Enable and start wg-quick@wg0` step:

```yaml
- name: Reconcile wg0 runtime state with wg0.conf (hub only)
  shell: "wg syncconf wg0 <(wg-quick strip wg0)"
  args:
    executable: /bin/bash
  changed_when: false
  when: wg_role == 'hub'
```

`wg syncconf` is the native WireGuard reconciler: reads a config file, applies the delta to the running kernel interface without tearing down existing handshakes. `wg-quick strip` filters out `[Interface]`-only directives (`PostUp`, `SaveConfig`, etc.) that `wg` itself doesn't accept.

## Why this over the agenda's other options

| Option | Why rejected |
|---|---|
| Hand-rolled `wg show` diff + `wg set peer add/remove` | Reinventing `wg syncconf`; more code to maintain |
| `notify` + `meta: flush_handlers` | Handler still won't fire without a textual change; wrong primitive |
| `wg-quick down/up` | Brief interface outage every run; disrupts ongoing handshakes unnecessarily |

## Test plan

### Discovery
Post-Phase 8 session start found real drift:
- `sudo wg show wg0 peers` → 4 keys
- `sudo grep ^PublicKey /etc/wireguard/wg0.conf` → 5 keys
- Missing peer: `LUOR6yrc7mymKuMyXGKmSluGyNu03iedCWe2RHoVK0k=` → `dev01`
- `sync_check.sh` section 9b: ❌ `hub has 4 WG peers — inventory expects 5 spokes`

### First run (real drift)
```
TASK [wireguard : Reconcile wg0 runtime state with wg0.conf (hub only)] ****
ok: [saconsole]
```
- Hub live peers after: **5** (including dev01 restored)
- `sync_check.sh` section 9b: ✅ `hub has 5 WG peers — matches inventory (5 spokes)`

### Deliberate drift regression test
```
$ ssh you@10.10.0.1 'sudo wg set wg0 peer LUOR6yrc7... remove'
$ ssh you@10.10.0.1 'sudo wg show wg0 peers | wc -l'  → 4
$ ansible-playbook --limit saconsole --tags wireguard
```
- `Deploy wg0.conf`: `ok` (unchanged, handler silent — the pathology)
- `Reconcile wg0 runtime state with wg0.conf (hub only)`: `ok`
- `sudo wg show wg0 peers | wc -l` → 5 (dev01 restored)

Confirms the fix handles the exact scenario #210 describes.

## Scope

Hub only (`wg_role == 'hub'`). Spokes have a single peer (the hub) and drift there is structurally unlikely — YAGNI.

## Test plan checklist

- [x] Root cause confirmed via code reading of `tasks/main.yml` + `handlers/main.yml` + `templates/wg0.conf.j2`
- [x] Real drift reproduced from live hub
- [x] Fix restores live state on first run
- [x] Deliberate drift regression test passes
- [x] `sync_check.sh` section 9b green
- [x] Idempotent on repeat runs (`changed_when: false`)
- [x] Commit GPG-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)