### PR TITLE
fix(kvm): sync_check survives fresh-hub known_hosts; Phase D asserts obs containers (#226)

### DIFF
--- a/platforms/kvm/rebuild_saconsole.sh
+++ b/platforms/kvm/rebuild_saconsole.sh
@@ -16,13 +16,18 @@
 #                 idempotent: seed → autoinstall → Fresh Install snap →
 #                 Ansible → Stage 2.2 Baseline snap → handoff).
 #   D  verify   — clear stale known_hosts, ping hub over WG, SSH via
-#                 you@10.10.0.1, assert hub-critical sync_check rows ✅.
+#                 you@10.10.0.1, assert hub-critical sync_check rows ✅
+#                 INCLUDING all 8 observability containers (#226).
 #
-# PENDING (Phase E, not in this script yet):
-#   E-1 (#226) — start observability docker stack on fresh hub.
+# The observability stack itself is brought up by the existing
+# `ansible/roles/observability` role during Phase C bootstrap (it ends
+# with `docker-compose up -d --force-recreate` + Grafana/Prom/Loki
+# health waits). No separate "services-up" phase is needed.
+#
+# PENDING (Phase E-2, not in this script yet):
 #   E-2 (#227) — re-register pre-existing WG spokes on fresh hub.
-# Until Phase E lands, the rebuilt hub has empty WG peer table + no
-# observability containers — sync_check will show ~9 extra failures
+# Until Phase E-2 lands, the rebuilt hub has empty WG peer table —
+# sync_check will show 1 extra failure ("hub has 0 WG peers")
 # beyond the pre-Run-01 baseline.
 #
 # Archive: ~/archives/saconsole/  (not in git; keep last 3 generations).
@@ -184,25 +189,33 @@ phase_d_verify() {
     || { log D "ERROR: SSH to hub failed"; exit 2; }
   log D "  SSH OK"
 
-  log D "sync_check.sh — assert hub-critical ✅ rows"
+  log D "sync_check.sh — assert hub-critical ✅ rows (incl. 8 observability containers)"
   tmp="$(mktemp)"
   bash "$SCRIPT_DIR/sync_check.sh" > "$tmp" 2>&1 || true
   required=(
-    "MCP grafana"
-    "Telegram bot"
-    "github MCP entry present"
+    "✅  MCP grafana"
+    "✅  Telegram bot"
+    "✅  github MCP entry present"
+    "✅  hub: 'prometheus' — up"
+    "✅  hub: 'grafana' — up"
+    "✅  hub: 'loki' — up"
+    "✅  hub: 'promtail' — up"
+    "✅  hub: 'alertmanager' — up"
+    "✅  hub: 'node_exporter' — up"
+    "✅  hub: 'cadvisor' — up"
+    "✅  hub: 'mcp-grafana' — up"
   )
   for r in "${required[@]}"; do
-    if ! grep -q "✅.*$r" "$tmp"; then
-      log D "ERROR: sync_check missing ✅ for '$r'"
-      grep -n "$r" "$tmp" || true
+    if ! grep -qF -- "$r" "$tmp"; then
+      log D "ERROR: sync_check missing line: '$r'"
+      grep -nF -- "${r#*  }" "$tmp" || true
       rm -f "$tmp"
       exit 2
     fi
   done
   grep -E "Passed:|Warnings:|Failed:" "$tmp" | tail -1
   rm -f "$tmp"
-  log D "  sync_check hub-critical rows green"
+  log D "  sync_check hub-critical + observability rows green"
 
   log D "verify complete — saconsole rebuild healthy"
 }

--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -45,6 +45,7 @@ remote_toshiba() { ssh -o ConnectTimeout=5 -o BatchMode=yes \
     "${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" "$@"; }
 
 remote_hub() { ssh -o ConnectTimeout=5 -o BatchMode=yes \
+    -o StrictHostKeyChecking=accept-new \
     -o ProxyJump="${HYPERVISOR_USER}@${HYPERVISOR_ALIAS}" \
     "${HUB_USER}@${HUB_VIRBR0_IP}" "$@"; }
 


### PR DESCRIPTION
## Summary

Re-scope of #226 (issue comment [4274885401](https://github.com/martinhbramwell/ESACP/issues/226#issuecomment-4274885401)).

Live inspection of the post-Session-A hub showed **all 8 observability containers already running** ("Up 4 hours") — the existing \`ansible/roles/observability\` role brings them up during Phase C bootstrap (\`docker-compose up -d --force-recreate\` + Grafana/Prom/Loki health waits). The "8 missing containers" and "hub has 0 WG peers" rows in \`sync_check.sh\` were both **false negatives** caused by the same root cause: \`remote_hub()\` used \`BatchMode=yes\` without \`StrictHostKeyChecking=accept-new\`, so the first SSH after \`rebuild_saconsole.sh\` Phase D clears \`known_hosts\` died silently with "Host key verification failed".

This PR fixes the root cause rather than papering over it with a redundant \`phase_e1_servicesup\` (which would duplicate the Ansible role and mask the SSH bug).

## Changes

- \`platforms/kvm/sync_check.sh:47-50\` — add \`-o StrictHostKeyChecking=accept-new\` to \`remote_hub\`.
- \`platforms/kvm/rebuild_saconsole.sh\` Phase D — broaden the required-row list from 3 hub-critical rows to also include the 8 observability container rows (the agenda's Step 5, "tighten Phase D's assertion", promoted to the primary edit).
- \`platforms/kvm/rebuild_saconsole.sh\` header — remove the stale "Phase E-1 PENDING" callout and document that obs bring-up lives in the Ansible role.

## Test plan

- [x] \`ssh-keygen -R 192.168.122.10\` to simulate fresh known_hosts after a rebuild
- [x] \`bash platforms/kvm/sync_check.sh\` → 3 ❌ (was 12), all 8 obs container rows ✅, WG peer drift row ✅ (5 spokes match inventory)
- [x] Commit GPG-signed (RSA key 9C6BCEA8...04E8)
- [ ] Manual confirmation: next \`./rebuild_saconsole.sh all\` end-to-end run shows 3 sync_check failures (= 3 unprovisioned dev VMs only)

## Carry-forward

**#227** ("Phase E-2 — re-register pre-existing WG spokes on fresh hub") was based on the same false-negative bug. Live \`wg show wg0\` on the hub reports 5 peers configured with active handshakes from the controller (10.10.0.2) and dev01 (10.10.0.13). The other 3 are configured peers for VMs that aren't currently provisioned. Out of scope for this PR per 1:1:1 — flagged for a separate session that will likely close #227 with a comment + the same merge SHA.

fixes #226