### PR TITLE
fix(helpers): waitForJob recognises status='error' as terminal (#268)

### DIFF
--- a/prototypes/cytoscape/tests/helpers.js
+++ b/prototypes/cytoscape/tests/helpers.js
@@ -25,6 +25,11 @@ export async function clickInfoButton(page, buttonText) {
   await btn.click()
 }
 
+// Job status contract — see tools/job_worker.py:84,86,88 and tools/api/jobs.py:53
+//   'running' — non-terminal (default when status file absent)
+//   'done'    — success (job_worker exit 0)
+//   'error'   — failure (exception raised OR unknown job type)
+// Any other value is treated as unexpected and fails fast on the next poll.
 export async function waitForJob(page, jobId, timeoutMs = 2_100_000) {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
@@ -32,8 +37,9 @@ export async function waitForJob(page, jobId, timeoutMs = 2_100_000) {
     const jobs = await resp.json()
     const job = jobs[jobId]
     if (!job) throw new Error(`Job ${jobId} not found`)
-    if (job.status === 'done') return job
-    if (job.status === 'failed') throw new Error(`Job ${jobId} failed`)
+    if (job.status === 'done')  return job
+    if (job.status === 'error') throw new Error(`Job ${jobId} errored`)
+    if (job.status !== 'running') throw new Error(`Job ${jobId} unexpected status '${job.status}'`)
     await page.waitForTimeout(5_000)
   }
   throw new Error(`Job ${jobId} timed out after ${timeoutMs}ms`)


### PR DESCRIPTION
## Summary

- Add `'error'` recognition to `prototypes/cytoscape/tests/helpers.js:waitForJob()` so it exits within ≤5s of a terminal job status, not after the outer timeout.
- Drop the dormant `'failed'` branch — backend never emits it; keeping it implied a contract that does not exist.
- Add a defensive guard: any status other than `'running'` or the terminal pair fails fast on the next poll.
- Header comment documents the full terminal-status contract with references to `tools/job_worker.py:84,86,88` and `tools/api/jobs.py:53`.

## Why

Run 06 attempt 1 (2026-04-21, job `9c821e47`) errored at T+10m; `waitForJob` kept polling until manual SIGTERM at T+29m — burned ~20 minutes of test wall-clock after the job was already dead.

This is the first of three sequenced sessions to unblock Matrix Run 06: **#268 → #267 → Run 06 attempt 2**. Fixing the flake-detector first so any future iteration of #267's fix fails fast and cheaply.

## Test plan

- [x] Diff review: single-file change, ≤10 lines
- [x] Backend contract surveyed: `job_worker.py` emits `done` / `error`; `api/jobs.py` defaults to `running`. No other terminal values exist.
- [ ] Behavioural verification: any acceptance-matrix spec run after merge — error-state jobs now surface within one poll interval (5s).

fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)