### PR TITLE
fix(sync_check): distinguish dormant VMs (#259)

### DIFF
--- a/hosts_map.yml
+++ b/hosts_map.yml
@@ -56,6 +56,7 @@ groups:
       backend: kvm
       hypervisor: toshiba
       vm_role: dev:unspecified
+      expected_state: "off"
       ansible_groups:
         - kvm
         - targets
@@ -74,6 +75,7 @@ groups:
       backend: kvm
       hypervisor: toshiba
       vm_role: dev:unspecified
+      expected_state: "off"
       ansible_groups:
         - kvm
         - targets
@@ -91,6 +93,7 @@ groups:
       backend: kvm
       hypervisor: toshiba
       vm_role: dev:unspecified
+      expected_state: "off"
       ansible_groups:
         - kvm
         - targets

--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -161,6 +161,26 @@ if [[ "${TOSHIBA_UP}" == true ]]; then
              fix "On toshiba: virsh --connect qemu:///system pool-start esacp"; }
 fi
 
+# Dormant VMs — expected_state=off in hosts_map.yml. Sections 7, 9, 11
+# downgrade ❌ to ⚠️ "dormant (expected off)" for these. Unsetting expected_state
+# (or setting it to "on") restores failure-on-unreachable semantics.
+DORMANT_VMS=$(python3 - "${PROJ_ROOT}/hosts_map.yml" <<'PYEOF'
+import yaml, sys
+d = yaml.safe_load(open(sys.argv[1]))
+for name, h in d.get('groups', {}).get('kvm', {}).items():
+    if str(h.get('expected_state', '')).lower() == 'off':
+        print(name)
+PYEOF
+)
+
+is_dormant() {
+    local vm="$1"
+    for d in ${DORMANT_VMS}; do
+        [[ "${d}" == "${vm}" ]] && return 0
+    done
+    return 1
+}
+
 # ── 7. VMs on toshiba ─────────────────────────────────────────────────────────
 hdr "7. VMs on toshiba"
 
@@ -170,7 +190,9 @@ if [[ "${TOSHIBA_UP}" == true ]]; then
     for vm in ${TOSHIBA_VMS}; do
         STATE=$(remote_toshiba "virsh --connect qemu:///system domstate ${vm} 2>/dev/null" \
             | tr -d '\n' || echo "unknown")
-        if [[ "${STATE}" == "running" ]]; then
+        if is_dormant "${vm}"; then
+            warn "VM '${vm}' — dormant (expected off), state: '${STATE}'"
+        elif [[ "${STATE}" == "running" ]]; then
             ok "VM '${vm}' — running"
         elif [[ "${STATE}" == "shut off" ]]; then
             fail "VM '${vm}' — shut off"
@@ -231,6 +253,8 @@ for label_ip in ${WG_PEERS}; do
     ip="${label_ip##*:}"
     if ping -c1 -W2 "${ip}" &>/dev/null; then
         ok "Ping ${label} (${ip}) — reachable"
+    elif is_dormant "${label}"; then
+        warn "Ping ${label} (${ip}) — dormant (expected off)"
     else
         fail "Ping ${label} (${ip}) — unreachable"
         fix "Check wg0 handshake and that ${label} VM is running on toshiba"
@@ -330,6 +354,8 @@ else
         [[ -z "${HTTP_CODE}" ]] && HTTP_CODE="000"
         if [[ "${HTTP_CODE}" =~ ^(200|301|302)$ ]]; then
             ok "ERPNext ${label} (${url}) — HTTP ${HTTP_CODE}"
+        elif [[ "${HTTP_CODE}" == "000" ]] && is_dormant "${label}"; then
+            warn "ERPNext ${label} (${url}) — dormant (expected off)"
         elif [[ "${HTTP_CODE}" == "000" ]]; then
             warn "ERPNext ${label} (${url}) — unreachable"
             fix "Check VM is running and nginx/bench are up on ${label}"


### PR DESCRIPTION
## Summary

- Adds \`expected_state: \"off\"\` field to \`hosts_map.yml\` entries for dev02, dev03, target5 (string-quoted — bare \`off\` parses as boolean False in YAML).
- \`platforms/kvm/sync_check.sh\` reads this field and emits ⚠️ \"dormant (expected off)\" instead of ❌ in sections 7 (virsh domstate), 9 (WG ping), and 11 (ERPNext HTTPS).
- Unsetting the field (or \`expected_state: \"on\"\`) restores failure-on-unreachable semantics.

## Before / after

\`bash platforms/kvm/sync_check.sh\` with all three idle VMs shut off on toshiba:

| | Before | After |
|---|---|---|
| Section 7 dev02/dev03/target5 | ⚠️ empty state | ⚠️ dormant (expected off) |
| Section 9 ping dev02/dev03/target5 | **❌ unreachable** | ⚠️ dormant (expected off) |
| Section 11 HTTPS dev02/dev03/target5 | ⚠️ unreachable + generic fix msg | ⚠️ dormant (expected off) |
| Summary | 45 ✅ / 9 ⚠️ / **3 ❌**, exit 1 | 44 ✅ / 13 ⚠️ / **0 ❌**, exit 0 |

## Compatibility

- Matrix specs use \`execSync\` + try/catch on \`sync_check.sh\` and grep specific rows (\`REQUIRED_SYNC_ROWS\` in accept-01, dev01 ERPNext row in accept-02/03/04). None of those rows are affected.
- Self-check 0b regex \`/[✅❌]/\` still matches — ✅ rows preserved.
- No SOPS files touched.

## Test plan

- [x] \`bash platforms/kvm/sync_check.sh\` exits 0, 0 ❌
- [x] dev01 row still ✅ when dev01 up
- [x] \`python3 -c \"import yaml; yaml.safe_load(open('hosts_map.yml'))\"\` parses \`expected_state\` as string \`'off'\`, not boolean
- [ ] Matrix Run 05 self-check 0b passes (will verify on next matrix run)

fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)