### PR TITLE
test(accept-matrix): Run 05 UI full company-specific — GREEN (fixes #265)

### DIFF
--- a/docs/SessionLogs/acceptance-matrix/params/05-ui-full-company-specific.yml
+++ b/docs/SessionLogs/acceptance-matrix/params/05-ui-full-company-specific.yml
@@ -1,0 +1,32 @@
+# Matrix Run 05 parameters — UI full company-specific ERPNext from golden backup.
+#
+# Parity partner: Run 02 (CLI). Canary assertions MUST match 02 exactly.
+#
+# UI lifecycle:
+#   1. Destroy dev01 via right-click → Destroy → confirm (if present at baseline).
+#   2. Drag tpl-erpnext-restored tile into Development zone.
+#   3. Fill Deploy dialog (hostname, nickname, wg_ip, virbr0_ip, hypervisor, backend,
+#      zone). Submit. Single atomic register+build.
+#
+# Administrator credential: spec derives it from config/build_secrets.sops.yml
+# (field erp_user_pwd). See memory/feedback_lab_admin_password.md.
+#
+# Transport asymmetry (noted, non-blocker): main.js:1828 forces vm_role=dev:unspecified
+# for the development zone; Run 02 CLI used dev:full_company_specific. Acceptance
+# does not assert vm_role — canary is the parity check.
+run: "05"
+transport: ui
+target_vm: dev01
+target_nickname: dev0
+target_wg_ip: "10.10.0.16"
+target_virbr0_ip: "192.168.122.26"
+variant: full_company_specific
+backup_source: golden_production
+zone: development
+hypervisor: toshiba
+backend: kvm
+wait_budget_seconds: 3000
+topology_convergence_budget_seconds: 300
+canary_doctype: Item
+canary_name: "Test Item"
+canary_app_url_path: "/app/item/Test%20Item"

--- a/prototypes/cytoscape/tests/accept-05-ui-full-company-specific.spec.js
+++ b/prototypes/cytoscape/tests/accept-05-ui-full-company-specific.spec.js
@@ -1,0 +1,270 @@
+// @ts-check
+import { test, expect } from '@playwright/test'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { BASE_URL, API_URL, waitForGraph, selectNode, clickInfoButton, waitForJob } from './helpers.js'
+
+/**
+ * Acceptance Run 05 — UI dev VM, full company-specific ERPNext from golden production backup.
+ *
+ * UI drag-to-deploy lifecycle (parity partner: Run 02 CLI):
+ *   1. Destroy existing dev01 via Cytoscape: selectNode → Destroy → confirm.
+ *   2. Drag tpl-erpnext-restored tile into Dev zone → Deploy from Template dialog.
+ *   3. Fill hostname/nickname/IPs/hypervisor/zone → submit → wait for job.
+ *
+ * Plan:    ~/.claude/plans/acceptance-matrix-transport-parity.md
+ * Agenda:  docs/SessionLogs/acceptance-matrix/05-ui-vm-full-company-specific-from-backup.md
+ * Params:  docs/SessionLogs/acceptance-matrix/params/05-ui-full-company-specific.yml
+ *
+ * Parity partner: Run 02 (CLI). Canary asserted verbatim for transport parity.
+ *
+ * Administrator password: derived automatically from config/build_secrets.sops.yml
+ * (field erp_user_pwd). Pipeline resets Administrator post-restore.
+ */
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname  = path.dirname(__filename)
+const PROJECT_ROOT = path.resolve(__dirname, '../../..')
+const PARAM_PATH = path.join(
+  PROJECT_ROOT,
+  'docs/SessionLogs/acceptance-matrix/params/05-ui-full-company-specific.yml'
+)
+const BUILD_SECRETS_PATH = path.join(PROJECT_ROOT, 'config/build_secrets.sops.yml')
+
+function loadParams() {
+  const raw = readFileSync(PARAM_PATH, 'utf8')
+  const params = {}
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*([a-z_]+)\s*:\s*(.+?)\s*$/)
+    if (!m) continue
+    const [, k, v] = m
+    const quoted = v.match(/^["'](.*)["']$/)
+    if (quoted) { params[k] = quoted[1]; continue }
+    if (/^-?\d+$/.test(v)) params[k] = parseInt(v, 10)
+    else if (v === 'true' || v === 'false') params[k] = v === 'true'
+    else params[k] = v
+  }
+  return params
+}
+
+function decryptBuildSecret(key) {
+  const raw = execSync(`sops -d ${BUILD_SECRETS_PATH}`, {
+    cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  for (const line of raw.split('\n')) {
+    const m = line.match(new RegExp(`^\\s*${key}\\s*:\\s*(.+?)\\s*$`))
+    if (!m) continue
+    const v = m[1].trim()
+    const quoted = v.match(/^["'](.*)["']$/)
+    return quoted ? quoted[1] : v
+  }
+  throw new Error(`${key} not found in decrypted ${BUILD_SECRETS_PATH}`)
+}
+
+function runSyncCheck() {
+  try {
+    return execSync('bash platforms/kvm/sync_check.sh', {
+      cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (err) {
+    return err.stdout || ''
+  }
+}
+
+const params = loadParams()
+const TARGET_URL = `https://${params.target_vm}.iridium.blue`
+const CANARY_URL = `${TARGET_URL}${params.canary_app_url_path}`
+
+test.use({ headless: process.env.HEADED !== '1' })
+
+test.describe('Acceptance Run 05 — UI full company-specific ERPNext', () => {
+  test.setTimeout(
+    (params.wait_budget_seconds + params.topology_convergence_budget_seconds + 900) * 1000
+  )
+
+  test('self-check + UI destroy + drag-deploy dev01 — job completes, UI converges, ERPNext canary reachable', async ({ page, browser }) => {
+    // ── Step 0: self-check ─
+    console.log('[accept-05] self-check: validating harness assumptions')
+    let ADMIN_PWD
+    try {
+      ADMIN_PWD = decryptBuildSecret('erp_user_pwd')
+    } catch (err) {
+      throw new Error(
+        `self-check 0a failed: cannot decrypt ${BUILD_SECRETS_PATH}. ` +
+        `Underlying: ${err.message}`
+      )
+    }
+    expect(ADMIN_PWD, 'erp_user_pwd from build_secrets.sops.yml').toBeTruthy()
+
+    const selfSync = runSyncCheck()
+    expect(
+      selfSync,
+      'self-check 0b: sync_check.sh output must contain row markers (✅/❌)'
+    ).toMatch(/[✅❌]/)
+
+    const apiResp = await page.request.get(`${API_URL}/api/hosts`)
+    expect(apiResp.ok(), 'self-check 0c: Cytoscape API /api/hosts').toBe(true)
+
+    const viteResp = await page.request.get(BASE_URL)
+    expect(viteResp.ok(), `self-check 0d: Vite ${BASE_URL}`).toBe(true)
+
+    try {
+      execSync(`ssh -o BatchMode=yes -o ConnectTimeout=5 ${params.hypervisor} true`, {
+        cwd: PROJECT_ROOT, stdio: ['ignore', 'ignore', 'pipe'],
+      })
+    } catch (err) {
+      throw new Error(`self-check 0e failed: cannot SSH to ${params.hypervisor}: ${err.message}`)
+    }
+
+    console.log('[accept-05] self-check OK — proceeding to baseline/destroy')
+
+    // ── Step 1: baseline + destroy via UI (idempotent clean slate) ─
+    await page.goto(BASE_URL)
+    await waitForGraph(page)
+
+    const baselineResp = await page.request.get(`${API_URL}/api/hosts`)
+    const baseline = await baselineResp.json()
+    const existing = baseline.hosts.find(h => h.hostname === params.target_vm)
+    if (existing) {
+      console.log(`[accept-05] ${params.target_vm} present at baseline — destroying via UI`)
+      await selectNode(page, params.target_vm)
+      await clickInfoButton(page, 'Destroy')
+      await page.waitForSelector('#confirm-overlay:not(.hidden)', { timeout: 5_000 })
+      const confirmBody = await page.textContent('#confirm-body')
+      expect(confirmBody).toContain(params.target_vm)
+      await page.click('#confirm-submit')
+      await page.waitForSelector('#confirm-overlay', { state: 'hidden', timeout: 10_000 })
+
+      // Wait for destroy job to finish before asserting absence.
+      await page.waitForTimeout(3_000)
+      const destroyJobsResp = await page.request.get(`${API_URL}/api/jobs`)
+      const destroyJobs = await destroyJobsResp.json()
+      const [destroyJobId] = Object.entries(destroyJobs).find(
+        ([, j]) => j.hostname === params.target_vm && j.status === 'running'
+      ) || []
+      if (destroyJobId) {
+        await waitForJob(page, destroyJobId, 300_000)
+      }
+
+      const afterDestroyResp = await page.request.get(`${API_URL}/api/hosts`)
+      const afterDestroy = await afterDestroyResp.json()
+      const stillThere = afterDestroy.hosts.find(h => h.hostname === params.target_vm)
+      expect(stillThere, `${params.target_vm} must be ABSENT after destroy`).toBeFalsy()
+
+      // Rehydrate Cytoscape from post-destroy /api/hosts — bypasses stale 30s poll (#249)
+      await page.reload()
+      await waitForGraph(page)
+    } else {
+      console.log(`[accept-05] ${params.target_vm} absent at baseline — nothing to destroy`)
+    }
+
+    const onGraphAtBaseline = await page.evaluate((h) => {
+      const cy = document.querySelector('#cy')?._cyreg?.cy
+      return cy ? !cy.$(`#${h}`).empty() : false
+    }, params.target_vm)
+    expect(onGraphAtBaseline, `${params.target_vm} must be absent from Cytoscape at baseline`).toBe(false)
+
+    // ── Step 2: UI drag-to-deploy ─
+    console.log(`[accept-05] drag tpl-erpnext-restored into Dev zone for ${params.target_vm}`)
+    await page.evaluate(() => {
+      const cy = document.querySelector('#cy')?._cyreg?.cy
+      if (!cy) throw new Error('Cytoscape instance not found')
+      const tpl = cy.$('#tpl-erpnext-restored')
+      if (tpl.empty()) throw new Error('Restored ERPNext template tile not found')
+      // Dev zone = right half, top (x > splitX, y < splitY). 600/200 is safely inside.
+      tpl.position({ x: 600, y: 200 })
+      tpl.emit('dragfree')
+    })
+
+    await page.waitForSelector('#dialog-overlay:not(.hidden)', { timeout: 5_000 })
+
+    await page.fill('#f-hostname', params.target_vm)
+    await page.fill('#f-nickname', params.target_nickname)
+    await page.fill('#f-wg-ip', params.target_wg_ip)
+    await page.fill('#f-virbr0-ip', params.target_virbr0_ip)
+    await page.fill('#f-hypervisor', params.hypervisor)
+    await page.selectOption('#f-backend', params.backend)
+    await page.selectOption('#f-zone', params.zone)
+
+    const siteUrl = page.locator('#site-url-preview')
+    if (await siteUrl.isVisible()) {
+      await expect(siteUrl).toContainText(`${params.target_vm}.iridium.blue`)
+    }
+
+    await page.click('#dialog-submit')
+    await page.waitForSelector('#dialog-overlay', { state: 'hidden', timeout: 10_000 })
+
+    // ── Step 3: capture provision job id + wait for completion ─
+    await page.waitForTimeout(3_000)
+    const jobsResp = await page.request.get(`${API_URL}/api/jobs`)
+    const jobs = await jobsResp.json()
+    const [jobId] = Object.entries(jobs).find(
+      ([, j]) => j.hostname === params.target_vm && j.status === 'running'
+    ) || []
+    expect(jobId, `provision job for ${params.target_vm} must be running after Deploy submit`).toBeTruthy()
+
+    console.log(`[accept-05] provision job ${jobId} — waiting up to ${params.wait_budget_seconds}s`)
+    const startedAt = Date.now()
+    await waitForJob(page, jobId, params.wait_budget_seconds * 1000)
+    const provisionSeconds = Math.round((Date.now() - startedAt) / 1000)
+    console.log(`[accept-05] provision job finished after ${provisionSeconds}s`)
+
+    // ── Step 4: topology convergence ─
+    console.log(`[accept-05] awaiting UI convergence within ${params.topology_convergence_budget_seconds}s`)
+    const convergenceStart = Date.now()
+    await expect(async () => {
+      const r = await page.request.get(`${API_URL}/api/hosts`)
+      const data = await r.json()
+      const h = data.hosts.find(x => x.hostname === params.target_vm)
+      expect(h, `${params.target_vm} in /api/hosts`).toBeTruthy()
+      expect(h.provisioned, `${params.target_vm} provisioned`).toBe(true)
+      expect(h.vm_state, `${params.target_vm} vm_state`).toBe('running')
+    }).toPass({
+      timeout: params.topology_convergence_budget_seconds * 1000,
+      intervals: [5_000],
+    })
+    const convergenceSeconds = Math.round((Date.now() - convergenceStart) / 1000)
+    console.log(`[accept-05] UI converged after ${convergenceSeconds}s`)
+
+    const uiPresent = await page.evaluate((h) => {
+      const cy = document.querySelector('#cy')?._cyreg?.cy
+      return cy ? !cy.$(`#${h}`).empty() : false
+    }, params.target_vm)
+    expect(uiPresent, `${params.target_vm} must appear in Cytoscape after convergence`).toBe(true)
+
+    // ── Step 5: ERPNext canary — login + Test Item (parity with Run 02) ─
+    console.log(`[accept-05] canary: login as Administrator + GET ${params.canary_app_url_path}`)
+    const erp = await browser.newContext()
+    try {
+      const login = await erp.request.post(`${TARGET_URL}/api/method/login`, {
+        form: { usr: 'Administrator', pwd: ADMIN_PWD },
+      })
+      expect(login.ok(), `ERPNext login (HTTP ${login.status()})`).toBe(true)
+
+      const itemResp = await erp.request.get(
+        `${TARGET_URL}/api/resource/${encodeURIComponent(params.canary_doctype)}/${encodeURIComponent(params.canary_name)}`
+      )
+      expect(
+        itemResp.ok(),
+        `${params.canary_doctype}/${params.canary_name} REST (HTTP ${itemResp.status()})`
+      ).toBe(true)
+      const itemBody = await itemResp.json()
+      expect(itemBody?.data?.name, 'canary doc name').toBe(params.canary_name)
+
+      const erpPage = await erp.newPage()
+      await erpPage.goto(CANARY_URL, { waitUntil: 'networkidle' })
+      await expect(erpPage.locator('body')).toContainText(params.canary_name)
+    } finally {
+      await erp.close()
+    }
+
+    // ── Step 6: sync_check — assert specific dev01 row ─
+    const syncOut = runSyncCheck()
+    expect(
+      syncOut,
+      `sync_check ERPNext row for ${params.target_vm} must be ✅`
+    ).toContain(`✅  ERPNext ${params.target_vm} (${TARGET_URL})`)
+  })
+})

--- a/prototypes/cytoscape/tests/accept-05-ui-full-company-specific.spec.js
+++ b/prototypes/cytoscape/tests/accept-05-ui-full-company-specific.spec.js
@@ -37,7 +37,7 @@ function loadParams() {
   const raw = readFileSync(PARAM_PATH, 'utf8')
   const params = {}
   for (const line of raw.split('\n')) {
-    const m = line.match(/^\s*([a-z_]+)\s*:\s*(.+?)\s*$/)
+    const m = line.match(/^\s*([a-z0-9_]+)\s*:\s*(.+?)\s*$/)
     if (!m) continue
     const [, k, v] = m
     const quoted = v.match(/^["'](.*)["']$/)


### PR DESCRIPTION
## Summary

- Matrix Run 05 (UI transport, full company-specific ERPNext from golden production backup) GREEN — 1 passed, 30.4m.
- Fixes #265 — spec's YAML params parser regex `[a-z_]+` silently skipped `target_virbr0_ip` (digit in key).

## Run 05 outcome

```
[accept-05] self-check OK — proceeding to baseline/destroy
[accept-05] dev01 absent at baseline — nothing to destroy
[accept-05] drag tpl-erpnext-restored into Dev zone for dev01
[accept-05] provision job 2b156924 — waiting up to 3000s
[accept-05] provision job finished after 1767s (29.5m)
[accept-05] awaiting UI convergence within 300s
[accept-05] UI converged after 1s
[accept-05] canary: login as Administrator + GET /app/item/Test%20Item
  ✓  accept-05 (30.4m)
```

Parity partner Run 02 (CLI) took 27.7m; Run 05 UI 30.4m — comparable.

### Canary (parity with Run 02)

- Admin login: HTTP 200
- REST `/api/resource/Item/Test%20Item`: HTTP 200, `data.name = "Test Item"`
- Desk `/app/item/Test%20Item`: body contains `Test Item`

### sync_check post-run

```
✅  VM 'dev01' — running
✅  Ping dev01 (10.10.0.16) — reachable
✅  ERPNext dev01 (https://dev01.iridium.blue) — HTTP 200
✅ Passed: 43  ⚠️  Warnings: 14  ❌ Failed: 0
```

## Session narrative (for audit)

1. Session opened; last session had crashed mid-Run-05. Working tree had uncommitted dev01 deregistration (destroy-half executed via CLI on crash). dev01 absent from toshiba.
2. Option A selected: restore pre-Run-05 state. `git restore` reverted the 4 uncommitted config files; `./tools/esacp.py provisionGeneric dev01 --wizard-mode existing --wizard-arg 20260420_142102-dev01_iridium_blue.tgz` rebuilt dev01 from the Run 04 B03 backup.
3. Run 05 Playwright attempt 1 — crashed at spec line 186 (`params.target_virbr0_ip` undefined). dev01 destroyed via UI (Step 1 succeeded).
4. Root-cause analysis: spec's `loadParams()` regex `[a-z_]+` rejects digit-containing keys. Audited all 5 acceptance specs — bug is shared but only Run 05's params contains a digit-key (`target_virbr0_ip`, from canonical libvirt bridge name `virbr0`). Runs 01–04 used CLI transport and never crossed the Node/YAML boundary with a digit key. Issue #265 filed with full analysis.
5. Narrow fix applied to Run 05 spec only; copies in 01–04 left dormant (archival; failure mode is loud-crash, not silent-corruption).
6. Run 05 Playwright attempt 2 — GREEN (dev01 absent at baseline, idempotent skip on destroy, full drag-to-deploy + golden-production restore).

## Commits

- `fce6819` test(accept-05): scaffold UI full company-specific spec + params (pre-existing)
- `05d96b1` fix(accept-05): parse params keys containing digits — fixes #265

## Working tree note

3 files modified post-run (`ansible/group_vars/all.yml`, `config/wireguard/keys.sops.yml`, `hosts_map.yml`) — the expected dev01 runtime churn. Matches Run 02/03/04 discipline — uncommitted, absorbed by Run 06's destroy+rebuild. Tracked by #241 for the long-term `hosts_map.local.yml` overlay fix.

## Test plan

- [x] sync_check clean (0 ❌)
- [x] Playwright spec passes
- [x] ERPNext canary REST + desk both reachable
- [x] Parity partner (Run 02) canary match — `Item / Test Item` reachable under Administrator credentials from `build_secrets.sops.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)