### PR TITLE
chore(scrub): acceptance-matrix agenda rename + body scrub (#246)

### DIFF
--- a/docs/SessionLogs/acceptance-matrix/02-cli-vm-full-company-specific-from-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/02-cli-vm-full-company-specific-from-backup.md
@@ -1,10 +1,10 @@
-# Agenda — Acceptance Run 02 (CLI) — dev VM, full Logichem ERPNext from backup
+# Agenda — Acceptance Run 02 (CLI) — dev VM, full company-specific ERPNext from backup
 
 Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
 
 ## Objective
 
-Prove a dev VM can be built from the CLI and end up running full Logichem ERPNext restored from the golden production backup, with the UI converging to reflect the new state.
+Prove a dev VM can be built from the CLI and end up running full company-specific ERPNext restored from the golden production backup, with the UI converging to reflect the new state.
 
 ## Entry preconditions
 
@@ -15,13 +15,13 @@ Prove a dev VM can be built from the CLI and end up running full Logichem ERPNex
 
 ## Parameter file
 
-`docs/SessionLogs/acceptance-matrix/params/02-cli-full-logichem.yml`
+`docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml`
 
 ```yaml
 run: "02"
 transport: cli
 target_vm: dev01
-variant: full_logichem
+variant: full_company_specific
 backup_source: golden_production
 wait_budget_seconds: 1800
 topology_convergence_budget_seconds: 300
@@ -30,20 +30,20 @@ topology_convergence_budget_seconds: 300
 ## Commands (single destroy, single build)
 
 1. Destroy: no-op at start (no dev VM present). If one is unexpectedly present, halt.
-2. Build: `./tools/esacp.py provision --params docs/SessionLogs/acceptance-matrix/params/02-cli-full-logichem.yml` (exact flag spelling confirmed at session start; must consume the param file without further input).
+2. Build: `./tools/esacp.py provision --params docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml` (exact flag spelling confirmed at session start; must consume the param file without further input).
 
 The `provision` subcommand already performs stages 1–9 as one unit; that satisfies "single build command".
 
 ## Playwright test
 
-`prototypes/cytoscape/tests/accept-02-cli-full-logichem.spec.js`
+`prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js`
 
 The test:
 
 1. Asserts starting topology (saconsole only).
 2. Spawns the build subprocess; asserts success exit.
 3. Within `topology_convergence_budget_seconds`, asserts the UI shows the new dev VM as green.
-4. Asserts `https://<target_vm>.iridium.blue` serves the Logichem login, and the canary Logichem record is present (helper defined here, reused by run 05).
+4. Asserts `https://<target_vm>.iridium.blue` serves the company-specific login, and the canary company-specific record is present (helper defined here, reused by run 05).
 
 ## Acceptance
 
@@ -53,7 +53,7 @@ The test:
 
 ## Exit state (handed to run 03)
 
-Saconsole + dev VM running full Logichem ERPNext via CLI provision. Run 03 destroys this dev VM first.
+Saconsole + dev VM running full company-specific ERPNext via CLI provision. Run 03 destroys this dev VM first.
 
 ## Findings protocol
 
@@ -61,4 +61,4 @@ Halt + issue. Canary-helper content here is the parity reference for run 05 (UI)
 
 ## Sign-off
 
-Branch `accept/02-cli-full-logichem`; PR; merge.
+Branch `accept/02-cli-full-company-specific`; PR; merge.

--- a/docs/SessionLogs/acceptance-matrix/03-cli-vm-pseudo-company-wizard-creates-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/03-cli-vm-pseudo-company-wizard-creates-backup.md
@@ -53,7 +53,7 @@ The test:
 2. Spawns build; asserts UI shows dev VM as green within the convergence budget.
 3. Navigates to `https://<target_vm>.iridium.blue`, drives the ERPNext setup wizard with run-03 params (helper defined here, reused by run 06).
 4. Triggers backup; writes artefact to `backup_output_path`; verifies integrity.
-5. Asserts company = `Pseudo-Co`, no Logichem records.
+5. Asserts company = `Pseudo-Co`, no company-specific records.
 
 ## Acceptance
 

--- a/docs/SessionLogs/acceptance-matrix/05-ui-vm-full-company-specific-from-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/05-ui-vm-full-company-specific-from-backup.md
@@ -1,10 +1,10 @@
-# Agenda — Acceptance Run 05 (UI) — dev VM, full Logichem ERPNext from backup
+# Agenda — Acceptance Run 05 (UI) — dev VM, full company-specific ERPNext from backup
 
 Plan: `~/.claude/plans/acceptance-matrix-transport-parity.md`
 
 ## Objective
 
-Prove that a dev VM can be built through the Cytoscape UI and end up running full Logichem ERPNext, restored from the golden production backup, via a single destroy + single build action validated by Playwright. Parity partner: run 02 (CLI).
+Prove that a dev VM can be built through the Cytoscape UI and end up running full company-specific ERPNext, restored from the golden production backup, via a single destroy + single build action validated by Playwright. Parity partner: run 02 (CLI).
 
 ## Entry preconditions
 
@@ -15,13 +15,13 @@ Prove that a dev VM can be built through the Cytoscape UI and end up running ful
 
 ## Parameter file
 
-`docs/SessionLogs/acceptance-matrix/params/05-ui-full-logichem.yml`
+`docs/SessionLogs/acceptance-matrix/params/05-ui-full-company-specific.yml`
 
 ```yaml
 run: "05"
 transport: ui
 target_vm: dev01  # confirm at session start against hosts_map.yml
-variant: full_logichem
+variant: full_company_specific
 backup_source: golden_production
 wait_budget_seconds: 1800
 ```
@@ -29,19 +29,19 @@ wait_budget_seconds: 1800
 ## Commands (single destroy, single build)
 
 1. Destroy: Playwright right-clicks the dev VM from run 04 → Destroy → confirms.
-2. Build: Playwright drags saconsole → the target quadrant → selects "Full Logichem from backup" in the pre-provision wizard → confirms. The restore source path is read from the param file, not entered interactively.
+2. Build: Playwright drags saconsole → the target quadrant → selects "Full company-specific from backup" in the pre-provision wizard → confirms. The restore source path is read from the param file, not entered interactively.
 
 ## Playwright test
 
-`prototypes/cytoscape/tests/accept-05-ui-full-logichem.spec.js`
+`prototypes/cytoscape/tests/accept-05-ui-full-company-specific.spec.js`
 
 The test:
 
 1. Destroys the run-04 dev VM and waits for the topology to reflect it.
-2. Performs the drag-and-build path with the `full_logichem` option.
+2. Performs the drag-and-build path with the `full_company_specific` option.
 3. Waits (bounded by `wait_budget_seconds`) for the dev VM to appear and turn green.
-4. Asserts `https://<target_vm>.iridium.blue` responds with the Logichem ERPNext login page.
-5. Queries the same canary Logichem record defined in run 02's helper — parity check against CLI transport.
+4. Asserts `https://<target_vm>.iridium.blue` responds with the company-specific ERPNext login page.
+5. Queries the same canary company-specific record defined in run 02's helper — parity check against CLI transport.
 
 ## Acceptance
 
@@ -52,7 +52,7 @@ The test:
 
 ## Exit state (handed to run 06)
 
-Saconsole + dev VM running full Logichem ERPNext, restored from golden backup. Run 06 begins by destroying this dev VM.
+Saconsole + dev VM running full company-specific ERPNext, restored from golden backup. Run 06 begins by destroying this dev VM.
 
 ## Findings protocol
 
@@ -60,4 +60,4 @@ Halt + issue. Divergence from run 02's observable outcome is a parity finding �
 
 ## Sign-off
 
-Branch `accept/05-ui-full-logichem`; PR; merge.
+Branch `accept/05-ui-full-company-specific`; PR; merge.

--- a/docs/SessionLogs/acceptance-matrix/06-ui-vm-pseudo-company-wizard-creates-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/06-ui-vm-pseudo-company-wizard-creates-backup.md
@@ -53,7 +53,7 @@ The test:
 3. Navigates to `https://<target_vm>.iridium.blue`, drives the ERPNext setup wizard with values from the param file (reuse helper from run 03).
 4. Triggers an ERPNext backup (via the wizard-completion hook or the admin UI, whichever the UI exposes as the "one build" endpoint).
 5. Fetches the backup artefact to `backup_output_path`, verifies integrity (file exists, gzip-valid, SQL header present).
-6. Asserts the ERPNext instance has company name = `Pseudo-Co` and no Logichem records.
+6. Asserts the ERPNext instance has company name = `Pseudo-Co` and no company-specific records.
 
 This is the one agenda whose Playwright test will be substantial. Test code is not length-limited; extract helpers shared with run 03 / run 07.
 

--- a/docs/SessionLogs/acceptance-matrix/07-ui-vm-pseudo-company-restore-from-wizard-backup.md
+++ b/docs/SessionLogs/acceptance-matrix/07-ui-vm-pseudo-company-restore-from-wizard-backup.md
@@ -41,7 +41,7 @@ The test:
 1. Destroys the run-06 dev VM.
 2. Builds the fresh dev VM with the pseudo-restore option using B06.
 3. Navigates to `https://<target_vm>.iridium.blue`.
-4. Asserts company = `Pseudo-Co`, wizard flag is set, admin email matches run 06's param file, and no Logichem records exist.
+4. Asserts company = `Pseudo-Co`, wizard flag is set, admin email matches run 06's param file, and no company-specific records exist.
 5. Compares canary facts against run 04's exit state (helper reuse) — confirms the UI restore path matches the CLI restore path.
 
 ## Acceptance
@@ -57,7 +57,7 @@ Saconsole + dev VM running restored skeletal ERPNext via UI transport. All 7 run
 
 With all 7 runs signed off, write a close-out note comparing:
 
-- Run 02 (CLI) vs Run 05 (UI) — full Logichem from golden backup.
+- Run 02 (CLI) vs Run 05 (UI) — full company-specific from golden backup.
 - Run 03 (CLI) vs Run 06 (UI) — wizard-driven skeletal (including B03 vs B06 content).
 - Run 04 (CLI) vs Run 07 (UI) — restore-from-wizard-backup.
 

--- a/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
+++ b/prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js
@@ -14,8 +14,7 @@ import { BASE_URL, API_URL, waitForGraph } from './helpers.js'
  *   2. ./tools/esacp.py provision dev01     (Config.provision_mode defaults to "restored")
  *
  * Plan:    ~/.claude/plans/acceptance-matrix-transport-parity.md
- * Agenda:  docs/SessionLogs/acceptance-matrix/02-cli-vm-full-logichem-from-backup.md
- *          (filename frozen pending #246; new artifacts use company-specific token)
+ * Agenda:  docs/SessionLogs/acceptance-matrix/02-cli-vm-full-company-specific-from-backup.md
  * Params:  docs/SessionLogs/acceptance-matrix/params/02-cli-full-company-specific.yml
  *
  * Parity partner: Run 05 (UI-driven full company-specific restore). Same canary asserted.


### PR DESCRIPTION
## Summary

Post-#239 follow-on scrub of the 5 acceptance-matrix agenda files under `docs/SessionLogs/acceptance-matrix/`.

- **Renamed** (2): agenda `02` and `05` filenames now use the `company-specific` token.
- **Body-scrubbed** (5): `02`, `03`, `05`, `06`, `07` — prose uses `company-specific` (kebab), YAML data uses `full_company_specific` (snake), per the #239 convention.
- **Live pointer**: the stale agenda-filename comment at `prototypes/cytoscape/tests/accept-02-cli-full-company-specific.spec.js:17` now points at the new filename.

## Acceptance (from #246)

- `grep -ri 'logichem' docs/SessionLogs/acceptance-matrix/` → zero hits ✅
- No plan, memory, or other-agenda pointer left referencing the old filenames. `docs/SessionLogs/**` session logs are the #239 historical carve-out and intentionally untouched.
- Landed before Run 03 begins (Run 03 still separately blocked by #234).

## Out of scope

- Hook file rename at `~/.claude/hooks/approve_logichem_bash.py` — tracked by #243.
- Illustrative `<real>` placeholder in `memory/feedback_no_real_client_names.md` — it's the rule's example, not a pointer.

## Test plan

- [x] `grep -ri 'logichem' docs/SessionLogs/acceptance-matrix/` returns zero matches
- [x] `git mv` detected as renames (not delete + add) — preserves history
- [x] GPG-signed commit (`e464942`), good signature
- [ ] PR merged via local `git merge --no-ff -S` per D4 from the 2026-04-20 minutes
- [ ] Close #246 with the merge commit hash

fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)