### PR TITLE
fix(wizard-replay): extract welcome-modal handler, extend to #296 + #297 sites

### DIFF
--- a/prototypes/cytoscape/recordings/wizard/pseudo-co-wizard.spec.js
+++ b/prototypes/cytoscape/recordings/wizard/pseudo-co-wizard.spec.js
@@ -58,6 +58,52 @@ async function waitForFrappeIdle(page, timeout = 30_000) {
   );
 }
 
+// ── Helper: dismiss Frappe's welcome/onboarding modal ───────────────────
+// Fixes #297 (which extends #284/#293). The onboarding modal
+// (.modal-backdrop.show / .modal.show) materialises asynchronously at
+// non-deterministic wizard transitions, intercepting pointer events.
+// waitForFrappeIdle does NOT cover this — it checks #freeze.modal-backdrop.in,
+// a different selector for Frappe's AJAX freeze indicator.
+//
+// Escape dismisses it in most cases (2 s budget). Under pipeline load the
+// Escape key is intermittently consumed by something other than the modal
+// (focus trap races, ancestor handlers); the DOM-remove fallback then
+// strips the backdrop directly so the next click always lands.
+//
+// Idempotent: returns immediately if no modal is visible. Safe to call
+// before every wizard interaction.
+async function dismissWelcomeModal(page, timeout = 2_000) {
+  const visible = await page.locator('.modal-backdrop.show').first()
+    .isVisible().catch(() => false);
+  if (!visible) return;
+  await page.keyboard.press('Escape');
+  const dismissed = await page.waitForFunction(
+    () => !document.querySelector('.modal-backdrop.show'),
+    null, { timeout },
+  ).then(() => true).catch(() => false);
+  if (dismissed) return;
+  await page.evaluate(() => {
+    document.querySelectorAll('.modal-backdrop, .modal.show, .modal.fade.show').forEach(n => n.remove());
+    document.body.classList.remove('modal-open');
+    document.body.style.removeProperty('overflow');
+    document.body.style.removeProperty('padding-right');
+  });
+  await page.waitForFunction(
+    () => !document.querySelector('.modal-backdrop.show') && !document.querySelector('.modal.show'),
+    null, { timeout },
+  );
+}
+
+// ── Composite guard for transitions where the welcome modal has been observed ─
+// Use at known-bad transitions only (#284 Industry-Next, #297 Company-name-Next,
+// #296 Complete-Setup). Calling at every wizard step regressed: the DOM-remove
+// fallback or stray Escape can interfere with screen-render timing at
+// transitions where no welcome modal is actually present.
+async function readyForInteraction(page) {
+  await waitForFrappeIdle(page);
+  await dismissWelcomeModal(page);
+}
+
 (async () => {
   const browser = await chromium.launch({
     headless: false
@@ -119,47 +165,18 @@ async function waitForFrappeIdle(page, timeout = 30_000) {
       throw new Error(`${industry} checkbox did not register as checked after DOM mutation`);
     }
   }
-  // Fixes #284 (second failure site) + #293 (pipeline-context Escape-fail follow-on).
-  // The welcome/onboarding modal can materialise AFTER the checkbox DOM mutation
-  // and before the Next click, intercepting pointer events (<div class="modal fade show">).
-  // #267 fixed the checkbox interaction via DOM mutation; Escape dismisses the modal
-  // in most cases. Under pipeline load the Escape key is intermittently consumed by
-  // something other than the modal (focus trap races, ancestor handlers), leaving the
-  // backdrop up — fall through to a DOM-level removal so the Next click always lands.
-  const industryModalBackdrop = await page.locator('.modal-backdrop.show').first()
-    .isVisible().catch(() => false);
-  if (industryModalBackdrop) {
-    await page.keyboard.press('Escape');
-    const dismissed = await page.waitForFunction(
-      () => !document.querySelector('.modal-backdrop.show'),
-      null, { timeout: 2_000 },
-    ).then(() => true).catch(() => false);
-    if (!dismissed) {
-      await page.evaluate(() => {
-        document.querySelectorAll('.modal-backdrop, .modal.show, .modal.fade.show').forEach(n => n.remove());
-        document.body.classList.remove('modal-open');
-        document.body.style.removeProperty('overflow');
-        document.body.style.removeProperty('padding-right');
-      });
-      await page.waitForFunction(
-        () => !document.querySelector('.modal-backdrop.show') && !document.querySelector('.modal.show'),
-        null, { timeout: 2_000 },
-      );
-    }
-  }
-  await waitForFrappeIdle(page);
+  // #267 + #284 + #293: welcome modal can materialise AFTER the checkbox
+  // DOM mutation and before this Next click. dismissWelcomeModal (called via
+  // readyForInteraction) handles Escape + DOM-remove fallback.
+  await readyForInteraction(page);
   await page.getByRole('button', { name: 'Next' }).click();
 
   // ── Wizard screen 4a: Company name + abbr ────────────────────────────────
-  // Fixes #284 (first failure site). Industry→Company screen transition
-  // stalled on Run 06 regen when a Frappe freeze-backdrop lingered longer
-  // than it did under Run 03's CLI-transport timing. Same class as #267
-  // on the Industry step — waitForFrappeIdle now guards every Next click.
   await waitForFrappeIdle(page);
   await page.getByRole('textbox').first().fill(CONFIG.company.name);
   await page.getByRole('textbox').first().press('Tab');
   await page.getByRole('textbox').nth(1).fill(CONFIG.company.abbr);
-  await waitForFrappeIdle(page);
+  await readyForInteraction(page);
   await page.getByRole('button', { name: 'Next' }).click();
 
   // ── Wizard screen 4b: Company description, currency, accounting standard ─
@@ -173,7 +190,7 @@ async function waitForFrappeIdle(page, timeout = 30_000) {
   // through Company INSERT + Chart-of-Accounts seeding (~30–45s). Wait for
   // the POST response itself — page.waitForFunction(async fn) returned
   // truthy prematurely in earlier attempts, producing pre-seed backups.
-  await waitForFrappeIdle(page);
+  await readyForInteraction(page);
   const [completeResp] = await Promise.all([
     page.waitForResponse(
       r => /setup_complete/.test(r.url()) && r.request().method() === 'POST',


### PR DESCRIPTION
## Summary

- Extracts the inline welcome-modal handler from `pseudo-co-wizard.spec.js` lines 122–149 into a reusable module-scope helper `dismissWelcomeModal(page)`. Idempotent — returns early if no `.modal-backdrop.show` is visible. Escape-then-DOM-remove fallback preserved (the #293 design).
- Adds composite `readyForInteraction(page)` = `waitForFrappeIdle` + `dismissWelcomeModal`.
- Calls `readyForInteraction` at three transitions where the welcome modal has been observed: #284 site (Industry-Next), #297 site (Company-name-Next), #296 site (Complete-Setup).
- Other transitions stay on plain `waitForFrappeIdle` — testing showed that calling the helper at every step interferes with screen-render timing at transitions where no welcome modal is present.

## Issues addressed

- `fixes #296` — Complete Setup HTTP 499 (welcome modal materialising during in-flight POST is the most defensible cause class; modal handler now fires before the click).
- `fixes #297` — same modal class at the Company-name → Company-description Next click; coverage gap left by #294.

## Acceptance — partial; matrix re-run blocked on #298

The 1844 next-agenda's 5-point sub-3 acceptance could **not** be fully run:

| Check | Status |
|---|---|
| 1. `node replay_wizard.js` exits 0 against fresh-reverted dev02 | ⚠️ Intermittent — 1/4 runs PASS, 3/4 FAIL at upstream Company-name-fill flake (#298) |
| 2. `provisionGeneric --wizard-mode=replay` exits 0 | ❌ Blocked by #298 + needs sub-2 merged |
| 3. `"ERPNext V13 Complete Generic"` snapshot created | ❌ Blocked — depends on item 2 |
| 4. New B03 in `golden_backups/` | ❌ Blocked — depends on item 2 |
| 5. `assert_clean_bench` + `verify_stage_6 --mode=generic` | ❌ Blocked — depends on item 2 |

The screen-4a Company-name-fill flake (#298) is **pre-existing in HEAD** — confirmed via a baseline run with no helper changes — and fires before the wizard ever reaches Complete Setup. #298 must land before #296+#297 can be end-to-end-verified.

The one PASS attempt (full-helper version, attempt 1) reached Complete Setup, POST returned 200, Company canary assertion green. That proves the modal-handler refactor does not regress the happy path; it does not prove #296 is fixed in the strict sense (single-run, intermittent race).

## Why land now

- Refactor is a code-quality improvement (inline → reusable helper) that doesn't regress what already works.
- Extends modal coverage to two more known transitions (#296, #297) where evidence already pointed.
- Lays foundation for #298 sub-4 work.
- Per `feedback_pr_merge_before_session_close.md`: this PR's "merged" semantics target umbrella; matrix-completion acceptance lives downstream in sub-2's PR + the certification session, not here.

## Test plan

- [x] `node --check` passes
- [x] One full green replay run (`node replay_wizard.js` reaches Complete Setup → 200 → Company canary green)
- [ ] **Cannot complete** — 3/4 runs blocked by #298. Will be re-run as part of #298 sub-4 PR + matrix re-run session.

## Branch topology

```
main @ a60b8f0 (chore(state): record dev02 re-registration)
  └─ umbrella/ladder-fixture @ 22997aa
       ├─ feat/playwright-wizard-generic-fixture (sub-2) @ 8dc2e71  ← unchanged
       └─ feat/wizard-complete-setup-fix (sub-3, this PR) @ cbf8f17
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)