### PR TITLE
fix(matrix-tests): Run 02 CLI full company-specific — green (closes #247 #248 #249)

### DIFF
--- a/config/ce_sri_parms.sops.json
+++ b/config/ce_sri_parms.sops.json
@@ -33,7 +33,7 @@
 	},
 	"environment": {
 		"company_tax_id": "ENC[AES256_GCM,data:MljYPNN707y+uFLiYA==,iv:jphut9v69IrR1RDZN6BvCDN+tjobICXLi7A4yJc40EQ=,tag:sa1yd3lIRiSYQN7V7Znc1Q==,type:str]",
-		"company_logo": "ENC[AES256_GCM,data:vYSqjoFErLdDnMhQrUIcGA==,iv:Kha3r2v3M/p8kf+ypQwg9m6iLezNsP+1qZ3CwjLaQ5s=,tag:JJC96Nuw9gHW+QfsYgoNgA==,type:str]",
+		"company_logo": "ENC[AES256_GCM,data:DS75/arjpSO15flj6EwS,iv:m0MsCtMnGnRG3ln18MAlEAU7RpVmYDbac8RuOPApU2Y=,tag:Jl9u3eNkEwBDzoWUVxePTA==,type:str]",
 		"company_logo_location": "ENC[AES256_GCM,data:/4dHXKbclcHdSpG7BECBIMRoyvJsKg==,iv:BCcx9wFKxrgE7g0a2Tn4Gr7uVU3waNCRg3Jqw8T32zA=,tag:w+Zt6VdKYHL9vxeIJy7SzA==,type:str]",
 		"legal_company_name": "ENC[AES256_GCM,data:OpG4BehnykurQPF9eLNkPtJR2QAwPB3pnNo+vRR2ZdiGinM=,iv:VQY7A/Xt04Akr0uuuhNCdNq9LgeuaMaPSGiCNQ/fT9c=,tag:lVjCdgVks4mlPYoIsVEGkQ==,type:str]",
 		"legal_head_office_address": "ENC[AES256_GCM,data:/b8w8SBfPcA4UKg5jwKbUXvbj12cU6UQgftM/NVdxxDSzYF8HwGqJODsPDKr5wN72b4OeVP1KkLQ,iv:19Q6nP1yeBSMn2eLCgOJaW31I/RuqpfbufJlXYucDNk=,tag:NRRtiPN/ZDc5ZeaUiC0N4A==,type:str]",
@@ -66,8 +66,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkbWJrVUlhOE9FR0VkNnB4\nSWsvU3NYc3BlclBTKy92T1hKNWtNYjlBRVNNCm9QWVc1bWRHZmQxTjZCZ21Wa0ts\nR20yM09IODVKL0R5V0Raa1o1MTMvR0kKLS0tIHhRdkpwQkdiT1kzTzVmdWNpbzBl\nR0Y5REVEMnI4SU5nSzBrODZpS2NaK1EKLhwFfKlsBWwn8xrzz0xc4ADecgR9yXIq\nLScrsDqXk9F41XIAtAJTHK4PVsnCsxCAaYhsf1yJT1q3cXHk/MLGeQ==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-04-13T15:02:32Z",
-		"mac": "ENC[AES256_GCM,data:HyoLcs7KZ7NIVDfFBn41ZHb2qi6xm1Jv/80El1MzQ7hewqyTMqDOGnECqdrTeh3AW+d+TtKZZuaXq2fYNfQKIPsg8jgSe36Q+hCn8Eqf4I6kkhRllHFhnbQQxb3MX6xrdMyJj9sxlEmKkTcE1JzmVIZxKa5WdNOhGnh1mmri2R0=,iv:Jm+PQCqWWt/Qkh/Vwo3Bn/SrH+CGgX0cSpZhH9nwqbY=,tag:6z/cdjwGSqjGZ6K6mQ4XPg==,type:str]",
+		"lastmodified": "2026-04-20T12:23:26Z",
+		"mac": "ENC[AES256_GCM,data:3rKRaGm8VDysgzgtIoD/q54OtYx9M+hivGHfE63AUCXwF9fdBh6yr8+2CsUj5Dxe38T6labkL5wKmlbqaBekf4f9Nmd4+3analqySXhd+qNEKiooMFQvnATdVfNNcRW3Wk2u8L28ySp+2WoXuYcoIXev9hLdbqzT2ky27z3LmJ4=,iv:eIi7VAe9FLpAOnOPmKHyAv95vCi6iRXovCWWZNblAqo=,tag:3MAqbUxck8nExtLEqYSSmw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.12.1"
 	}

--- a/docs/SessionLogs/2026-04-20-0802-session-minutes.md
+++ b/docs/SessionLogs/2026-04-20-0802-session-minutes.md
@@ -1,0 +1,123 @@
+# Session Minutes — 2026-04-20 08:02 EDT — Matrix Run 02, attempt 4 — HALTED
+
+**Branch:** `accept/02-cli-full-company-specific` (off `main@8e695a4`)
+**Agenda:** `docs/SessionLogs/acceptance-matrix/02-cli-vm-full-logichem-from-backup.md` (filename frozen pending #246)
+**Plan:** `~/.claude/plans/acceptance-matrix-transport-parity.md`
+
+---
+
+## Objective (entering)
+
+Close Matrix Run 02, attempt 4 — CLI-driven dev VM build with full company-specific ERPNext restored from the golden production backup, driven by a Playwright spec that also asserts Cytoscape topology convergence and an ERPNext canary.
+
+## Status
+
+**HALTED at Step 6 of the Playwright spec.** SUT fully healthy; failure is test-code only. Two new issues filed (#247 blocker, #248 side-finding). Attempt 5 unblocks once #247 merges.
+
+---
+
+## Precondition gates (all passed)
+
+- `main` at `8e695a4` (post-`bf30b76` PR #242 + `8e695a4` PR #245 memory scrub).
+- Sync check: 43 ✅ / 8 ⚠️ / 3 ❌ at session start. The 3 ❌ are the expected idle-VM ping failures (`dev02`/`dev03`/`target5`).
+- MEMORY.md carries the `$BESPOKE_ROOT` header from the 2026-04-19 18:16 memory-scrub session.
+- `dev01` absent at baseline. `saconsole` running on toshiba. Cytoscape API :8088 and Vite :5173 both HTTP 200.
+
+## D3 / D4 / D5 decisions (this session)
+
+- **D3 (acceptance-matrix agenda filenames + body scrub)**: (c) — leave the 5 agendas frozen; new artifacts use `company-specific` token; file follow-on issue for later scrub pass. Result: **#246 filed**.
+- **D4 (`wait_budget_seconds`)**: 3600 (empirically 28.7 min for full restore — budget was ~2× generous).
+- **D5 (canary)**: `https://${HOST}/app/item/Test%20Item` — an `Item` doctype record `Test Item` present in the golden backup. REST + desk view both asserted.
+
+---
+
+## Artefacts authored + committed
+
+| File | Purpose | Commit |
+|---|---|---|
+| `docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml` | Run 02 parameters | `9680b5f` |
+| `prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js` | Run 02 Playwright spec (190 lines) | `9680b5f` |
+
+Commit `9680b5f` — signed, Conventional Commits format, Claude co-author trailer, refs #239 + #246.
+
+---
+
+## Execution timeline
+
+### Attempt 4a (2026-04-19 late night EDT, ~28.8 min wall time)
+
+- Step 1 (baseline): ✅ saconsole up, dev01 absent from `/api/hosts` and Cytoscape.
+- Step 2 (`./tools/esacp.py addHost dev01 …`): ✅ exit 0.
+- Step 3 (`./tools/esacp.py provision dev01`): ✅ exit 0 after 1724s. Snapshot `ERPNext v13 Restored Baseline` taken. Company `Logichem Solutions S. A.` restored.
+- Step 4 (topology convergence): ✅ converged in 1s.
+- **Step 5 (canary login): ❌ HTTP 401.**
+  - Root cause: user-supplied `ERP_ADMIN_PWD=09oikjmn.0.0.0` (intended as the production Administrator password) was rejected. Confirmed reproducible via raw `curl` (not a Playwright quirk).
+  - Investigation: the pipeline resets the restored Administrator to the build-time secret `erp_user_pwd` from `config/build_secrets.sops.yml` — which is `sasa`, not the production value. Design intent is sensible (lab shouldn't carry production creds). `curl -d 'usr=Administrator&pwd=sasa' https://dev01.iridium.blue/api/method/login` → HTTP 200.
+
+User chose **Path A**: destroy `dev01`, re-run with `ERP_ADMIN_PWD=sasa`.
+
+### Destroy
+
+- `echo y | ./tools/esacp.py destroy dev01`: ✅ 8 steps clean (WG peer removal, snapshot delete, virsh destroy+undefine, hosts_map.yml clean, group_vars update, inventory regen, hub WG update, key removal, cloud-init dir removal).
+- `/api/hosts` confirmed dev01 absent.
+
+### Attempt 4b (2026-04-20 early morning EDT, ~29.2 min wall time)
+
+- Steps 1–5: ✅ all green. Provision exit 0 after 1724s (same wall time — repeatable). Canary login with `sasa` succeeded. REST `/api/resource/Item/Test%20Item` OK. Desk URL `/app/item/Test%20Item` rendered with "Test Item" visible.
+- **Step 6 (sync_check): ❌ `execSync` throws.**
+  - Root cause: `sync_check.sh` exits non-zero whenever ANY row fails. The 3 ❌ rows are the pre-existing idle-VM ping failures, unrelated to dev01. Live re-run confirms `✅  ERPNext dev01 (https://dev01.iridium.blue) — HTTP 200` row IS present.
+  - Test-code defect: wrap in try/catch, inspect `err.stdout`, assert specific row.
+  - Same pattern latent in accept-01 spec; Run 01's canonical Playwright green was formally waived 2026-04-19 pm so the trap was never tripped there.
+
+---
+
+## Path decision at halt
+
+User chose **Path X** (strict matrix): file #247, fix test code, destroy dev01, re-run. Then pivoted to session-end audit before execution. Session closes halted; attempt 5 picks up from here.
+
+---
+
+## Issues filed this session
+
+| # | Title | Role |
+|---|---|---|
+| **#246** | chore(scrub): rename + body-scrub the 5 acceptance-matrix agenda files (post-#239 follow-on) | D3(c) follow-on — deferred |
+| **#247** | bug(matrix-tests): execSync of sync_check.sh in Run 01/02 specs throws on script's legitimate non-zero exit | Blocker for Run 02 attempt 5 |
+| **#248** | bug(scrub): #239 completeness — LogichemLogo.png filename still referenced; stale .pyc bytecode | #239 regression — low priority |
+
+---
+
+## Findings NOT filed (with reason)
+
+- **WG reachability drift post-provision.** First attempt showed `ping 10.10.0.12 — unreachable` for ~minutes after provision completed (while HTTPS via public DNS worked). Re-run showed `ping 10.10.0.16 — reachable` immediately. Probably a post-provision settling delay (WG handshake refresh), not a reproducible bug. Noted here; did not file.
+
+---
+
+## State at session close
+
+- Branch `accept/02-cli-full-company-specific` at `9680b5f`. To be pushed by the close-out commit (these minutes + MEMORY.md update).
+- `dev01` **remains provisioned** on toshiba. Attempt 5 must begin with destroy.
+- Working tree has live config mutations (`hosts_map.yml`, `group_vars/all.yml`, `inventory/kvm.yml`, `keys.sops.yml`) from dev01's live state — will revert automatically on destroy. Not committed.
+- Playwright test-results artifacts under `prototypes/cytoscape/test-results/` are uncommitted and will be discarded on next run.
+
+---
+
+## What unblocks attempt 5
+
+1. #247 fix merged to main — single-file test-code edit in `accept-02-cli-full-company-specific.spec.js` (and same edit in accept-01 for hygiene).
+2. Destroy `dev01` (or confirm still absent from previous session clean-up).
+3. Re-run: `ERP_ADMIN_PWD=sasa npx playwright test --grep accept-02` from `prototypes/cytoscape/`.
+
+Empirical wall-time budget: 30 min provision + ~1 min convergence + ~5 min canary + sync_check = ~35 min per attempt.
+
+---
+
+## Acceptance-of-minutes checklist
+
+- [x] Objective stated.
+- [x] All three D-decisions recorded with reasoning.
+- [x] Every forward-tense phrase from the session resolved (see Audit Step 1 in this session's transcript).
+- [x] Every GH issue referenced confirmed current (no uncommitted findings).
+- [x] No PR opened (session halted, not "DONE").
+- [x] Two new issues filed; MEMORY.md tracker updated.
+- [x] Side findings either filed or explicitly dismissed with reason.

--- a/docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml
+++ b/docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml
@@ -1,3 +1,9 @@
+# Matrix Run 02 parameters — CLI full company-specific ERPNext from golden backup.
+#
+# Administrator credential: the accept-02 spec derives it automatically from
+# config/build_secrets.sops.yml (field erp_user_pwd). The provisioning pipeline
+# resets Administrator to that value post-restore — never supply a production
+# Administrator credential. See memory/feedback_lab_admin_password.md.
 run: "02"
 transport: cli
 target_vm: dev01
@@ -6,7 +12,7 @@ backup_source: golden_production
 zone: development
 vm_role: "dev:full_company_specific"
 hypervisor: toshiba
-wait_budget_seconds: 3600
+wait_budget_seconds: 3000
 topology_convergence_budget_seconds: 300
 canary_doctype: Item
 canary_name: "Test Item"

--- a/docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml
+++ b/docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml
@@ -1,0 +1,13 @@
+run: "02"
+transport: cli
+target_vm: dev01
+variant: full_company_specific
+backup_source: golden_production
+zone: development
+vm_role: "dev:full_company_specific"
+hypervisor: toshiba
+wait_budget_seconds: 3600
+topology_convergence_budget_seconds: 300
+canary_doctype: Item
+canary_name: "Test Item"
+canary_app_url_path: "/app/item/Test%20Item"

--- a/prototypes/cytoscape/tests/accept-01-cli-saconsole.spec.js
+++ b/prototypes/cytoscape/tests/accept-01-cli-saconsole.spec.js
@@ -171,9 +171,17 @@ test.describe('Acceptance Run 01 — CLI saconsole rebuild', () => {
     ).trim()
     expect(parseInt(obsUpRaw, 10), 'obs containers Up').toBe(8)
 
-    const syncOut = execSync('bash platforms/kvm/sync_check.sh', {
-      cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
-    })
+    // sync_check.sh exits non-zero when ANY row fails — including pre-existing
+    // idle-VM ping failures unrelated to the host under test (#247). Tolerate
+    // exit status; inspect stdout.
+    let syncOut
+    try {
+      syncOut = execSync('bash platforms/kvm/sync_check.sh', {
+        cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    } catch (err) {
+      syncOut = err.stdout || ''
+    }
     for (const req of REQUIRED_SYNC_ROWS) {
       expect(syncOut, `sync_check missing row: ${req}`).toContain(req)
     }

--- a/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
+++ b/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
@@ -19,6 +19,10 @@ import { BASE_URL, API_URL, waitForGraph } from './helpers.js'
  * Params:  docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml
  *
  * Parity partner: Run 05 (UI-driven full company-specific restore). Same canary asserted.
+ *
+ * Administrator password: derived automatically from config/build_secrets.sops.yml
+ * (field erp_user_pwd). The provisioning pipeline resets Administrator to that value
+ * post-restore — see memory/feedback_lab_admin_password.md for the why.
  */
 
 const __filename = fileURLToPath(import.meta.url)
@@ -28,6 +32,7 @@ const PARAM_PATH = path.join(
   PROJECT_ROOT,
   'docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml'
 )
+const BUILD_SECRETS_PATH = path.join(PROJECT_ROOT, 'config/build_secrets.sops.yml')
 
 function loadParams() {
   const raw = readFileSync(PARAM_PATH, 'utf8')
@@ -45,6 +50,33 @@ function loadParams() {
   return params
 }
 
+function decryptBuildSecret(key) {
+  const raw = execSync(`sops -d ${BUILD_SECRETS_PATH}`, {
+    cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  for (const line of raw.split('\n')) {
+    const m = line.match(new RegExp(`^\\s*${key}\\s*:\\s*(.+?)\\s*$`))
+    if (!m) continue
+    const v = m[1].trim()
+    const quoted = v.match(/^["'](.*)["']$/)
+    return quoted ? quoted[1] : v
+  }
+  throw new Error(`${key} not found in decrypted ${BUILD_SECRETS_PATH}`)
+}
+
+function runSyncCheck() {
+  // sync_check.sh exits non-zero when ANY row fails — including pre-existing
+  // idle-VM ping failures that are unrelated to the host under test (#247).
+  // Swallow exit status; inspect stdout.
+  try {
+    return execSync('bash platforms/kvm/sync_check.sh', {
+      cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (err) {
+    return err.stdout || ''
+  }
+}
+
 const params = loadParams()
 const TARGET_URL = `https://${params.target_vm}.iridium.blue`
 const CANARY_URL = `${TARGET_URL}${params.canary_app_url_path}`
@@ -52,30 +84,73 @@ const CANARY_URL = `${TARGET_URL}${params.canary_app_url_path}`
 test.use({ headless: process.env.HEADED !== '1' })
 
 test.describe('Acceptance Run 02 — CLI full company-specific ERPNext', () => {
-  // wait_budget (provision) + convergence + 10 min margin (login + canary + sync_check)
+  // wait_budget (provision) + convergence + 15 min margin (self-check + destroy + canary + sync_check)
   test.setTimeout(
-    (params.wait_budget_seconds + params.topology_convergence_budget_seconds + 600) * 1000
+    (params.wait_budget_seconds + params.topology_convergence_budget_seconds + 900) * 1000
   )
 
-  test('addHost + provision dev01 — exit 0, UI converges, ERPNext canary reachable', async ({ page, browser }) => {
-    const ADMIN_PWD = process.env.ERP_ADMIN_PWD
-    if (!ADMIN_PWD) {
+  test('self-check + destroy + addHost + provision dev01 — exit 0, UI converges, ERPNext canary reachable', async ({ page, browser }) => {
+    // ── Step 0: self-check — validate test-harness assumptions BEFORE any SUT spend ─
+    console.log('[accept-02] self-check: validating harness assumptions')
+
+    // 0a. sops decrypt of build_secrets → ERP_ADMIN_PWD derivable
+    let ADMIN_PWD
+    try {
+      ADMIN_PWD = decryptBuildSecret('erp_user_pwd')
+    } catch (err) {
       throw new Error(
-        'ERP_ADMIN_PWD env var is required. The Administrator password baked into the ' +
-        'golden production backup is not committed to the repo; set it on the command line:\n' +
-        '  ERP_ADMIN_PWD=... npx playwright test --grep "accept-02"'
+        `self-check 0a failed: cannot decrypt ${BUILD_SECRETS_PATH}. ` +
+        `Verify sops + age key. Underlying: ${err.message}`
       )
     }
+    expect(ADMIN_PWD, 'erp_user_pwd from build_secrets.sops.yml').toBeTruthy()
 
-    // ── Step 1: precondition + baseline ────────────────────────────────────
+    // 0b. sync_check.sh parseable via try/catch path (#247 regression guard)
+    const selfSync = runSyncCheck()
+    expect(
+      selfSync,
+      'self-check 0b: sync_check.sh output must contain row markers (✅/❌)'
+    ).toMatch(/[✅❌]/)
+
+    // 0c. Cytoscape API :8088 reachable
+    const apiResp = await page.request.get(`${API_URL}/api/hosts`)
+    expect(apiResp.ok(), 'self-check 0c: Cytoscape API /api/hosts').toBe(true)
+
+    // 0d. Vite :5173 reachable
+    const viteResp = await page.request.get(BASE_URL)
+    expect(viteResp.ok(), `self-check 0d: Vite ${BASE_URL}`).toBe(true)
+
+    // 0e. toshiba SSH reachable (destroy depends on it)
+    try {
+      execSync(`ssh -o BatchMode=yes -o ConnectTimeout=5 ${params.hypervisor} true`, {
+        cwd: PROJECT_ROOT, stdio: ['ignore', 'ignore', 'pipe'],
+      })
+    } catch (err) {
+      throw new Error(`self-check 0e failed: cannot SSH to ${params.hypervisor}: ${err.message}`)
+    }
+
+    console.log('[accept-02] self-check OK — proceeding to baseline/destroy')
+
+    // ── Step 1: baseline + destroy-as-precondition (idempotent clean slate) ─
     await page.goto(BASE_URL)
     await waitForGraph(page)
 
     const baselineResp = await page.request.get(`${API_URL}/api/hosts`)
-    expect(baselineResp.ok(), '/api/hosts baseline').toBe(true)
     const baseline = await baselineResp.json()
     const existing = baseline.hosts.find(h => h.hostname === params.target_vm)
-    expect(existing, `${params.target_vm} must be ABSENT at baseline`).toBeFalsy()
+    if (existing) {
+      console.log(`[accept-02] ${params.target_vm} present at baseline — destroying (attempt-restart safety)`)
+      execSync(`echo y | ./tools/esacp.py destroy ${params.target_vm}`, {
+        cwd: PROJECT_ROOT, stdio: ['ignore', 'inherit', 'inherit'],
+        shell: '/bin/bash',
+      })
+      const afterDestroyResp = await page.request.get(`${API_URL}/api/hosts`)
+      const afterDestroy = await afterDestroyResp.json()
+      const stillThere = afterDestroy.hosts.find(h => h.hostname === params.target_vm)
+      expect(stillThere, `${params.target_vm} must be ABSENT after destroy`).toBeFalsy()
+    } else {
+      console.log(`[accept-02] ${params.target_vm} absent at baseline — nothing to destroy`)
+    }
 
     const onGraphAtBaseline = await page.evaluate((h) => {
       const cy = document.querySelector('#cy')?._cyreg?.cy
@@ -178,10 +253,8 @@ test.describe('Acceptance Run 02 — CLI full company-specific ERPNext', () => {
       await erp.close()
     }
 
-    // ── Step 6: sync_check ─────────────────────────────────────────────────
-    const syncOut = execSync('bash platforms/kvm/sync_check.sh', {
-      cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
-    })
+    // ── Step 6: sync_check — assert specific dev01 row (#247) ──────────────
+    const syncOut = runSyncCheck()
     expect(
       syncOut,
       `sync_check ERPNext row for ${params.target_vm} must be ✅`

--- a/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
+++ b/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
@@ -148,6 +148,11 @@ test.describe('Acceptance Run 02 — CLI full company-specific ERPNext', () => {
       const afterDestroy = await afterDestroyResp.json()
       const stillThere = afterDestroy.hosts.find(h => h.hostname === params.target_vm)
       expect(stillThere, `${params.target_vm} must be ABSENT after destroy`).toBeFalsy()
+
+      // Rehydrate Cytoscape from post-destroy /api/hosts — the 30s poll tick
+      // may not have fired yet, so the in-memory graph is otherwise stale (#249).
+      await page.reload()
+      await waitForGraph(page)
     } else {
       console.log(`[accept-02] ${params.target_vm} absent at baseline — nothing to destroy`)
     }

--- a/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
+++ b/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
@@ -1,0 +1,190 @@
+// @ts-check
+import { test, expect } from '@playwright/test'
+import { spawn, execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { BASE_URL, API_URL, waitForGraph } from './helpers.js'
+
+/**
+ * Acceptance Run 02 — CLI dev VM, full company-specific ERPNext from golden production backup.
+ *
+ * Two-step CLI lifecycle (per shelved-attempt-3 decisions D1=(a), D2=(a)):
+ *   1. ./tools/esacp.py addHost dev01 ...
+ *   2. ./tools/esacp.py provision dev01     (Config.provision_mode defaults to "restored")
+ *
+ * Plan:    ~/.claude/plans/acceptance-matrix-transport-parity.md
+ * Agenda:  docs/SessionLogs/acceptance-matrix/02-cli-vm-full-logichem-from-backup.md
+ *          (filename frozen pending #246; new artifacts use company-specific token)
+ * Params:  docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml
+ *
+ * Parity partner: Run 05 (UI-driven full company-specific restore). Same canary asserted.
+ */
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname  = path.dirname(__filename)
+const PROJECT_ROOT = path.resolve(__dirname, '../../..')
+const PARAM_PATH = path.join(
+  PROJECT_ROOT,
+  'docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml'
+)
+
+function loadParams() {
+  const raw = readFileSync(PARAM_PATH, 'utf8')
+  const params = {}
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*([a-z_]+)\s*:\s*(.+?)\s*$/)
+    if (!m) continue
+    const [, k, v] = m
+    const quoted = v.match(/^["'](.*)["']$/)
+    if (quoted) { params[k] = quoted[1]; continue }
+    if (/^-?\d+$/.test(v)) params[k] = parseInt(v, 10)
+    else if (v === 'true' || v === 'false') params[k] = v === 'true'
+    else params[k] = v
+  }
+  return params
+}
+
+const params = loadParams()
+const TARGET_URL = `https://${params.target_vm}.iridium.blue`
+const CANARY_URL = `${TARGET_URL}${params.canary_app_url_path}`
+
+test.use({ headless: process.env.HEADED !== '1' })
+
+test.describe('Acceptance Run 02 — CLI full company-specific ERPNext', () => {
+  // wait_budget (provision) + convergence + 10 min margin (login + canary + sync_check)
+  test.setTimeout(
+    (params.wait_budget_seconds + params.topology_convergence_budget_seconds + 600) * 1000
+  )
+
+  test('addHost + provision dev01 — exit 0, UI converges, ERPNext canary reachable', async ({ page, browser }) => {
+    const ADMIN_PWD = process.env.ERP_ADMIN_PWD
+    if (!ADMIN_PWD) {
+      throw new Error(
+        'ERP_ADMIN_PWD env var is required. The Administrator password baked into the ' +
+        'golden production backup is not committed to the repo; set it on the command line:\n' +
+        '  ERP_ADMIN_PWD=... npx playwright test --grep "accept-02"'
+      )
+    }
+
+    // ── Step 1: precondition + baseline ────────────────────────────────────
+    await page.goto(BASE_URL)
+    await waitForGraph(page)
+
+    const baselineResp = await page.request.get(`${API_URL}/api/hosts`)
+    expect(baselineResp.ok(), '/api/hosts baseline').toBe(true)
+    const baseline = await baselineResp.json()
+    const existing = baseline.hosts.find(h => h.hostname === params.target_vm)
+    expect(existing, `${params.target_vm} must be ABSENT at baseline`).toBeFalsy()
+
+    const onGraphAtBaseline = await page.evaluate((h) => {
+      const cy = document.querySelector('#cy')?._cyreg?.cy
+      return cy ? !cy.$(`#${h}`).empty() : false
+    }, params.target_vm)
+    expect(onGraphAtBaseline, `${params.target_vm} must be absent from Cytoscape at baseline`).toBe(false)
+
+    // ── Step 2: addHost (registration only — no VM build) ──────────────────
+    console.log(`[accept-02] addHost ${params.target_vm}`)
+    execSync(
+      `./tools/esacp.py addHost ${params.target_vm} ` +
+      `--zone ${params.zone} ` +
+      `--vm-role ${params.vm_role} ` +
+      `--hypervisor ${params.hypervisor}`,
+      { cwd: PROJECT_ROOT, stdio: ['ignore', 'inherit', 'inherit'] }
+    )
+
+    const afterAddResp = await page.request.get(`${API_URL}/api/hosts`)
+    const afterAdd = await afterAddResp.json()
+    const registered = afterAdd.hosts.find(h => h.hostname === params.target_vm)
+    expect(registered, `${params.target_vm} must be present after addHost`).toBeTruthy()
+    expect(registered.provisioned, `${params.target_vm} provisioned should be false pre-build`).toBe(false)
+
+    // ── Step 3: provision (full restore from golden production backup) ─────
+    console.log(
+      `[accept-02] provision ${params.target_vm}  ` +
+      `(wait budget: ${params.wait_budget_seconds}s)`
+    )
+    const startedAt = Date.now()
+    const proc = spawn('./tools/esacp.py', ['provision', params.target_vm], {
+      cwd: PROJECT_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    })
+    let stderrTail = ''
+    proc.stdout.on('data', d => process.stdout.write(d))
+    proc.stderr.on('data', d => {
+      const s = d.toString()
+      process.stderr.write(s)
+      stderrTail = (stderrTail + s).slice(-2000)
+    })
+    const exitCode = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        proc.kill('SIGKILL')
+        reject(new Error(`provision exceeded wait_budget_seconds=${params.wait_budget_seconds}`))
+      }, params.wait_budget_seconds * 1000)
+      proc.on('exit', code => { clearTimeout(timer); resolve(code) })
+      proc.on('error', err => { clearTimeout(timer); reject(err) })
+    })
+    const provisionSeconds = Math.round((Date.now() - startedAt) / 1000)
+    console.log(`[accept-02] provision exited code=${exitCode} after ${provisionSeconds}s`)
+    expect(exitCode, `provision exit (stderr tail: ${stderrTail})`).toBe(0)
+
+    // ── Step 4: topology convergence ───────────────────────────────────────
+    console.log(`[accept-02] awaiting UI convergence within ${params.topology_convergence_budget_seconds}s`)
+    const convergenceStart = Date.now()
+    await expect(async () => {
+      const r = await page.request.get(`${API_URL}/api/hosts`)
+      const data = await r.json()
+      const h = data.hosts.find(x => x.hostname === params.target_vm)
+      expect(h, `${params.target_vm} in /api/hosts`).toBeTruthy()
+      expect(h.provisioned, `${params.target_vm} provisioned`).toBe(true)
+      expect(h.vm_state, `${params.target_vm} vm_state`).toBe('running')
+    }).toPass({
+      timeout: params.topology_convergence_budget_seconds * 1000,
+      intervals: [5_000],
+    })
+    const convergenceSeconds = Math.round((Date.now() - convergenceStart) / 1000)
+    console.log(`[accept-02] UI converged after ${convergenceSeconds}s`)
+
+    const uiPresent = await page.evaluate((h) => {
+      const cy = document.querySelector('#cy')?._cyreg?.cy
+      return cy ? !cy.$(`#${h}`).empty() : false
+    }, params.target_vm)
+    expect(uiPresent, `${params.target_vm} must appear in Cytoscape after convergence`).toBe(true)
+
+    // ── Step 5: ERPNext canary — login + Test Item ─────────────────────────
+    console.log(`[accept-02] canary: login as Administrator + GET ${params.canary_app_url_path}`)
+    const erp = await browser.newContext()
+    try {
+      const login = await erp.request.post(`${TARGET_URL}/api/method/login`, {
+        form: { usr: 'Administrator', pwd: ADMIN_PWD },
+      })
+      expect(login.ok(), `ERPNext login (HTTP ${login.status()})`).toBe(true)
+
+      const itemResp = await erp.request.get(
+        `${TARGET_URL}/api/resource/${encodeURIComponent(params.canary_doctype)}/${encodeURIComponent(params.canary_name)}`
+      )
+      expect(
+        itemResp.ok(),
+        `${params.canary_doctype}/${params.canary_name} REST (HTTP ${itemResp.status()})`
+      ).toBe(true)
+      const itemBody = await itemResp.json()
+      expect(itemBody?.data?.name, 'canary doc name').toBe(params.canary_name)
+
+      const erpPage = await erp.newPage()
+      await erpPage.goto(CANARY_URL, { waitUntil: 'networkidle' })
+      await expect(erpPage.locator('body')).toContainText(params.canary_name)
+    } finally {
+      await erp.close()
+    }
+
+    // ── Step 6: sync_check ─────────────────────────────────────────────────
+    const syncOut = execSync('bash platforms/kvm/sync_check.sh', {
+      cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    expect(
+      syncOut,
+      `sync_check ERPNext row for ${params.target_vm} must be ✅`
+    ).toContain(`✅  ERPNext ${params.target_vm} (${TARGET_URL})`)
+  })
+})


### PR DESCRIPTION
## Summary

- **Matrix Run 02 attempt 6: GREEN (27.7 min)** — CLI-driven dev VM build, full company-specific ERPNext restored from golden production backup, Playwright spec passing.
- **#247 fixed**: \`execSync\` of \`sync_check.sh\` wrapped in try/catch across accept-01 + accept-02 specs; reads \`err.stdout\` when the script exits non-zero on unrelated idle-VM ping failures.
- **#248 fixed** (scrub completeness): encrypted \`company_logo\` field rewritten \`LogichemLogo.png\` → \`CompanyLogo.png\`; stale \`__pycache__\` bytecode cleared locally.
- **#249 fixed**: accept-02 destroy-as-precondition now rehydrates Cytoscape via \`page.reload()\` after destroy — prior version raced the 30s \`_refreshVmState()\` poller.

## New capabilities in accept-02

- **Self-check preamble (Step 0)** — validates sops decryptability of \`build_secrets.sops.yml\`, \`sync_check.sh\` output parseability, Cytoscape API :8088 + Vite :5173 reachability, hypervisor SSH. Fails fast before 30-min provision spend.
- **Destroy-as-precondition (Step 1)** — idempotent re-run; Matrix Run 02 no longer requires a manual destroy between attempts.
- **Auto-derived Administrator password** — decrypts \`build_secrets.sops.yml\` directly; operator no longer supplies \`ERP_ADMIN_PWD\` env var. See \`memory/feedback_lab_admin_password.md\` for the lab-isolation rationale.
- **Budget tightened** — \`wait_budget_seconds\` 3600 → 3000 (empirical ~27 min; 50 min still allows ~2× headroom).

## Commits

- \`750d97f\` — fix(matrix-tests): harden accept-02 + tolerate sync_check.sh non-zero exit (closes #247)
- \`c4f1ee7\` — fix(scrub): rewrite company_logo filename in encrypted ce_sri parms (closes #248)
- \`c8e289d\` — fix(matrix-tests): reload graph after destroy-as-precondition (fixes #249)

## Side finding (filed as #250)

Run 02 provision log still shows \`[SKIP] Logo not found at /home/erpadm/.ssh/secrets/CompanyLogo.png\`. #248's charter (scrub completeness) is met — the filename and bytecode regressions are both resolved. The SKIP persists because the logo file is SCP'd to \`/tmp/\` but never moved to \`company_logo_location\`; this is a pre-existing bug (same [SKIP] under the old filename pre-scrub), not a new regression. Tracked in #250.

## Test plan

- [x] \`node --check\` both spec files — syntax clean
- [x] \`npx playwright test --grep accept-02\` (headless) — 1 passed (27.7m)
- [x] Self-check 0a-0e all green
- [x] Destroy-as-precondition: destroyed dev01 cleanly, rehydrated graph, re-asserted absence
- [x] addHost + provision exit 0 (1615s, 26.9 min)
- [x] UI convergence in 1s (dev01 visible on Cytoscape post-provision)
- [x] ERPNext canary: Administrator login, REST \`Item/Test Item\`, desk view all green
- [x] sync_check specific-row assertion green (tolerates unrelated idle-VM ping failures)
- [x] accept-01 spec still syntax-clean after same \`execSync\` try/catch fix (latent pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)