### PR TITLE
chore(housekeeping): CC-OPS sweep — fixes #213 #238 #243 #188

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/session_close_audit.sh",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/session_close_audit.sh",
             "timeout": 5,
             "statusMessage": "Checking for session-close signals…"
           }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,19 @@ Common scopes: `kvm`, `vbox`, `observability`, `wireguard`, `ansible`, `claude`,
 
 **Existing violations**: None — G-pre, H4e, and H4a have all been migrated to standalone Python scripts in `tools/vm_scripts/`.
 
+## Invoke scripts as executables
+
+Every script under `tools/` has `#!/usr/bin/env python3` and is `chmod +x`.
+Run them directly:
+
+- ✓ `./tools/esacp.py confirmPrerequisites`
+- ✗ `python tools/esacp.py …` (no `python` on PATH)
+- ✗ `python3 tools/esacp.py …` (bypasses the shebang contract)
+
+Covers `esacp.py`, `generate_inventory.py`, `host_identity.py`, pipeline
+scripts, and every other shebanged Python file. Rationale + recurrence
+history: `feedback_invoke_as_executable.md` in project memory (#188).
+
 ## Function and script size limits
 
 Any function or standalone script over **50 lines** needs decomposition. This is a gradient, not a cliff:

--- a/tools/pre_commit_size_check.py
+++ b/tools/pre_commit_size_check.py
@@ -108,14 +108,6 @@ def main():
                 baselines[filepath] = lines
                 baselines_changed = True
 
-    if baselines_changed:
-        save_baselines(baselines)
-        # Auto-stage the updated baselines file so it's included in the commit.
-        subprocess.run(
-            ["git", "add", str(BASELINES_FILE)],
-            cwd=REPO_ROOT,
-        )
-
     if violations:
         print("Anti-spiral size check FAILED:")
         print()
@@ -125,6 +117,16 @@ def main():
         print("Dispatcher/pipeline files must not grow. Extract logic to")
         print("tools/pipeline/ and delete the old code in the same commit.")
         return 1
+
+    # Persist baselines only when the commit will proceed. Writing on the
+    # failure path (#238) locks in baselines for files that never shipped,
+    # and the auto-stage pollutes the working tree.
+    if baselines_changed:
+        save_baselines(baselines)
+        subprocess.run(
+            ["git", "add", str(BASELINES_FILE)],
+            cwd=REPO_ROOT,
+        )
 
     return 0
 


### PR DESCRIPTION
## Summary

Phase 1A of the post-matrix open-issues purge (`~/.claude/plans/open-issues-purge.md`).
Housekeeping bundle under the #262 amendment — four issues, one sweep branch, zero matrix-SUT impact.

fixes #213
fixes #238
fixes #243
fixes #188

## What landed

**In-repo**
- **#213** — `.claude/settings.json`: `session_close_audit` hook now resolves via `${CLAUDE_PROJECT_DIR}/.claude/hooks/session_close_audit.sh`. Matching allow entry also updated in `.claude/settings.local.json` (gitignored, not in this commit).
- **#238** — `tools/pre_commit_size_check.py`: baseline persistence + auto-stage moved below the violation-exit branch. Blocked commits no longer freeze a baseline for a file that never shipped.
- **#188** — `CLAUDE.md`: added an **Invoke scripts as executables** section that promotes the rule from operator memory into the in-repo instruction set.

**Operator-local (outside repo, documented here for the record)**
- **#243** — renamed `~/.claude/hooks/approve_logichem_bash.py` → `~/.claude/hooks/approve_bespoke_bash.py`; `~/.claude/settings.json` updated; `feedback_compound_cmd_hook.md` (CC memory dir) scrubbed of the legacy token and its carve-out note.

## Matrix blast-radius

Zero. Nothing touches pipeline SUT, acceptance fixtures, or anything covered by the 7-run transport-parity matrix. Sweep-bundle acts as the litmus test for the #262 amendment.

## Test plan

- [x] `./tools/pre_commit_size_check.py` exits 0 on a no-staged-changes invocation
- [x] Commit on this branch itself runs cleanly through the size-check hook (no baseline churn)
- [x] GPG-signed commit verified (`gpg: Good signature`)
- [ ] Next CC session opened on this repo emits **no** `UserPromptSubmit` "not found" warning (verifies #213 at runtime)
- [ ] Compound `cd && git` still auto-approves under the new hook name (verifies #243 at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)