### PR TITLE
docs: acceptance matrix plan — 8 agendas for UI/CLI transport-parity runs

### DIFF
--- a/docs/SessionLogs/2026-04-17-1702-next-agenda.md
+++ b/docs/SessionLogs/2026-04-17-1702-next-agenda.md
@@ -1,0 +1,73 @@
+# Agenda — Next Session
+
+**Objective (to confirm):** Execute **Acceptance Run 01** — UI saconsole destroy + rebuild — per `docs/SessionLogs/acceptance-matrix/01-ui-saconsole-destroy-rebuild.md`.
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+Memory context: `memory/project_acceptance_matrix.md`, `memory/feedback_sut_frozen_tests_unlimited.md`.
+
+**Branch:** `accept/01-ui-saconsole` (create fresh from `main` at session start).
+
+---
+
+## Precondition check (before committing to the objective)
+
+1. **PR #221** (this session's plan commit) must be `mergedAt != null` on `main`. If still open, merging it is the first action — the agendas must live on `main` before any run branches off.
+2. **PR #218** (prior session's minutes) — check state. Not blocking, but note whether it's still open.
+3. Run `bash platforms/kvm/sync_check.sh`. Expected: 3 ❌ for unprovisioned dev VMs; everything else green. Investigate anything else.
+4. Confirm Cytoscape UI starts cleanly: `uvicorn tools.api:app --port 8088` + `bash doCytoscape.sh` → http://localhost:5173 responds.
+5. `gh issue list --state open --repo martinhbramwell/ESACP` — confirm #219 and #220 are still OPEN and parked; no new issues have filed themselves in.
+
+If any precondition fails, halt and triage before starting Run 01.
+
+---
+
+## Run-01 execution (from the agenda file)
+
+Follow `docs/SessionLogs/acceptance-matrix/01-ui-saconsole-destroy-rebuild.md` end-to-end. Key mechanical steps:
+
+1. Create `docs/SessionLogs/acceptance-matrix/params/01-ui-saconsole.yml` with the fields the agenda specifies.
+2. Create `prototypes/cytoscape/tests/accept-01-ui-saconsole.spec.js` implementing the destroy-rebuild Playwright flow.
+3. Run the Playwright test. Green = run passes.
+4. Verify `sync_check.sh` saconsole row ✅ post-run.
+5. Confirm no tracked files mutated outside the new test + param file.
+
+## Findings protocol (plan §Findings)
+
+Any failure halts Run 01:
+
+- File a GitHub issue with Playwright trace path, observed state, and link to the run agenda.
+- Write minutes recording the halt + the issue number.
+- Do not proceed to Run 02 until the blocker is closed in its own 1:1:1 session.
+
+## Sign-off condition
+
+- Playwright green.
+- Minutes committed; next-agenda for Run 02 written.
+- **PR for `accept/01-ui-saconsole` merged** (`mergedAt != null`) before writing "DONE" anywhere. See `feedback_pr_merge_before_session_close.md`.
+
+## Carry-forward notes
+
+- **ERPNext is the real priority.** The matrix is foundation work so ERPNext changes can proceed on trusted ground. Do not let scope creep turn any acceptance run into ERPNext feature work.
+- **SUT is frozen.** If Run 01 exposes a bug in `main.js` (#219) or `bootstrap_hub.sh` (#220) or any other SUT file, halt and file. Do not patch during acceptance.
+- **Test code is not length-limited.** Playwright specs can be long if the flow is long — extract helpers only when the same logic reappears across runs (likely in runs 03/04/07/08).
+- The 30+ other files over 100 lines in the SUT call graph (verify.py family, ansible roles, platform scripts) are tracked for a post-matrix tech-debt sweep. Do not take them on ad hoc.
+- `ScheduleWakeup` remains unreliable for long waits — prefer `Monitor` with an until-loop when polling Playwright completion.
+- `hosts_map.yml` is the source of truth. Unexpected mutations during a run are themselves findings.
+
+## Housekeeping items still parked (NOT in scope for Run 01)
+
+| # | Title |
+|---|---|
+| #213 | session_close_audit hook uses relative path (one-line fix) |
+| #216 | audit phase1/gate subcommands in install_specific |
+| #217 | add `tools/vm_scripts/` to pre_commit_size_check.py ratchet |
+| #206 | snapshot_vm subprocess violation (Phase 7 deferral) |
+| #211 | audit orphan `orchestration/` files |
+| #202 | cloud-init template generation (priority: high) |
+| #187 | esacp.py legacy command cleanup |
+| #188 | invoke scripts as executables, not via `python` |
+| #219 | **main.js decomposition (post-matrix)** |
+| #220 | **bootstrap_hub.sh decomposition (post-matrix)** |
+| #218 | previous session's minutes PR — merge when convenient |
+
+Respect 1:1:1 — do not cluster these with Run 01.

--- a/docs/SessionLogs/2026-04-17-1702-session-minutes.md
+++ b/docs/SessionLogs/2026-04-17-1702-session-minutes.md
@@ -1,0 +1,78 @@
+# Session Minutes — 2026-04-17 17:02
+
+**Type:** Planning session (no production code changes).
+**Objective at start:** Scope Stage 2.x — produce an agreed plan for one of: CloudStack backend / Chaos on KVM / Version watchdog.
+**Actual objective pursued (user redirected):** Define an 8-run UI↔CLI acceptance matrix that proves Gen 3 pipeline parity, as the foundation for resuming ERPNext-focused work.
+
+## What happened
+
+### 1. Session-start review
+
+- Read MEMORY.md; read `docs/SessionLogs/2026-04-17-1649-next-agenda.md`.
+- Ran `bash platforms/kvm/sync_check.sh`: 44 ✅ / 10 ⚠️ / 3 ❌. The 3 failures (WG-ping to `dev02`, `dev03`, `target5`) are expected per the agenda — unprovisioned VMs. No regression.
+- Listed 16 open issues via `gh issue list`.
+- Proposed Stage 2.x planning objective.
+
+### 2. User-driven scope pivot
+
+User asked to enumerate acceptance runs needed to trust saconsole + VM destroy/rebuild across UI and CLI. Agreed on **8 runs**: 4 per transport, ordered saconsole → full-Logichem → pseudo-wizard → pseudo-restore, UI first then CLI.
+
+### 3. Cross-cutting invariants captured
+
+After dialogue the following invariants were pinned for the matrix:
+
+1. Single-command launch (1 destroy + 1 build, no mid-run input).
+2. Parametric pre-configuration (all variant differences in a param file before the command fires).
+3. Playwright is the sign-off.
+4. Topology convergence is observed by Playwright for CLI runs (05–08); intrinsic for UI runs.
+5. SUT frozen during runs. Test code itself is **not** length-limited (a user-refined point of the rule); any new non-test code created during acceptance stays ≤~100 lines. Code under test must not be altered — findings halt the run and become their own 1:1:1 session.
+
+### 4. SUT oversize-file survey + exemption decision
+
+Measured all files in the destroy/build call graph. ~34 files exceed 100 lines. Of those, only three are blatantly oversized and in-scope for the 8 runs:
+
+- `prototypes/cytoscape/src/main.js` (2013) — in every run.
+- `platforms/kvm/bootstrap_hub.sh` (406) — in runs 01 and 05.
+- `platforms/kvm/prepare_hypervisor.sh` (370) — confirmed **not** in any run's call graph (one-time hypervisor prep).
+
+User chose to park `main.js` and `bootstrap_hub.sh` with explicit exemptions so the acceptance matrix can proceed. Filed:
+
+- **#219** `refactor(cytoscape): decompose main.js (2013 lines) into per-concern modules`
+- **#220** `refactor(kvm): decompose bootstrap_hub.sh (406 lines) into phase scripts`
+
+Both tagged `refactor`, scheduled after the matrix closes.
+
+### 5. Planning deliverables
+
+- Plan file: `~/.claude/plans/acceptance-matrix-transport-parity.md` (local home, not under the repo).
+- Agenda files (8, under the repo): `docs/SessionLogs/acceptance-matrix/NN-*.md`.
+- Memory entries (local home):
+  - `memory/project_acceptance_matrix.md` — project context for future sessions.
+  - `memory/feedback_sut_frozen_tests_unlimited.md` — the SUT-frozen / test-code-unlimited rule.
+  - `memory/MEMORY.md` — new matrix index line added; open-issues line updated with #219, #220.
+
+### 6. Git / PR
+
+- Discovered previous session's PR **#218** still open on branch `docs/2026-04-17-1649-phase9-minutes`. Did not touch that branch.
+- Branched fresh from `main` as `docs/acceptance-matrix-plan`.
+- Committed the 8 agendas as a single signed commit `28c7d3a`.
+- Pushed; opened **PR #221**: `docs: acceptance matrix plan — 8 agendas for UI/CLI transport-parity runs`.
+- PR #221 state at the time of writing these minutes: **OPEN, MERGEABLE, `mergedAt: null`** — session not yet closed per `feedback_pr_merge_before_session_close.md`.
+
+## What was NOT done
+
+- The original Stage 2.x scoping (CloudStack / Chaos / Watchdog) — superseded by the matrix planning; remains available as the follow-on conversation after the matrix closes.
+- No production code changes. No SUT file was altered.
+- No Playwright test files were created yet — they are written per-run in each acceptance session, not up front.
+- Minutes do not claim the session is DONE. That word is gated on #221's merge.
+
+## Open issues touched this session
+
+- **Created:** #219, #220.
+- **Referenced:** #218 (prior session's PR, unmerged — left alone).
+
+## State handed to next session
+
+- 8 agendas committed and on PR #221 pending merge.
+- Once #221 merges, the next 1:1:1 session picks up Acceptance Run 01 per `docs/SessionLogs/acceptance-matrix/01-ui-saconsole-destroy-rebuild.md`.
+- Previous session's PR #218 remains open and will be resolved on its own track.

--- a/docs/SessionLogs/acceptance-matrix/01-ui-saconsole-destroy-rebuild.md
+++ b/docs/SessionLogs/acceptance-matrix/01-ui-saconsole-destroy-rebuild.md
@@ -1,0 +1,67 @@
+# Agenda — Acceptance Run 01 (UI) — saconsole destroy + rebuild
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove saconsole can be destroyed and rebuilt entirely through the Cytoscape UI, with a single destroy action and a single build action, validated by a dedicated Playwright test.
+
+## Entry preconditions
+
+- Working tree clean; `main` at HEAD.
+- Hypervisor (toshiba) reachable; `sync_check.sh` green except for the expected unprovisioned dev-VM warnings.
+- `hosts_map.yml` known-good; saconsole currently running and reachable.
+- No in-flight pipeline jobs.
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/01-ui-saconsole.yml`
+
+```yaml
+run: "01"
+transport: ui
+target: saconsole
+wait_budget_seconds: 600
+```
+
+Confirm this file exists and matches before the run. If missing, create it — that's the only pre-session code change permitted.
+
+## Commands (single destroy, single build)
+
+Both issued through Playwright against the running Cytoscape UI at `http://localhost:5173`:
+
+1. Destroy: right-click the saconsole node → Destroy → confirm.
+2. Build: right-click the empty hub quadrant → Build saconsole → confirm.
+
+No further input. The UI's own progress indicators carry the run to completion.
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-01-ui-saconsole.spec.js` (create if absent; file a halt issue if the UI lacks the selectors the test needs).
+
+The test:
+
+1. Asserts saconsole is present and green at start.
+2. Performs the destroy click path; waits for saconsole to leave the topology.
+3. Performs the build click path; waits for saconsole to return to the topology as green.
+4. Asserts WireGuard hub responds (backend health endpoint) and the sync_check row for saconsole reports ✅.
+
+## Acceptance
+
+- Playwright test ends green.
+- `sync_check.sh` saconsole row ✅.
+- `hosts_map.yml` and all other tracked files unchanged (`git status` clean).
+
+## Exit state (handed to run 02)
+
+Saconsole running on a freshly-rebuilt hub VM; no dev/target VMs; WireGuard hub up; topology shows only saconsole.
+
+## Findings protocol
+
+Any failure halts the run. File a GitHub issue with the Playwright trace path and observed state; do not patch the SUT in place. See plan §Findings protocol.
+
+## Sign-off
+
+- Commit minutes + any new files (param file, Playwright spec) on a branch named `accept/01-ui-saconsole`.
+- Open PR, merge, close branch.
+- Update memory index if the matrix's overall state changed.

--- a/docs/SessionLogs/acceptance-matrix/02-ui-vm-full-logichem-from-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/02-ui-vm-full-logichem-from-backup.md
@@ -1,0 +1,62 @@
+# Agenda — Acceptance Run 02 (UI) — dev VM, full Logichem ERPNext from backup
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove that a dev VM can be built through the Cytoscape UI and end up running full Logichem ERPNext, restored from the golden production backup, via a single destroy + single build action validated by Playwright.
+
+## Entry preconditions
+
+- Run 01 complete; minutes committed.
+- Saconsole running; no dev/target VMs.
+- Golden production backup available at its known path on the controller (see `project_production_erpnext.md` / `project_prod_repos_ssh.md`).
+- `hosts_map.yml` entry for the chosen dev VM name pre-registered.
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/02-ui-full-logichem.yml`
+
+```yaml
+run: "02"
+transport: ui
+target_vm: dev01  # confirm at session start against hosts_map.yml
+variant: full_logichem
+backup_source: golden_production
+wait_budget_seconds: 1800
+```
+
+## Commands (single destroy, single build)
+
+1. Destroy: no-op at start of run 02 (no dev VM present from run 01's exit state). If a dev VM is unexpectedly present, that's a finding — halt.
+2. Build: Playwright drags saconsole → the target quadrant → selects "Full Logichem from backup" in the pre-provision wizard → confirms. The restore source path is read from the param file, not entered interactively.
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-02-ui-full-logichem.spec.js`
+
+The test:
+
+1. Asserts starting state (saconsole only).
+2. Performs the drag-and-build path with the `full_logichem` option.
+3. Waits (bounded by `wait_budget_seconds`) for the dev VM to appear and turn green.
+4. Asserts `https://<target_vm>.iridium.blue` responds with the Logichem ERPNext login page.
+5. Queries a known stable Logichem record (canary lookup defined in the helpers) to confirm the restore delivered real data, not a blank install.
+
+## Acceptance
+
+- Playwright green.
+- `sync_check.sh` ERPNext row for target VM ✅.
+- No unexpected mutations in tracked files.
+
+## Exit state (handed to run 03)
+
+Saconsole + dev VM running full Logichem ERPNext, restored from golden backup. Run 03 begins by destroying this dev VM.
+
+## Findings protocol
+
+Halt + issue, per plan. Production backups are read-only — a damaged backup on-disk is itself a finding.
+
+## Sign-off
+
+Branch `accept/02-ui-full-logichem`; PR; merge.

--- a/docs/SessionLogs/acceptance-matrix/03-ui-vm-pseudo-company-wizard-creates-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/03-ui-vm-pseudo-company-wizard-creates-backup.md
@@ -1,0 +1,76 @@
+# Agenda — Acceptance Run 03 (UI) — dev VM, pseudo-company skeletal ERPNext via setup wizard, backup produced
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove that a dev VM can be built through the Cytoscape UI into a bare ERPNext instance, driven through the ERPNext setup wizard by Playwright, and a post-wizard backup archived — all as one single-command run whose outcome is validated by Playwright.
+
+## Entry preconditions
+
+- Run 02 complete; minutes committed.
+- Saconsole running; the dev VM from run 02 destroyed (by this run's first action — see below).
+- `hosts_map.yml` entry for the target dev VM still pre-registered (same name as run 02 is fine).
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/03-ui-pseudo-wizard.yml`
+
+```yaml
+run: "03"
+transport: ui
+target_vm: dev01
+variant: pseudo_wizard
+company:
+  name: "Pseudo-Co"
+  abbr: "PSC"
+  country: "Canada"
+  currency: "CAD"
+  language: "en"
+admin_user:
+  email: "admin@pseudo-co.example"
+backup_output_path: "docs/SessionLogs/acceptance-matrix/artefacts/B03-wizard.sql.gz"
+wait_budget_seconds: 1800
+```
+
+The wizard fills every required field from this file. No interactive input during the wizard run.
+
+## Commands (single destroy, single build)
+
+1. Destroy: Playwright right-clicks the dev VM from run 02 → Destroy → confirms.
+2. Build: Playwright drags saconsole → target quadrant → selects "Pseudo-company skeletal (wizard)" → confirms. The Playwright test then continues — post-build it drives the ERPNext setup wizard and triggers the backup.
+
+"One build command" here means the UI's single build action. Everything that follows — wizard completion, backup archival — is part of the same Playwright run, no human input required.
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-03-ui-pseudo-wizard.spec.js`
+
+The test:
+
+1. Destroys the run-02 dev VM and waits for the topology to reflect it.
+2. Builds the fresh dev VM with the pseudo-wizard option.
+3. Navigates to `https://<target_vm>.iridium.blue`, drives the ERPNext setup wizard with values from the param file.
+4. Triggers an ERPNext backup (via the wizard-completion hook or the admin UI, whichever the UI exposes as the "one build" endpoint).
+5. Fetches the backup artefact to `backup_output_path`, verifies integrity (file exists, gzip-valid, SQL header present).
+6. Asserts the ERPNext instance has company name = `Pseudo-Co` and no Logichem records.
+
+This is the one agenda whose Playwright test will be substantial. Test code is not length-limited; extract helpers when they repeat into runs 04, 07, 08.
+
+## Acceptance
+
+- Playwright green.
+- Backup artefact at `backup_output_path` passes integrity check.
+- No unexpected mutations in tracked files aside from the artefact and the spec file.
+
+## Exit state (handed to run 04)
+
+Saconsole + dev VM running skeletal ERPNext for "Pseudo-Co". Backup **B03** archived at the path above. Run 04 will consume B03 after destroying this dev VM.
+
+## Findings protocol
+
+Halt + issue. The wizard-automation surface is the most likely source of gaps; if selectors don't exist yet, that is a finding, not a fix-in-place.
+
+## Sign-off
+
+Branch `accept/03-ui-pseudo-wizard`; PR; merge. Backup artefact committed (gzipped SQL dump from a skeletal company is small; safe to track).

--- a/docs/SessionLogs/acceptance-matrix/04-ui-vm-pseudo-company-restore-from-wizard-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/04-ui-vm-pseudo-company-restore-from-wizard-backup.md
@@ -1,0 +1,64 @@
+# Agenda — Acceptance Run 04 (UI) — dev VM, pseudo-company skeletal ERPNext restored from wizard backup
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove that the backup produced in run 03 (B03) can be used to rebuild an equivalent skeletal ERPNext instance through the Cytoscape UI, with a single destroy + single build, validated by Playwright.
+
+## Entry preconditions
+
+- Run 03 complete; minutes committed.
+- Backup **B03** present at the path declared in run 03's param file.
+- Saconsole running; dev VM from run 03 still present (this run destroys it as its first action).
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/04-ui-pseudo-restore.yml`
+
+```yaml
+run: "04"
+transport: ui
+target_vm: dev01
+variant: pseudo_restore
+backup_source: "docs/SessionLogs/acceptance-matrix/artefacts/B03-wizard.sql.gz"
+wait_budget_seconds: 1500
+```
+
+`backup_source` must match run 03's `backup_output_path` exactly. Confirm before launching.
+
+## Commands (single destroy, single build)
+
+1. Destroy: Playwright right-clicks the dev VM from run 03 → Destroy → confirms.
+2. Build: Playwright drags saconsole → target quadrant → selects "Pseudo-company skeletal (restore)" → confirms. Restore source is read from the param file.
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-04-ui-pseudo-restore.spec.js`
+
+The test:
+
+1. Destroys the run-03 dev VM.
+2. Builds the fresh dev VM with the pseudo-restore option using B03.
+3. Navigates to `https://<target_vm>.iridium.blue`.
+4. Asserts company = `Pseudo-Co`, wizard flag is set, admin email matches run 03's param file, and no Logichem records exist.
+5. Compares a small set of canary facts against what the test knows run 03 produced (reuses a helper from run 03).
+
+## Acceptance
+
+- Playwright green.
+- Canary facts identical to run 03's exit state — the restore reproduced the wizard's state faithfully.
+
+## Exit state (handed to run 05)
+
+Saconsole + dev VM running restored skeletal ERPNext. Run 05 destroys saconsole, which implicitly collapses this dev VM — a natural reset point between UI and CLI transports.
+
+## Findings protocol
+
+Halt + issue. A mismatch between B03's intent and the restored instance is a real finding — the whole matrix premise is that 04 reproduces 03.
+
+## Sign-off
+
+Branch `accept/04-ui-pseudo-restore`; PR; merge.
+
+**UI transport milestone:** after this run, record in minutes whether runs 01–04 all met acceptance. This is the halfway parity snapshot.

--- a/docs/SessionLogs/acceptance-matrix/05-cli-saconsole-destroy-rebuild.md
+++ b/docs/SessionLogs/acceptance-matrix/05-cli-saconsole-destroy-rebuild.md
@@ -1,0 +1,63 @@
+# Agenda — Acceptance Run 05 (CLI) — saconsole destroy + rebuild
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove saconsole can be destroyed and rebuilt from the CLI with a single destroy + single build command, and that the running Cytoscape UI (opened separately by Playwright) converges to reflect the new reality within the wait budget.
+
+## Entry preconditions
+
+- Run 04 complete; minutes committed.
+- UI still running at `http://localhost:5173` so Playwright can observe convergence.
+- Saconsole and the run-04 dev VM currently present (they will be torn down by this run's destroy command, since destroying saconsole collapses everything that depends on it).
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/05-cli-saconsole.yml`
+
+```yaml
+run: "05"
+transport: cli
+target: saconsole
+wait_budget_seconds: 600
+topology_convergence_budget_seconds: 300
+```
+
+## Commands (single destroy, single build)
+
+1. Destroy: `./tools/esacp.py destroy saconsole` (exact subcommand name confirmed at session start from `./tools/esacp.py --help`; substitute whichever shipping subcommand destroys the hub).
+2. Build: `bash platforms/kvm/bootstrap_hub.sh` — the saconsole rebuild script. Exempt from the ≤~100-line rule for this matrix (see plan §Exempt SUT files; issue **#220**).
+
+Both commands run to completion without further input.
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-05-cli-saconsole.spec.js`
+
+The test:
+
+1. Opens the Cytoscape UI; records the starting topology.
+2. Spawns the destroy command as a subprocess, asserts success exit.
+3. Within `topology_convergence_budget_seconds`, asserts the UI has removed saconsole from the topology.
+4. Spawns the build command as a subprocess, asserts success exit.
+5. Within `topology_convergence_budget_seconds` of command completion, asserts the UI shows saconsole back as green.
+6. Asserts backend health endpoint and `sync_check.sh` saconsole row ✅.
+
+## Acceptance
+
+- Playwright green (functional + topology convergence).
+- `sync_check.sh` saconsole row ✅.
+- Tracked files unchanged.
+
+## Exit state (handed to run 06)
+
+Saconsole running on a CLI-rebuilt hub; no dev/target VMs; WireGuard hub up.
+
+## Findings protocol
+
+Halt + issue. Topology non-convergence is a real finding — it is the whole point of the observer check for CLI runs.
+
+## Sign-off
+
+Branch `accept/05-cli-saconsole`; PR; merge.

--- a/docs/SessionLogs/acceptance-matrix/06-cli-vm-full-logichem-from-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/06-cli-vm-full-logichem-from-backup.md
@@ -1,0 +1,64 @@
+# Agenda — Acceptance Run 06 (CLI) — dev VM, full Logichem ERPNext from backup
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove a dev VM can be built from the CLI and end up running full Logichem ERPNext restored from the golden production backup, with the UI converging to reflect the new state.
+
+## Entry preconditions
+
+- Run 05 complete; minutes committed.
+- Cytoscape UI running for observation.
+- Saconsole running; no dev VMs.
+- Golden production backup available on the controller.
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/06-cli-full-logichem.yml`
+
+```yaml
+run: "06"
+transport: cli
+target_vm: dev01
+variant: full_logichem
+backup_source: golden_production
+wait_budget_seconds: 1800
+topology_convergence_budget_seconds: 300
+```
+
+## Commands (single destroy, single build)
+
+1. Destroy: no-op at start (no dev VM present). If one is unexpectedly present, halt.
+2. Build: `./tools/esacp.py provision --params docs/SessionLogs/acceptance-matrix/params/06-cli-full-logichem.yml` (exact flag spelling confirmed at session start; must consume the param file without further input).
+
+The `provision` subcommand already performs stages 1–9 as one unit; that satisfies "single build command".
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-06-cli-full-logichem.spec.js`
+
+The test:
+
+1. Asserts starting topology (saconsole only).
+2. Spawns the build subprocess; asserts success exit.
+3. Within `topology_convergence_budget_seconds`, asserts the UI shows the new dev VM as green.
+4. Asserts `https://<target_vm>.iridium.blue` serves the Logichem login, and the canary Logichem record is present (helper reused from run 02).
+
+## Acceptance
+
+- Playwright green.
+- `sync_check.sh` ERPNext row ✅.
+- Tracked files unchanged.
+
+## Exit state (handed to run 07)
+
+Saconsole + dev VM running full Logichem ERPNext via CLI provision. Run 07 destroys this dev VM first.
+
+## Findings protocol
+
+Halt + issue. Any divergence from run 02's observable outcome is a parity finding and must be logged in minutes.
+
+## Sign-off
+
+Branch `accept/06-cli-full-logichem`; PR; merge.

--- a/docs/SessionLogs/acceptance-matrix/07-cli-vm-pseudo-company-wizard-creates-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/07-cli-vm-pseudo-company-wizard-creates-backup.md
@@ -1,0 +1,74 @@
+# Agenda — Acceptance Run 07 (CLI) — dev VM, pseudo-company skeletal ERPNext via setup wizard, backup produced
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove a dev VM can be built from the CLI into a bare ERPNext instance, driven through the ERPNext setup wizard by Playwright, and a post-wizard backup archived — with the UI converging to reflect the new reality.
+
+## Entry preconditions
+
+- Run 06 complete; minutes committed.
+- Cytoscape UI running for observation.
+- Saconsole running; dev VM from run 06 present (this run destroys it first).
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/07-cli-pseudo-wizard.yml`
+
+```yaml
+run: "07"
+transport: cli
+target_vm: dev01
+variant: pseudo_wizard
+company:
+  name: "Pseudo-Co"
+  abbr: "PSC"
+  country: "Canada"
+  currency: "CAD"
+  language: "en"
+admin_user:
+  email: "admin@pseudo-co.example"
+backup_output_path: "docs/SessionLogs/acceptance-matrix/artefacts/B07-wizard.sql.gz"
+wait_budget_seconds: 1800
+topology_convergence_budget_seconds: 300
+```
+
+Note the company values are identical to run 03 deliberately — this is the parity check. B07 should be equivalent to B03.
+
+## Commands (single destroy, single build)
+
+1. Destroy: `./tools/esacp.py destroyVM <target_vm>` (exact spelling confirmed at session start).
+2. Build: `./tools/esacp.py provision --params docs/SessionLogs/acceptance-matrix/params/07-cli-pseudo-wizard.yml`.
+
+The wizard run and backup-trigger are part of the Playwright test that observes/drives the post-build state — they do not count as additional commands, they're part of the test harness's observation pass.
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-07-cli-pseudo-wizard.spec.js`
+
+The test:
+
+1. Spawns destroy; asserts UI converges to saconsole-only within the convergence budget.
+2. Spawns build; asserts UI shows dev VM as green within the convergence budget.
+3. Navigates to `https://<target_vm>.iridium.blue`, drives the ERPNext setup wizard with run-07 params (reuse helper from run 03).
+4. Triggers backup; writes artefact to `backup_output_path`; verifies integrity.
+5. Asserts company = `Pseudo-Co`, no Logichem records.
+
+## Acceptance
+
+- Playwright green.
+- B07 artefact integrity check passes.
+- B07's canary facts match B03's — the CLI path produced an equivalent backup.
+
+## Exit state (handed to run 08)
+
+Saconsole + dev VM running skeletal ERPNext for `Pseudo-Co`, backup **B07** archived.
+
+## Findings protocol
+
+Halt + issue. Divergence between B03 and B07 is a high-value parity finding — both transports are supposed to land at the same state through the same pipeline primitives.
+
+## Sign-off
+
+Branch `accept/07-cli-pseudo-wizard`; PR; merge. B07 committed alongside the spec.

--- a/docs/SessionLogs/acceptance-matrix/08-cli-vm-pseudo-company-restore-from-wizard-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/08-cli-vm-pseudo-company-restore-from-wizard-backup.md
@@ -1,0 +1,74 @@
+# Agenda — Acceptance Run 08 (CLI) — dev VM, pseudo-company skeletal ERPNext restored from wizard backup
+
+Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+## Objective
+
+Prove that B07 (the backup produced in run 07) can be used to rebuild an equivalent skeletal ERPNext instance from the CLI, with the UI converging to reflect the result. This is the final run of the matrix.
+
+## Entry preconditions
+
+- Run 07 complete; minutes committed.
+- Cytoscape UI running for observation.
+- Backup **B07** present.
+- Saconsole running; dev VM from run 07 present (this run destroys it first).
+
+## Parameter file
+
+`docs/SessionLogs/acceptance-matrix/params/08-cli-pseudo-restore.yml`
+
+```yaml
+run: "08"
+transport: cli
+target_vm: dev01
+variant: pseudo_restore
+backup_source: "docs/SessionLogs/acceptance-matrix/artefacts/B07-wizard.sql.gz"
+wait_budget_seconds: 1500
+topology_convergence_budget_seconds: 300
+```
+
+## Commands (single destroy, single build)
+
+1. Destroy: `./tools/esacp.py destroyVM <target_vm>`.
+2. Build: `./tools/esacp.py provision --params docs/SessionLogs/acceptance-matrix/params/08-cli-pseudo-restore.yml` (the pipeline is expected to route to the restore variant based on the param file — no separate restore command).
+
+## Playwright test
+
+`prototypes/cytoscape/tests/accept-08-cli-pseudo-restore.spec.js`
+
+The test:
+
+1. Spawns destroy; waits for UI to converge.
+2. Spawns build (with restore variant); waits for UI to converge.
+3. Navigates to `https://<target_vm>.iridium.blue`.
+4. Asserts company = `Pseudo-Co` and canary facts match run 07's exit state (helper reuse).
+
+## Acceptance
+
+- Playwright green.
+- Restored instance's canary facts identical to run 07's.
+
+## Exit state (handed to matrix close-out)
+
+Saconsole + dev VM running restored skeletal ERPNext, all eight runs complete.
+
+## Final parity check (matrix close-out)
+
+With all 8 runs signed off, write a close-out note comparing:
+
+- Run 01 vs Run 05 — saconsole rebuild equivalence.
+- Run 02 vs Run 06 — full Logichem from backup equivalence.
+- Run 03 vs Run 07 — wizard-driven skeletal equivalence (including B03 vs B07 content).
+- Run 04 vs Run 08 — restore-from-wizard-backup equivalence.
+
+Equivalence here means functionally indistinguishable endpoints, identical canary facts, topology in both UI- and CLI-driven cases converged within the wait budget.
+
+Record the close-out in `docs/SessionLogs/acceptance-matrix/MATRIX-CLOSEOUT.md` and update `MEMORY.md` with the foundation-solid status so subsequent ERPNext-focused work can start from a trusted baseline.
+
+## Findings protocol
+
+Halt + issue. The final parity check's failures matter more than any single run's — they indicate transport divergence in the shared pipeline primitives, which is exactly what Gen 3 was supposed to prevent.
+
+## Sign-off
+
+Branch `accept/08-cli-pseudo-restore`; PR; merge. Matrix closed.


### PR DESCRIPTION
## Summary

- Adds `docs/SessionLogs/acceptance-matrix/` with 8 thin agenda files covering an acceptance matrix that proves saconsole + dev-VM destroy/rebuild parity between the Cytoscape UI and the CLI.
- Each agenda points to the local-home plan at `~/.claude/plans/acceptance-matrix-transport-parity.md` and states a single objective, entry preconditions, parameter-file spec, the single destroy + single build commands, the Playwright test path, and exit state.
- The matrix exists to give first-hand evidence that Gen 3's shared pipeline primitives deliver identical outcomes across transports, before ERPNext-focused work resumes.

## Why this PR is separate from #218

Previous session's PR #218 (Phase 9 minutes close-out) is still open. Per 1:1:1 discipline, the acceptance-matrix planning work is a distinct scope and gets its own branch, not an in-flight expansion of #218.

## Tracked-exemption issues filed alongside this plan

- #219 — `refactor(cytoscape): decompose main.js (2013 lines)` — parked post-matrix.
- #220 — `refactor(kvm): decompose bootstrap_hub.sh (406 lines)` — parked post-matrix.

Both are SUT files that exceed the matrix's ~100-line ceiling. The matrix runs against them as-is; decomposition is scheduled after matrix close-out.

## Test plan

- [ ] Reviewer reads the plan file at `~/.claude/plans/acceptance-matrix-transport-parity.md` (local-home, not in repo).
- [ ] Reviewer confirms the 8 agendas each state a single objective and point to the plan without re-summarising it.
- [ ] Reviewer confirms the ordering: UI transport first (01–04), CLI transport second (05–08); within each, saconsole → full-Logichem → pseudo-wizard → pseudo-restore.
- [ ] No production code touched. No `.gitignore`-ed / env / secret files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)