### PR TITLE
feat(kvm): rebuild_saconsole.sh — CLI saconsole rebuild primitive (#222)

### DIFF
--- a/docs/SessionLogs/2026-04-18-0720-saconsole-pre-rebuild-capture.md
+++ b/docs/SessionLogs/2026-04-18-0720-saconsole-pre-rebuild-capture.md
@@ -1,0 +1,139 @@
+# Saconsole Pre-Rebuild State Capture — 2026-04-18 07:20
+
+Reference snapshot taken before Session A (`fix/222-rebuild-saconsole`) begins
+building `platforms/kvm/rebuild_saconsole.sh`. Purpose: record the "before"
+state so post-rebuild integrity and blast-radius assertions are anchored.
+
+Not part of the rebuild script; not consumed by any automation.
+
+---
+
+## Libvirt domain (on `toshy`)
+
+| Field | Value |
+|---|---|
+| Name | `saconsole` |
+| UUID | `c3eaf848-fe5d-4c61-9e8a-56337aa555ff` |
+| State | `running` (Id 45) |
+| CPUs | 2 |
+| Memory | 4 GiB |
+| Autostart | disabled |
+| Security | apparmor enforcing, libvirt-c3eaf848-… |
+
+### Block devices
+
+| Target | Source |
+|---|---|
+| `vda` | `/mnt/esacp-disk/var/lib/libvirt/images/saconsole.qcow2` (pool `esacp`, capacity 20 GiB, allocation 17.50 GiB, physical 32.50 GiB) |
+| `sdb` | `/mnt/esacp-disk/var/lib/libvirt/images/saconsole-seed.iso` (pool `esacp`, 366 KiB) |
+
+### Interfaces
+
+| Interface | Type | Source | Model | MAC |
+|---|---|---|---|---|
+| `vnet0` | network | `default` | virtio | `52:54:00:05:4b:f8` |
+
+### Snapshots
+
+| Name | Created | State |
+|---|---|---|
+| `Fresh Install` | 2026-04-15 11:56:01 -0400 | running |
+| `Stage 2.2 Baseline` | 2026-04-15 12:07:13 -0400 | running |
+
+### Persistent domain XML
+
+Archived at `~/archives/saconsole/saconsole-pre-rebuild-domain.xml`
+(controller-local, not in git).
+
+- 145 lines
+- sha256 `a16bf41c02cd11b57002b1f495f462e36d97a4e631c929331a3af2a2e90d60df`
+
+---
+
+## WireGuard peer state — from the hub (saconsole, 10.10.0.1)
+
+- Hub public key: `nn916J0YAufbwZNOKvWs2VX6sV4BKuTqE//985lIiRw=`
+- Listen port: `51820`
+
+| Peer pubkey (prefix) | Allowed IPs | Endpoint | Latest handshake |
+|---|---|---|---|
+| `LUOR6…` | 10.10.0.13/32 (dev01) | 192.168.122.21:45039 | 29s ago |
+| `j94AP…` | 10.10.0.2/32 (controller) | 192.168.1.82:35020 | 46s ago |
+| `kFwCk…` | 10.10.0.12/32 (dev02) | — | — |
+| `9joY/…` | 10.10.0.14/32 (dev03) | — | — |
+| `8AFeP…` | 10.10.0.15/32 (target5) | — | — |
+
+Active peers at capture time: dev01 + controller. Others are registered but
+the VMs are down (expected — only dev01 running).
+
+### Controller side (Mighty)
+
+- `wg0` IPv4: `10.10.0.2/24`
+- Route: `10.10.0.0/24 dev wg0 proto kernel scope link src 10.10.0.2`
+- Hub endpoint (from hosts_map): `192.168.122.10` (virbr0-side); external WG
+  endpoint used by controller: `192.168.1.79:51820` (toshy).
+
+---
+
+## Controller-side source of truth
+
+These files define saconsole and MUST NOT mutate during the rebuild. Hashes
+recorded for post-rebuild comparison.
+
+| File | sha256 |
+|---|---|
+| `config/wireguard/keys.sops.yml` | `a218d71b2bde3d2e77cdb85e394a0f9ad3979e1bd151ac103a17c56d8fa680de` |
+| `hosts_map.yml` | `f6bfd35b8528077d61e799435312bc5a9ce16cffba1b9a2ffb4b679e5e7ff2c3` |
+
+### `hosts_map.yml` saconsole entry (kvm group)
+
+```yaml
+saconsole:
+  vm_name: saconsole
+  hostname: saconsole
+  display_name: "Hub Console"
+  nickname: sac
+  virbr0_ip: "192.168.122.10"
+  wg_ip: "10.10.0.1"
+  wg_role: hub
+  wg_hub_endpoint: "192.168.122.10"
+  ansible_managed: true
+  backend: kvm
+  hypervisor: toshiba
+  ansible_groups: [kvm, development, lab]
+```
+
+---
+
+## Archive location + retention (agreed this session)
+
+- **Path (controller):** `/home/hasan/archives/saconsole/`
+- **Naming:** `saconsole-pre-rebuild-<YYYY-MM-DD-HHMM>.qcow2`, plus matching
+  `.xml` (persistent domain) and `.seed.iso`.
+- **Transport:** `virsh vol-download` via `qemu:///system` over SSH — no sudo
+  needed on toshy; libvirt streams the volume.
+- **Retention:** last 3 archives, manually pruned.
+- **Not in git** (file sizes far too large; path referenced from the rebuild
+  script's header comment only).
+
+---
+
+## Rebuild blast-radius contract
+
+Anything below is expected to SURVIVE rebuild unchanged:
+
+- `hosts_map.yml` (hash above)
+- `config/wireguard/keys.sops.yml` (hash above)
+- Dev VMs on toshy (currently dev01 running; others defined-but-off)
+- Controller WG interface state
+
+Anything below WILL be replaced:
+
+- saconsole libvirt domain definition
+- saconsole qcow2 disk + seed ISO
+- saconsole's view of its own WG peer table (rebuilt from SOPS + hosts_map via
+  `bootstrap_hub.sh`)
+
+---
+
+Captured by: Session A precondition step (issue #222).

--- a/platforms/kvm/rebuild_saconsole.sh
+++ b/platforms/kvm/rebuild_saconsole.sh
@@ -124,9 +124,17 @@ phase_b_teardown() {
   log B "teardown complete"
 }
 
+phase_c_bootstrap() {
+  log C "delegating to platforms/kvm/bootstrap_hub.sh"
+  log C "(expect 30–60 min: seed + autoinstall + ansible + snapshots + handoff)"
+  bash "$SCRIPT_DIR/bootstrap_hub.sh"
+  log C "bootstrap complete"
+}
+
 case "${1:-all}" in
-  backup|A)   phase_a_backup ;;
-  teardown|B) phase_b_teardown ;;
-  all)        phase_a_backup; phase_b_teardown ;;   # C/D added in later commits
-  *)          echo "usage: $0 [backup|teardown|all]"; exit 64 ;;
+  backup|A)    phase_a_backup ;;
+  teardown|B)  phase_b_teardown ;;
+  bootstrap|C) phase_c_bootstrap ;;
+  all)         phase_a_backup; phase_b_teardown; phase_c_bootstrap ;;   # D added next
+  *)           echo "usage: $0 [backup|teardown|bootstrap|all]"; exit 64 ;;
 esac

--- a/platforms/kvm/rebuild_saconsole.sh
+++ b/platforms/kvm/rebuild_saconsole.sh
@@ -72,8 +72,61 @@ phase_a_backup() {
   log A "backup complete: $ARCH_BASE.{xml,qcow2,seed.iso}"
 }
 
+phase_b_teardown() {
+  log B "pre-teardown guard: verify no other domain shares saconsole's volumes"
+
+  sac_paths="$($VIRSH domblklist "$HUB_VM_NAME" | awk 'NR>2 && $2 != "-" {print $2}')"
+  [ -n "$sac_paths" ] || { log B "ERROR: saconsole has no volumes (unexpected)"; exit 2; }
+
+  log B "saconsole volumes to be removed:"
+  printf '    %s\n' $sac_paths
+
+  others="$($VIRSH list --all --name | awk 'NF' | grep -vx "$HUB_VM_NAME" || true)"
+  if [ -n "$others" ]; then
+    log B "other domains on $SSH_HOST (will NOT be touched):"
+    while IFS= read -r dom; do
+      [ -z "$dom" ] && continue
+      dstate="$($VIRSH domstate "$dom" | tr -d '[:space:]')"
+      printf '    %-32s %s\n' "$dom" "$dstate"
+    done <<< "$others"
+    while IFS= read -r dom; do
+      [ -z "$dom" ] && continue
+      dom_paths="$($VIRSH domblklist "$dom" | awk 'NR>2 && $2 != "-" {print $2}')"
+      for p in $sac_paths; do
+        if printf '%s\n' $dom_paths | grep -Fxq "$p"; then
+          log B "ERROR: domain '$dom' also references $p — aborting"
+          exit 2
+        fi
+      done
+    done <<< "$others"
+  fi
+  log B "guard passed — only saconsole will be touched"
+
+  state="$($VIRSH domstate "$HUB_VM_NAME" | tr -d '[:space:]')"
+  if [ "$state" = "running" ]; then
+    log B "saconsole is running — hard stop (virsh destroy)"
+    $VIRSH destroy "$HUB_VM_NAME"
+  fi
+
+  snaps="$($VIRSH snapshot-list "$HUB_VM_NAME" --name | awk 'NF')"
+  if [ -n "$snaps" ]; then
+    log B "deleting existing snapshots (preserved in archive qcow2)"
+    while IFS= read -r s; do
+      [ -z "$s" ] && continue
+      log B "  snapshot-delete $s"
+      $VIRSH snapshot-delete "$HUB_VM_NAME" "$s"
+    done <<< "$snaps"
+  fi
+
+  log B "virsh undefine --remove-all-storage $HUB_VM_NAME"
+  $VIRSH undefine --remove-all-storage "$HUB_VM_NAME"
+
+  log B "teardown complete"
+}
+
 case "${1:-all}" in
-  backup|A) phase_a_backup ;;
-  all)      phase_a_backup ;;   # B/C/D added in later commits
-  *)        echo "usage: $0 [backup|all]"; exit 64 ;;
+  backup|A)   phase_a_backup ;;
+  teardown|B) phase_b_teardown ;;
+  all)        phase_a_backup; phase_b_teardown ;;   # C/D added in later commits
+  *)          echo "usage: $0 [backup|teardown|all]"; exit 64 ;;
 esac

--- a/platforms/kvm/rebuild_saconsole.sh
+++ b/platforms/kvm/rebuild_saconsole.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ============================================================================
+# rebuild_saconsole.sh — atomic CLI rebuild of the WireGuard hub.
+#
+# Issue: #222. Saconsole lifecycle is CLI-only by design.
+# Blast radius: saconsole only. hosts_map.yml + SOPS keys + controller WG
+# state are NOT touched — they are the source of truth and survive the VM.
+#
+# Phases:  A=backup  B=teardown  C=bootstrap  D=verify
+#          (B/C/D added in subsequent commits — Phase A lands first.)
+#
+# Archive: ~/archives/saconsole/  (not in git; keep last 3 generations)
+#
+# ---- Manual revert from an archived generation -----------------------------
+# (documented in full when Phases B/C/D land.)
+# ----------------------------------------------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ARCHIVE_DIR="${SACONSOLE_ARCHIVE_DIR:-$HOME/archives/saconsole}"
+TS="$(date +%Y-%m-%d-%H%M)"
+ARCH_BASE="$ARCHIVE_DIR/saconsole-pre-rebuild-$TS"
+
+# Identity — resolved from hosts_map.yml (no hardcoded names).
+cd "$PROJECT_ROOT"
+eval "$("$PROJECT_ROOT/tools/host_identity.py")"
+: "${HUB_VM_NAME:?hosts_map.yml resolution failed}"
+: "${HUB_HYPERVISOR:?hosts_map.yml resolution failed}"
+
+SSH_HOST="${SACONSOLE_SSH_HOST:-$HUB_HYPERVISOR}"
+POOL="${SACONSOLE_POOL:-esacp}"
+VIRSH="virsh -c qemu+ssh://$SSH_HOST/system"   # libvirt-native remote transport
+
+log() { printf '[rebuild:%s] %s\n' "$1" "$2"; }
+
+phase_a_backup() {
+  log A "archive dir: $ARCHIVE_DIR"
+  mkdir -p "$ARCHIVE_DIR"
+
+  log A "dump persistent domain XML (pre-shutdown)"
+  $VIRSH dumpxml --inactive "$HUB_VM_NAME" > "$ARCH_BASE.xml"
+  [ -s "$ARCH_BASE.xml" ] || { log A "ERROR: domain XML empty"; exit 2; }
+
+  log A "graceful shutdown of $HUB_VM_NAME via $SSH_HOST"
+  $VIRSH shutdown "$HUB_VM_NAME" || true
+
+  state=""
+  for _ in $(seq 1 60); do
+    state="$($VIRSH domstate "$HUB_VM_NAME" | tr -d '[:space:]')"
+    [ "$state" = "shutoff" ] && break
+    sleep 2
+  done
+  [ "$state" = "shutoff" ] || { log A "ERROR: not shut off in 120s (state=$state)"; exit 2; }
+  log A "shutdown confirmed"
+
+  log A "vol-download $HUB_VM_NAME.qcow2 → $ARCH_BASE.qcow2"
+  $VIRSH vol-download "$HUB_VM_NAME.qcow2" --pool "$POOL" "$ARCH_BASE.qcow2"
+
+  log A "vol-download $HUB_VM_NAME-seed.iso → $ARCH_BASE.seed.iso"
+  $VIRSH vol-download "$HUB_VM_NAME-seed.iso" --pool "$POOL" "$ARCH_BASE.seed.iso"
+
+  log A "verify qcow2 integrity"
+  qemu-img info "$ARCH_BASE.qcow2" >/dev/null
+
+  (cd "$ARCHIVE_DIR" && sha256sum \
+      "$(basename "$ARCH_BASE").xml" \
+      "$(basename "$ARCH_BASE").qcow2" \
+      "$(basename "$ARCH_BASE").seed.iso") | tee "$ARCH_BASE.sha256"
+
+  log A "backup complete: $ARCH_BASE.{xml,qcow2,seed.iso}"
+}
+
+case "${1:-all}" in
+  backup|A) phase_a_backup ;;
+  all)      phase_a_backup ;;   # B/C/D added in later commits
+  *)        echo "usage: $0 [backup|all]"; exit 64 ;;
+esac

--- a/platforms/kvm/rebuild_saconsole.sh
+++ b/platforms/kvm/rebuild_saconsole.sh
@@ -6,13 +6,48 @@
 # Blast radius: saconsole only. hosts_map.yml + SOPS keys + controller WG
 # state are NOT touched — they are the source of truth and survive the VM.
 #
-# Phases:  A=backup  B=teardown  C=bootstrap  D=verify
-#          (B/C/D added in subsequent commits — Phase A lands first.)
+# Phases:
+#   A  backup   — graceful shutdown, pull qcow2 + seed ISO + domain XML to
+#                 controller archive, verify with qemu-img info + SHA256.
+#   B  teardown — pre-flight guard (no other domain shares saconsole's
+#                 volumes), snapshot-delete, virsh destroy (if running),
+#                 virsh undefine --remove-all-storage.
+#   C  bootstrap — delegate to platforms/kvm/bootstrap_hub.sh (9-phase
+#                 idempotent: seed → autoinstall → Fresh Install snap →
+#                 Ansible → Stage 2.2 Baseline snap → handoff).
+#   D  verify   — clear stale known_hosts, ping hub over WG, SSH via
+#                 you@10.10.0.1, assert hub-critical sync_check rows ✅.
 #
-# Archive: ~/archives/saconsole/  (not in git; keep last 3 generations)
+# PENDING (Phase E, not in this script yet):
+#   E-1 (#226) — start observability docker stack on fresh hub.
+#   E-2 (#227) — re-register pre-existing WG spokes on fresh hub.
+# Until Phase E lands, the rebuilt hub has empty WG peer table + no
+# observability containers — sync_check will show ~9 extra failures
+# beyond the pre-Run-01 baseline.
+#
+# Archive: ~/archives/saconsole/  (not in git; keep last 3 generations).
+# Transport: libvirt qemu+ssh:// — no sudo on toshy, one TCP stream.
+# Perf: ~4 MB/s → ~2.5 h for a 32.5 GiB physical qcow2. See #225.
 #
 # ---- Manual revert from an archived generation -----------------------------
-# (documented in full when Phases B/C/D land.)
+# 1. ssh toshiba "virsh --connect qemu:///system destroy saconsole" 2>/dev/null || true
+# 2. ssh toshiba "virsh --connect qemu:///system undefine --remove-all-storage saconsole" 2>/dev/null || true
+# 3. Pick an archive:
+#      ARCH=~/archives/saconsole/saconsole-pre-rebuild-YYYY-MM-DD-HHMM
+#      sha256sum -c "$ARCH.sha256"
+# 4. Restore volumes into pool esacp (over qemu+ssh):
+#      virsh -c qemu+ssh://toshiba/system vol-create-as esacp saconsole.qcow2 \
+#          "$(stat -c%s "$ARCH.qcow2")" --format qcow2
+#      virsh -c qemu+ssh://toshiba/system vol-upload saconsole.qcow2 "$ARCH.qcow2" --pool esacp
+#      virsh -c qemu+ssh://toshiba/system vol-create-as esacp saconsole-seed.iso \
+#          "$(stat -c%s "$ARCH.seed.iso")" --format raw
+#      virsh -c qemu+ssh://toshiba/system vol-upload saconsole-seed.iso "$ARCH.seed.iso" --pool esacp
+# 5. Redefine the domain from the archived XML:
+#      virsh -c qemu+ssh://toshiba/system define "$ARCH.xml"
+# 6. Start it:
+#      virsh -c qemu+ssh://toshiba/system start saconsole
+# Note: the restored VM has the SAME WG keys + SSH host keys as the original
+# archive — pre-existing spokes stay valid without Phase E work.
 # ----------------------------------------------------------------------------
 
 set -euo pipefail
@@ -30,6 +65,7 @@ eval "$("$PROJECT_ROOT/tools/host_identity.py")"
 : "${HUB_HYPERVISOR:?hosts_map.yml resolution failed}"
 
 SSH_HOST="${SACONSOLE_SSH_HOST:-$HUB_HYPERVISOR}"
+HUB_USER="${ESACP_VM_USER:-you}"               # matches config.sh VM_USER
 POOL="${SACONSOLE_POOL:-esacp}"
 VIRSH="virsh -c qemu+ssh://$SSH_HOST/system"   # libvirt-native remote transport
 
@@ -131,10 +167,51 @@ phase_c_bootstrap() {
   log C "bootstrap complete"
 }
 
+phase_d_verify() {
+  log D "clear stale known_hosts entries for rebuilt hub"
+  for h in "$HUB_HOSTNAME" "$HUB_WG_IP" "$HUB_VIRBR0_IP"; do
+    ssh-keygen -R "$h" >/dev/null 2>&1 || true
+  done
+
+  log D "ping hub ($HUB_WG_IP)"
+  ping -c 2 -W 2 "$HUB_WG_IP" >/dev/null \
+    || { log D "ERROR: hub ping failed"; exit 2; }
+  log D "  ping OK"
+
+  log D "SSH to hub ($HUB_USER@$HUB_WG_IP via WG)"
+  ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 \
+      -o BatchMode=yes "$HUB_USER@$HUB_WG_IP" 'true' \
+    || { log D "ERROR: SSH to hub failed"; exit 2; }
+  log D "  SSH OK"
+
+  log D "sync_check.sh — assert hub-critical ✅ rows"
+  tmp="$(mktemp)"
+  bash "$SCRIPT_DIR/sync_check.sh" > "$tmp" 2>&1 || true
+  required=(
+    "MCP grafana"
+    "Telegram bot"
+    "github MCP entry present"
+  )
+  for r in "${required[@]}"; do
+    if ! grep -q "✅.*$r" "$tmp"; then
+      log D "ERROR: sync_check missing ✅ for '$r'"
+      grep -n "$r" "$tmp" || true
+      rm -f "$tmp"
+      exit 2
+    fi
+  done
+  grep -E "Passed:|Warnings:|Failed:" "$tmp" | tail -1
+  rm -f "$tmp"
+  log D "  sync_check hub-critical rows green"
+
+  log D "verify complete — saconsole rebuild healthy"
+}
+
 case "${1:-all}" in
   backup|A)    phase_a_backup ;;
   teardown|B)  phase_b_teardown ;;
   bootstrap|C) phase_c_bootstrap ;;
-  all)         phase_a_backup; phase_b_teardown; phase_c_bootstrap ;;   # D added next
-  *)           echo "usage: $0 [backup|teardown|bootstrap|all]"; exit 64 ;;
+  verify|D)    phase_d_verify ;;
+  all)         phase_a_backup; phase_b_teardown; phase_c_bootstrap; phase_d_verify ;;
+  *)           echo "usage: $0 [backup|teardown|bootstrap|verify|all]"; exit 64 ;;
 esac

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -127,6 +127,19 @@ Resolves host identities from `hosts_map.yml` at import time. Provides:
 
 All Python code that previously hardcoded host-specific values imports from here instead.
 
+**Shell-eval emitter.** Also callable directly as an executable
+(`#!/usr/bin/env python3`, `chmod +x`). Prints KEY=VALUE lines for
+bash consumption — use from shell scripts that need the hub identity
+without a `python -c` / `PYTHONPATH` layer:
+
+```bash
+eval "$(./tools/host_identity.py)"
+echo "$HUB_VM_NAME $HUB_HYPERVISOR"
+```
+
+Emits: `HUB_KEY`, `HUB_VM_NAME`, `HUB_HOSTNAME`, `HUB_VIRBR0_IP`,
+`HUB_WG_IP`, `HUB_HYPERVISOR`, `DEFAULT_HYPERVISOR`.
+
 ## secrets.py — Build Secrets Loader
 
 Loads `erp_user_pwd` and `db_root_pwd` from env vars (`ESACP_ERP_USER_PWD`, `ESACP_DB_ROOT_PWD`) or from `config/build_secrets.sops.yml` (sops-encrypted). No hardcoded password defaults in code.

--- a/tools/host_identity.py
+++ b/tools/host_identity.py
@@ -102,3 +102,14 @@ def virbr0_gateway(virbr0_ip: str) -> str:
 def virbr0_subnet_prefix() -> str:
     """Return the virbr0 subnet prefix from the hub's virbr0_ip (e.g. '192.168.122')."""
     return HUB_VIRBR0_IP.rsplit(".", 1)[0]
+
+
+if __name__ == "__main__":
+    # Shell-eval emitter: `eval "$(./tools/host_identity.py)"` in bash.
+    print(f"HUB_KEY={HUB_KEY}")
+    print(f"HUB_VM_NAME={HUB_VM_NAME}")
+    print(f"HUB_HOSTNAME={HUB_HOSTNAME}")
+    print(f"HUB_VIRBR0_IP={HUB_VIRBR0_IP}")
+    print(f"HUB_WG_IP={HUB_WG_IP}")
+    print(f"HUB_HYPERVISOR={HUB_HYPERVISOR}")
+    print(f"DEFAULT_HYPERVISOR={DEFAULT_HYPERVISOR}")


### PR DESCRIPTION
## Summary

Delivers `platforms/kvm/rebuild_saconsole.sh` — the CLI-only primitive for
atomically rebuilding the WireGuard hub (saconsole). Closes **#222**.

Saconsole lifecycle is CLI-only by design (see `memory/feedback_saconsole_cli_only.md`) — no UI counterpart will ever destroy/rebuild the hub.

## Phases delivered

- **A (backup)** — graceful shutdown, pull qcow2 + seed ISO + domain XML to
  controller archive via `virsh -c qemu+ssh://` (no sudo on toshy, one TCP
  stream). Integrity verified with `qemu-img info` + SHA256 sidecar.
- **B (teardown)** — pre-flight guard (aborts if any other domain shares
  saconsole's volumes), snapshot-delete, `virsh destroy` (if running),
  `virsh undefine --remove-all-storage`.
- **C (bootstrap)** — thin delegation to existing `bootstrap_hub.sh` (9-phase
  idempotent). `bootstrap_hub.sh` itself is parked for decomposition under
  #220 and **not touched**.
- **D (verify)** — clear stale `known_hosts`, ping hub over WG, SSH via
  `you@10.10.0.1`, assert hub-critical `sync_check.sh` rows ✅.

## Tested live

Full A → B → C → D cycle executed against the running lab:

| Phase | Duration | Outcome |
|---|---|---|
| A | 2h 46m | 32.5 GiB archive; both snapshots preserved; XML hash matches pre-shutdown capture |
| B | < 5s | Guard passed (dev01 + 4 shut-off VMs unaffected); 2 snapshots cleared; domain + volumes removed |
| C | 21 min | 138 Ansible ok / 83 changed / 0 failed; both snapshots; hub pubkey handed off |
| D | ~10 s | ping + SSH + required sync_check rows green |

Dev01 remained running throughout; `hosts_map.yml` + `config/wireguard/keys.sops.yml` hashes unchanged.

## Known Phase E work — filed as follow-up

Phase D's narrow asserts pass, but broader `sync_check.sh` reveals that
`bootstrap_hub.sh` produces a *fresh* hub and does not re-establish the
*pre-existing world* — the rebuild coordinator's job. Two follow-ups:

- **#226** — Phase E-1: start observability stack on fresh hub (8 containers
  not running post-rebuild).
- **#227** — Phase E-2: re-register pre-existing WG spokes (controller,
  dev01) on fresh hub from SOPS keyring.

Until Phase E lands, `./rebuild_saconsole.sh all` on a previously-peered hub
leaves ~9 extra sync_check failures beyond the pre-Run-01 baseline of 3.

Also filed during Session A:
- **#225** — Backup transport perf (4 MB/s ceiling) + development-quadrant
  volume right-sizing.

## Ancillary changes

- `tools/host_identity.py` — added shell-eval `__main__` emitter; `chmod +x`.
  Replaces a `python3 -c`/PYTHONPATH hack with `eval "$(./tools/host_identity.py)"`.
  Honours `feedback_shebang_executable.md` and `feedback_invoke_as_executable.md`.
- `tools/CLAUDE.md` — documented the new executable usage.
- `docs/SessionLogs/2026-04-18-0720-saconsole-pre-rebuild-capture.md` —
  reference note of the pre-rebuild state (libvirt domain, WG peer table,
  hosts_map + SOPS hashes).

## Test plan

- [x] Phase A runs green, archive integrity verified
- [x] Phase B runs green, guard protects other domains, saconsole + its
      volumes removed
- [x] Phase C runs green, new saconsole up with both snapshots
- [x] Phase D narrow asserts green
- [ ] Phase E-1 + E-2 (separate PRs, #226 + #227)
- [ ] Acceptance Run 01 — full `./rebuild_saconsole.sh all` against frozen
      SUT via Playwright (subsequent 1:1:1 session).

## Rules respected

- No `sed`, no heredocs feeding code.
- No hardcoded params (hub identity via `tools/host_identity.py`;
  VM user via `${ESACP_VM_USER:-you}` matching `config.sh`).
- No modification of `bootstrap_hub.sh` (#220 parked post-matrix).
- Conventional Commits + GPG-signed + co-author trailer on every commit.
- 1:1:1: one issue (#222), one branch, one session; Phase E gaps filed as
  #226/#227 for separate sessions.