### PR TITLE
fix(cli): call snapshot_ops primitive instead of subprocess (#206)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,7 +41,7 @@ tasks, ❌ fatal errors, and the PLAY RECAP summary. All other Ansible output is
 All check targets (jobs, nodenames, datasource UIDs, dashboard titles) are derived
 from the project's own config files — nothing is hardcoded in the script.
 
-**`snapShotVM` is KVM-only**: hardwired to `platforms/kvm/snapshot.py` → `virsh`.
+**`snapShotVM` is KVM-only**: dispatcher calls `tools/pipeline/orchestration/snapshot_ops.py` (local virsh). The standalone `platforms/kvm/snapshot.py` tool still provides revert/delete/start/state for operator use.
 
 ---
 

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -22,7 +22,6 @@ pipeline primitive, format output. Business logic lives in
 
 Subprocess is banned in dispatchers except:
 1. `tools/api/jobs.py` — `subprocess.Popen` to spawn `tools/job_worker.py`
-2. `tools/cli/snapshot_vm.py` — documented #206 deferral
 
 The pre-commit ratchet (`tools/pre_commit_size_check.py`) enforces the caps.
 
@@ -101,7 +100,7 @@ Non-obvious behaviours:
 - `provisionVM` Ansible output filter: shows PLAY headers, ✓ ok, ★ changed, ❌ fatal, RECAP only (filter lives in `tools/pipeline/stages/common/ansible_output.py`; orchestrator is `tools/pipeline/orchestration/ansible_provision.py`)
 - `validateObservability` credential order: `GRAFANA_ADMIN_USER`/`GRAFANA_ADMIN_PASSWORD` env vars → SSH hub `/opt/observability/.env` → interactive prompt
 - `buildVM`: uses `virsh vol-create-as` + `virsh vol-upload` for seed ISO — not `sudo cp` (hangs in uvicorn threads)
-- `snapShotVM`: KVM-only, hardwired to `platforms/kvm/snapshot.py` → `virsh` (#206 — pending extraction to a snapshot primitive)
+- `snapShotVM`: KVM-only; dispatcher calls `pipeline/orchestration/snapshot_ops.py` (local virsh). Standalone `platforms/kvm/snapshot.py` still exists for operator use (revert/delete/start/state) per `docs/BuildOutProcedure.md`.
 - `destroyVM` (legacy, local libvirt only): uses `tools/pipeline/orchestration/local_vm_teardown.py` for inspect + teardown; not to be confused with `destroy` which runs the full `macro/destroy.py`
 
 ## diagnose.py — Remote VM Process Diagnostics

--- a/tools/cli/snapshot_vm.py
+++ b/tools/cli/snapshot_vm.py
@@ -1,29 +1,27 @@
-"""CLI: create or list KVM VM snapshots.
-
-Note: this module contains a direct ``subprocess.run`` call to
-``platforms/kvm/snapshot.py`` — this is a documented Phase 7 exception
-tracked in GitHub issue #206, pending extraction to a pipeline primitive.
-"""
+"""CLI: create or list KVM VM snapshots via the snapshot_ops primitive (#206)."""
 
 from __future__ import annotations
 
-import subprocess
-from pathlib import Path
-
 from tools.cli._common import banner
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-SNAPSHOT_PY  = PROJECT_ROOT / "platforms" / "kvm" / "snapshot.py"
+from tools.pipeline.orchestration import snapshot_ops
 
 
 def run(args, config: dict) -> int:
-    vm   = args.vm
+    vm = args.vm
     name = args.name
 
     if name:
         banner(f"Snapshot: {vm} / {name}")
-        r = subprocess.run(["python3", str(SNAPSHOT_PY), "create", vm, name])
-    else:
-        banner(f"Snapshots: {vm}")
-        r = subprocess.run(["python3", str(SNAPSHOT_PY), "list", vm])
-    return r.returncode
+        if name in snapshot_ops.list_snapshots(vm):
+            print(f"  Snapshot '{name}' already exists on {vm} — skipping.")
+            return 0
+        return 0 if snapshot_ops.create_snapshot(vm, name, emit=print) else 1
+
+    banner(f"Snapshots: {vm}")
+    snapshots = snapshot_ops.list_snapshots(vm)
+    if not snapshots:
+        print(f"  (no snapshots on {vm})")
+        return 0
+    for s in snapshots:
+        print(f"  {s}")
+    return 0

--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -29,7 +29,7 @@
   "tools/cli/provision.py": 44,
   "tools/cli/provision_generic.py": 75,
   "tools/cli/provision_vm.py": 28,
-  "tools/cli/snapshot_vm.py": 29,
+  "tools/cli/snapshot_vm.py": 27,
   "tools/cli/validate_keys.py": 26,
   "tools/cli/validate_observability.py": 30,
   "tools/cli/verify_add_host.py": 62,

--- a/tools/verify_phase7.py
+++ b/tools/verify_phase7.py
@@ -33,7 +33,6 @@ CATEGORY_CAPS = [
 # Files allowed to call subprocess.run/Popen inside the dispatcher surfaces.
 SUBPROCESS_EXCEPTIONS = {
     "tools/api/jobs.py",        # spawn_job (Popen) — documented GH #37
-    "tools/cli/snapshot_vm.py", # GH #206 — pending pipeline primitive
 }
 
 
@@ -75,6 +74,10 @@ def check_no_subprocess() -> list[str]:
     for line in r.stdout.splitlines():
         rel = line.split(":", 1)[0]
         if rel in SUBPROCESS_EXCEPTIONS:
+            continue
+        # tools/cli/verify_*.py are SUT integration harnesses, not dispatchers —
+        # they invoke the built esacp.py CLI under test (GH #275).
+        if rel.startswith("tools/cli/verify_") and rel.endswith(".py"):
             continue
         fails.append(f"[FAIL] unexpected subprocess call: {line}")
     if not fails:


### PR DESCRIPTION
## Summary

- Rewrites `tools/cli/snapshot_vm.py` to call the existing `tools/pipeline/orchestration/snapshot_ops.py` primitive instead of shelling out to `platforms/kvm/snapshot.py`. This removes the last documented dispatcher-rule subprocess exception (Phase 7 / #195 deferral).
- Teaches `tools/verify_phase7.py` to skip `tools/cli/verify_*.py` files — these are SUT integration harnesses that legitimately invoke the built CLI (per `memory/feedback_sut_frozen_tests_unlimited.md`) and are not dispatcher leaks.

Closes #206 (snapshot_vm subprocess violation) and #275 (verify_phase7 FP on SUT harnesses).

## Why bundled

#275 is a natural dependency of #206's own acceptance criterion: issue #206 required the grep check `grep -rn 'subprocess.run' tools/esacp.py tools/api/ tools/job_worker.py tools/cli/` to return only `_spawn_job`. That check cannot pass while the two integration harnesses (added between Phase 7 landing and now) are flagged as violations. The carve-out is a one-line change in `check_no_subprocess()` with zero behaviour change to the SUT — tight enough coupling to justify a single PR.

## Behaviour delta

- `esacp.py snapShotVM <vm>` (list): output is now names-only, one per line. Previously the full `virsh snapshot-list` table. The operator-facing standalone `platforms/kvm/snapshot.py list <vm>` still prints the full table.
- `esacp.py snapShotVM <vm> <name>` (create): output now `[OK] Snapshot '<name>' taken` (from `snapshot_ops.create_snapshot`'s emit). Previously `Taking snapshot…` / `✅ Snapshot … created`. Info content preserved.
- Pre-create `already exists → skip` semantics preserved by checking `list_snapshots()` before `create_snapshot()`.

## Files

- `tools/cli/snapshot_vm.py` — 29 → 27 lines, subprocess removed
- `tools/verify_phase7.py` — dropped `snapshot_vm.py` from `SUBPROCESS_EXCEPTIONS`; added `tools/cli/verify_*.py` skip in `check_no_subprocess()`
- `tools/CLAUDE.md` — removed `#206 deferral` bullet; updated `snapShotVM` note
- `docs/CLI.md` — updated `snapShotVM` wiring note
- `tools/size_baselines.json` — auto-ratcheted by pre-commit hook (29 → 27)

`platforms/kvm/snapshot.py` is intentionally untouched — it remains the operator-facing standalone tool referenced in `docs/BuildOutProcedure.md` (revert/delete/start/state operations).

## Test plan

- [x] `./tools/verify_phase7.py` — 6/6 green (target caps + category caps + no-subprocess + help loads)
- [x] `grep -rn 'subprocess.run\|subprocess.Popen' tools/esacp.py tools/api/ tools/job_worker.py tools/cli/` — returns only `_spawn_job` (#37) and the two carved-out `verify_*.py` SUT harnesses
- [x] `python3 -c "from tools.cli import snapshot_vm"` — imports clean
- [x] `./tools/esacp.py snapShotVM --help` — argparse unchanged
- [ ] Manual end-to-end snapshot smoke on a local libvirt VM — **not feasible on controller**; Mighty has no local VMs (VMs live on toshiba, reachable only via ProxyJump). This limitation is pre-existing and orthogonal to the fix. The replaced code path had the same constraint.
- [x] GPG-signed commit