### PR TITLE
fix(wizard): DOM-mutate Manufacturing checkbox to close modal race (#267)

### DIFF
--- a/prototypes/cytoscape/recordings/wizard/pseudo-co-wizard.spec.js
+++ b/prototypes/cytoscape/recordings/wizard/pseudo-co-wizard.spec.js
@@ -28,19 +28,33 @@ const { chromium } = require('playwright');
   await page.getByRole('textbox').nth(1).press('Tab');
   await page.locator('input[type="password"]').fill('sasa');
   await page.getByRole('button', { name: 'Next' }).click();
-  // Flake guard: the Industry page occasionally shows a Bootstrap welcome
-  // modal that intercepts pointer events on the checkbox (attempts 3 and 5
-  // of #256 blocked > 30s here). Wait for Frappe's AJAX freeze to clear,
-  // then Escape-dismiss any lingering modal before the checkbox click.
+  // Wait for Frappe's AJAX freeze overlay to clear before Industry-page
+  // interaction (#256 flake guard — does not cover the welcome-modal race,
+  // which is handled below).
   await page.waitForFunction(
     () => !document.querySelector('#freeze.modal-backdrop.in'),
     null, { timeout: 30_000 },
   );
-  if (await page.locator('.modal.fade.show').count()) {
-    await page.keyboard.press('Escape');
-    await page.waitForSelector('.modal.fade.show', { state: 'detached', timeout: 10_000 });
+  // Fixes #267. Run 06 attempt 1 showed the welcome modal can materialise
+  // DURING Playwright's .check() retry loop, not just before it — a
+  // pre-click Escape guard cannot see the future. Resolve the checkbox
+  // via the role locator, then mutate it directly in the page origin:
+  // the assignment + event dispatch runs synchronously and does not
+  // compete with any overlay. Verify via isChecked() so that if Frappe
+  // did not observe the change (e.g. custom component swallowing native
+  // events), we fail immediately instead of passing a broken wizard.
+  const mfgCheckbox = page.getByRole('checkbox', { name: 'Manufacturing' });
+  await mfgCheckbox.waitFor({ state: 'attached', timeout: 30_000 });
+  await mfgCheckbox.evaluate((cb) => {
+    if (!cb.checked) {
+      cb.checked = true;
+      cb.dispatchEvent(new Event('input',  { bubbles: true }));
+      cb.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+  if (!(await mfgCheckbox.isChecked())) {
+    throw new Error('Manufacturing checkbox did not register as checked after DOM mutation');
   }
-  await page.getByRole('checkbox', { name: 'Manufacturing' }).check();
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByRole('textbox').first().fill('Pseudo-Co');
   await page.getByRole('textbox').first().press('Tab');


### PR DESCRIPTION
## Summary

Fixes #267. The shared wizard recording `prototypes/cytoscape/recordings/wizard/pseudo-co-wizard.spec.js` had a pre-click modal-dismiss guard that ran **once** at T=0 before `.check()` on the Industry-page Manufacturing checkbox. Run 06 attempt 1 (job `9c821e47`, 2026-04-21) exposed a failure mode the guard does not cover: the welcome modal materialises **during** Playwright's `.check()` retry loop, not before it. Playwright's built-in retries burn the 30 s actionability budget clicking the modal overlay and time out. Run 03 has passed to date only by timing luck on the same shared recording.

## Approach — DOM mutation via role-resolved locator

Replace the pre-click guard + `.check()` with a role-locator-resolved DOM mutation (`input`/`change` event dispatch) + post-condition `isChecked()` verification.

```js
const mfgCheckbox = page.getByRole('checkbox', { name: 'Manufacturing' });
await mfgCheckbox.waitFor({ state: 'attached', timeout: 30_000 });
await mfgCheckbox.evaluate((cb) => {
  if (!cb.checked) {
    cb.checked = true;
    cb.dispatchEvent(new Event('input',  { bubbles: true }));
    cb.dispatchEvent(new Event('change', { bubbles: true }));
  }
});
if (!(await mfgCheckbox.isChecked())) {
  throw new Error('Manufacturing checkbox did not register as checked after DOM mutation');
}
```

The assignment + event dispatch runs synchronously inside the page origin; no Playwright actionability model sits between us and the DOM, so an overlay cannot intercept. The post-condition `isChecked()` fails fast if Frappe swallowed the native events (e.g. custom component), instead of silently passing a broken wizard.

## Options considered and rejected

- **Pre-click wait on positive signal** — improves on current guard but shrinks the race window rather than closing it; modal can still appear between the wait and the dispatch.
- **`{ force: true }` click** — wrong mechanism: skips actionability but still clicks at screen coordinates, so an overlaying modal receives the click, not the checkbox. False-positive risk.
- **Dismiss-on-intercept retry loop** — more moving parts, still race-susceptible within each attempt window, brittle if Frappe introduces a new modal variant that does not respond to Escape.

## Preserved

The `#256`-era `#freeze.modal-backdrop.in` wait stays — it addresses Frappe's AJAX freeze overlay, which is a separate concern from the welcome-modal race.

## Scope

Single-file change to the shared wizard recording. Both Run 03 (CLI, currently green but latent-flake) and Run 06 (UI, currently blocked) consume it; one fix hardens both.

## Acceptance

Per the issue: Run 06 GREEN on the fixed recording, Run 03 re-run GREEN (parity preservation). Both are acceptance-matrix sessions, out of scope for this PR — same pattern as PR #269 (#268's helper fix). Runtime validation is **Run 06 attempt 2** in the next session.

Closes #267.

## Test plan

- [ ] Static: `node --check` on the edited spec ✅ (confirmed locally before commit)
- [ ] Runtime: Run 06 attempt 2 — deferred to next session (Playwright replay-wizard via Cytoscape UI path)
- [ ] Regression check: Run 03 re-run — optional follow-up; same code path, so Run 06 green implies Run 03 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)