### PR TITLE
fix(destroy): hosts_map.yml byte-identical after add→remove (#253)

### DIFF
--- a/tools/pipeline/orchestration/hosts_map_remove.py
+++ b/tools/pipeline/orchestration/hosts_map_remove.py
@@ -17,7 +17,7 @@ def remove_from_hosts_map(
     """Delete the indented block for *hostname* from *hosts_map*."""
     text = hosts_map.read_text()
     pattern = rf'\n    {re.escape(hostname)}:\n(?:[ ]{{6}}[^\n]*\n)+'
-    new_text = re.sub(pattern, "\n", text)
+    new_text = re.sub(pattern, "", text)
     new_text = re.sub(r'\n{3,}', "\n\n", new_text)
     if new_text == text:
         emit(f"  [WARN] '{hostname}' block not found in hosts_map.yml — nothing removed")

--- a/tools/pipeline/orchestration/test_hosts_map_remove.py
+++ b/tools/pipeline/orchestration/test_hosts_map_remove.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Round-trip test: add→remove must leave hosts_map.yml byte-identical.
+
+Run directly: ``./tools/pipeline/orchestration/test_hosts_map_remove.py``
+Exit 0 on pass, 1 on fail. No pytest dependency.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.pipeline.orchestration.host_registration_block import (  # noqa: E402
+    MARKER, build_host_block,
+)
+from tools.pipeline.orchestration.hosts_map_remove import (  # noqa: E402
+    remove_from_hosts_map,
+)
+
+
+def test_round_trip_byte_identical(tmp_path: Path) -> None:
+    src = REPO_ROOT / "hosts_map.yml"
+    original_bytes = src.read_bytes()
+
+    work = tmp_path / "hosts_map.yml"
+    work.write_bytes(original_bytes)
+
+    block = build_host_block(
+        hostname="dev01", nickname="D1IRBL",
+        virbr0_ip="192.168.122.11", wg_ip="10.10.0.11",
+        hypervisor="toshiba", vm_role="dev:unspecified",
+        backend="kvm", zone="development",
+    )
+    text = work.read_text()
+    assert MARKER in text, f"marker {MARKER!r} must exist in hosts_map.yml"
+    work.write_text(text.replace(MARKER, block + MARKER))
+
+    remove_from_hosts_map("dev01", work, emit=lambda _m: None)
+
+    assert work.read_bytes() == original_bytes, (
+        "hosts_map.yml is not byte-identical after add→remove"
+    )
+
+
+def main() -> int:
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        test_round_trip_byte_identical(Path(td))
+    print("OK  add→remove round-trip is byte-identical")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -69,6 +69,7 @@
   "tools/pipeline/orchestration/snapshot_ops.py": 39,
   "tools/pipeline/orchestration/sops_key_remove.py": 73,
   "tools/pipeline/orchestration/template_metadata.py": 46,
+  "tools/pipeline/orchestration/test_hosts_map_remove.py": 57,
   "tools/pipeline/orchestration/verify_build_vm.py": 80,
   "tools/pipeline/orchestration/verify_vpn.py": 77,
   "tools/pipeline/orchestration/virsh.py": 15,


### PR DESCRIPTION
## Summary

- `tools/pipeline/orchestration/hosts_map_remove.py:20` — replace matched block with `""` instead of `"\n"`. The block emitted by `build_host_block` already contains its own leading `\n`; leaving a glue newline produces the stray blank line reported in #253.
- New colocated round-trip test `tools/pipeline/orchestration/test_hosts_map_remove.py` — asserts byte-identity after `build_host_block` → insert-at-MARKER → `remove_from_hosts_map`. Fails on `main`, passes on this branch.

## Scope

Fix A from #253's two-part triage. Fix B (`config/wireguard/keys.sops.yml` ciphertext rotation) is **not** in scope — sops encrypt is non-deterministic, and the manual `git checkout --` workaround is acceptable per the user's "not a perfection project" guidance. File a separate issue only if it becomes painful.

## Test plan

- [x] Colocated round-trip test passes: `./tools/pipeline/orchestration/test_hosts_map_remove.py` → `OK  add→remove round-trip is byte-identical`.
- [x] Ad-hoc reproducer from #253 body passes on this branch, fails on `main`.
- [x] `size_baselines.json` ratchet updated; both files under the 80-line cap (26 + 57).

Closes #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)