### PR TITLE
refactor(cf-mcp-refresh): extract token-writer to standalone script

### DIFF
--- a/docs/BuildOutProcedure.md
+++ b/docs/BuildOutProcedure.md
@@ -45,10 +45,14 @@ repo copy onto the operator's `PATH`:
 
 ```bash
 install -m 0755 tools/cf-mcp-refresh ~/.local/bin/cf-mcp-refresh
+install -m 0755 tools/cf-mcp-write-tokens.py ~/.local/bin/cf-mcp-write-tokens.py
 ```
 
-Re-run the install whenever `tools/cf-mcp-refresh` is updated. `sync_check.sh`
-expects the script at `~/.local/bin/cf-mcp-refresh`.
+Re-run the install whenever `tools/cf-mcp-refresh` or
+`tools/cf-mcp-write-tokens.py` is updated. `cf-mcp-refresh` locates its
+sibling token-writer by `BASH_SOURCE`-relative path, so both files must
+live in the same directory on `PATH`. `sync_check.sh` expects
+`cf-mcp-refresh` at `~/.local/bin/cf-mcp-refresh`.
 
 ---
 

--- a/tools/cf-mcp-refresh
+++ b/tools/cf-mcp-refresh
@@ -54,19 +54,5 @@ if [ -z "$RESPONSE" ] || ! echo "$RESPONSE" | python3 -c "import json,sys; d=jso
 fi
 
 # Write fresh tokens to ALL version dirs
-python3 - "$MCP_AUTH_DIR" "$URL_HASH" <<PYEOF
-import json, sys, os, glob
-
-mcp_auth_dir = sys.argv[1]
-url_hash = sys.argv[2]
-new_tokens = json.loads("""$RESPONSE""")
-
-pattern = os.path.join(mcp_auth_dir, f"mcp-remote-*/{url_hash}_tokens.json")
-written = 0
-for path in glob.glob(pattern):
-    with open(path, 'w') as fh:
-        json.dump(new_tokens, fh, indent=2)
-    written += 1
-
-print(f"cf-mcp-refresh: ✅ token refreshed and written to {written} version dir(s)")
-PYEOF
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+echo "$RESPONSE" | "$SCRIPT_DIR/cf-mcp-write-tokens.py" "$MCP_AUTH_DIR" "$URL_HASH"

--- a/tools/cf-mcp-write-tokens.py
+++ b/tools/cf-mcp-write-tokens.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Write fresh OAuth tokens to all mcp-remote version dirs.
+
+Invoked by tools/cf-mcp-refresh after a successful refresh_token exchange.
+Reads the new token JSON from stdin; mcp_auth_dir + url_hash via argv.
+Replaces a bash heredoc that fed Python through three escaping layers (#276).
+"""
+import glob
+import json
+import os
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: cf-mcp-write-tokens.py <mcp_auth_dir> <url_hash>",
+            file=sys.stderr,
+        )
+        return 2
+
+    mcp_auth_dir, url_hash = sys.argv[1], sys.argv[2]
+    new_tokens = json.load(sys.stdin)
+
+    pattern = os.path.join(mcp_auth_dir, f"mcp-remote-*/{url_hash}_tokens.json")
+    written = 0
+    for path in glob.glob(pattern):
+        with open(path, "w") as fh:
+            json.dump(new_tokens, fh, indent=2)
+        written += 1
+
+    print(f"cf-mcp-refresh: ✅ token refreshed and written to {written} version dir(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Replace bash heredoc-feeding-Python in `tools/cf-mcp-refresh` with a standalone `tools/cf-mcp-write-tokens.py` invoked via stdin.
- Update `docs/BuildOutProcedure.md` so both files get installed to `~/.local/bin/` side-by-side.

## Why

The prior heredoc relied on a Python triple-quoted string interpolated from a shell variable — three escaping layers (bash → heredoc → Python). A `"""` substring in the Cloudflare OAuth response would terminate the Python literal early and break `json.loads`. Beyond the specific fragility, the pattern is explicitly banned by CLAUDE.md's "Banned Patterns — sed and heredocs-as-code" section. See #276.

## Scope

- `cf-mcp-refresh` locates its sibling via `BASH_SOURCE`-relative path; behaviour on the happy path is identical (same stdout, same exit codes).
- Inline `python3 -c "…"` one-liners at lines 36 and 50 are intentionally kept — they are not heredocs and are out of scope per #276's proposed fix.
- Operator-local tooling only; no pipeline / matrix impact.

## Test plan

- [x] `./tools/cf-mcp-write-tokens.py` with no args → `usage:` on stderr, exit 2.
- [x] `echo '{"access_token":"x"}' | ./tools/cf-mcp-write-tokens.py /tmp/nonexistent hash` → `written to 0 version dir(s)`, exit 0.
- [x] `grep -nE 'heredoc|PYEOF|<<[A-Z]' tools/cf-mcp-refresh` → no matches.
- [x] Install both files; run `cf-mcp-refresh` from PATH → `✅ token refreshed and written to 2 version dir(s)`, exit 0.
- [x] `bash platforms/kvm/sync_check.sh` § 14 Cloudflare MCP — all green (`cf-mcp-refresh — token refreshed successfully`), 0 failures.
- [x] GPG-signed commit (verified).

fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)