### PR TITLE
fix(esacp): clear stale ~/.ssh/known_hosts on destroy/addHost

### DIFF
--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -196,7 +196,7 @@ Acceptance test: `./tools/verify_phase9.py`.
 | `macro/provision.py` | Stages 1–9 sequentially | `job_worker.py` (provision job) |
 | `macro/provision_generic.py` | Stages 1–9 + wizard completion | `job_worker.py` (provision_generic job) |
 | `macro/refresh.py` | Stages 3–9 (WG transport) | `job_worker.py` (refresh job) |
-| `macro/destroy.py` | 8-step teardown: WG peer → VM → hosts_map → group_vars → inventory → Ansible WG → SOPS keys → cloud-init | `job_worker.py` (destroy job), `esacp.py` (destroy cmd) |
+| `macro/destroy.py` | 9-step teardown: WG peer → VM → hosts_map → group_vars → inventory → Ansible WG → SOPS keys → cloud-init → known_hosts cleanup | `job_worker.py` (destroy job), `esacp.py` (destroy cmd) |
 
 ### Destroy orchestration primitives (in `orchestration/`)
 
@@ -213,6 +213,7 @@ Each is a single-task atomic script — no duplicated logic:
 | `ansible_wg_update.py` | Run Ansible to update hub WG config |
 | `sops_key_remove.py` | Remove host keys from SOPS-encrypted keyring |
 | `cloud_init_cleanup.py` | Remove cloud-init directory |
+| `known_hosts_cleanup.py` | Clear stale `~/.ssh/known_hosts` entries (used by destroy + addHost) |
 
 ### Dispatcher-extracted primitives (Phase 7, #195)
 

--- a/tools/pipeline/macro/destroy.py
+++ b/tools/pipeline/macro/destroy.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python3
-"""Macro: full destroy — tear down a VM and remove all traces from config.
+"""Macro: full destroy — 9-step teardown.
 
-8-step sequence:
-1. Remove live WireGuard peer from hub
-2. Destroy VM on hypervisor (snapshots + domain + storage)
-3. Remove host block from hosts_map.yml
-4. Remove wg_pubkey line from group_vars/all.yml
-5. Regenerate Ansible inventory
-6. Update hub WireGuard config via Ansible
-7. Remove WireGuard keys from SOPS keyring
-8. Remove cloud-init directory
+Steps: live WG peer → VM → hosts_map → group_vars → inventory → hub WG
+→ SOPS keys → cloud-init → known_hosts cleanup.
 """
 
 from __future__ import annotations
@@ -23,6 +16,7 @@ from tools.pipeline.orchestration.destroy_vm import destroy_vm
 from tools.pipeline.orchestration.group_vars_remove import remove_from_group_vars
 from tools.pipeline.orchestration.hosts_map_remove import remove_from_hosts_map
 from tools.pipeline.orchestration.inventory_regen import regenerate_inventory
+from tools.pipeline.orchestration.known_hosts_cleanup import clear_known_hosts
 from tools.pipeline.orchestration.sops_key_remove import remove_keys_from_sops
 from tools.pipeline.orchestration.wg_peer_remove import remove_wg_peer_live
 from tools.pipeline.orchestration.wg_pubkey import get_wg_pubkey
@@ -71,5 +65,11 @@ def run(
 
     emit("── Step 8: Remove cloud-init directory ──")
     remove_cloud_init(hostname, root / "platforms" / "kvm" / "cloud-init", emit)
+
+    emit("── Step 9: Clear stale ~/.ssh/known_hosts entries ──")
+    clear_known_hosts(
+        [hostname, host_cfg.get("wg_ip") or "", host_cfg.get("virbr0_ip") or ""],
+        emit,
+    )
 
     emit("── Destroy complete ──")

--- a/tools/pipeline/orchestration/host_registration.py
+++ b/tools/pipeline/orchestration/host_registration.py
@@ -9,7 +9,6 @@ three api.py endpoints. Raises ``HostRegistrationError`` (HTTP 400),
 from __future__ import annotations
 
 import re
-import subprocess
 from pathlib import Path
 from typing import Callable
 
@@ -18,6 +17,8 @@ import yaml
 from tools.pipeline.orchestration.host_registration_block import (
     MARKER, build_host_block,
 )
+from tools.pipeline.orchestration.inventory_regen import regenerate_inventory
+from tools.pipeline.orchestration.known_hosts_cleanup import clear_known_hosts
 
 Emit = Callable[[str], None]
 
@@ -65,10 +66,9 @@ def register_host(
     hosts_map_path.write_text(text.replace(MARKER, block + MARKER))
     emit(f"  [OK] registered {hostname} in hosts_map.yml")
 
-    result = subprocess.run(
-        ["python3", "tools/generate_inventory.py"],
-        cwd=str(root), capture_output=True, text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"generate_inventory.py failed:\n{result.stderr}")
-    emit("  [OK] inventory regenerated")
+    # Defense-in-depth: clear stale known_hosts entries in case a prior VM
+    # at these addresses was destroyed elsewhere or the controller was
+    # different. destroy.py also runs this; the duplication is intentional.
+    clear_known_hosts([hostname, wg_ip, virbr0_ip], emit)
+
+    regenerate_inventory(root, emit)

--- a/tools/pipeline/orchestration/known_hosts_cleanup.py
+++ b/tools/pipeline/orchestration/known_hosts_cleanup.py
@@ -1,0 +1,42 @@
+"""Clear stale SSH known_hosts entries for a host.
+
+Used by destroy (after VM teardown — host keys guaranteed stale) and by
+host_registration (defense-in-depth — in case destroy was bypassed or was
+performed on a different controller).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from tools.pipeline.stages.common.types import Emit
+
+
+def clear_known_hosts(keys: list[str], emit: Emit) -> None:
+    """Remove ~/.ssh/known_hosts entries for each given key (hostname or IP).
+
+    Idempotent: succeeds whether entries exist or not. Each key is passed
+    to `ssh-keygen -R` independently; missing entries are silently skipped.
+    """
+    known_hosts = Path.home() / ".ssh" / "known_hosts"
+    if not known_hosts.exists():
+        emit("  [SKIP] ~/.ssh/known_hosts does not exist")
+        return
+
+    cleared = []
+    for key in keys:
+        if not key:
+            continue
+        r = subprocess.run(
+            ["ssh-keygen", "-f", str(known_hosts), "-R", key],
+            capture_output=True, text=True, timeout=10,
+        )
+        output = (r.stdout or "") + (r.stderr or "")
+        if "found: line" in output:
+            cleared.append(key)
+
+    if cleared:
+        emit(f"  [OK] cleared known_hosts entries: {', '.join(cleared)}")
+    else:
+        emit("  [SKIP] no stale known_hosts entries to clear")

--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -77,6 +77,7 @@
   "tools/pipeline/orchestration/hypervisor_helpers.py": 67,
   "tools/pipeline/orchestration/inventory_regen.py": 20,
   "tools/pipeline/orchestration/ip_suggestions.py": 32,
+  "tools/pipeline/orchestration/known_hosts_cleanup.py": 42,
   "tools/pipeline/orchestration/load_host_config.py": 18,
   "tools/pipeline/orchestration/local_vm_teardown.py": 73,
   "tools/pipeline/orchestration/memory_guard.py": 77,


### PR DESCRIPTION
## Summary

Closes #300. Three-occurrence pattern made the fix self-evident: every destroy-rebuild cycle on dev VMs leaves a stale host-key entry in the operator's \`~/.ssh/known_hosts\`, breaking acceptance verification SSH until manually cleared.

## Changes

| File | Change |
|---|---|
| \`tools/pipeline/orchestration/known_hosts_cleanup.py\` (new, 42 lines) | Primitive \`clear_known_hosts(keys, emit)\`: invokes \`ssh-keygen -R\` per key; idempotent (silent skip when entry absent) |
| \`tools/pipeline/macro/destroy.py\` | New Step 9 at end of teardown — host keys are guaranteed stale after VM destroy. Docstring tightened to absorb the new step within the 80-line ratchet |
| \`tools/pipeline/orchestration/host_registration.py\` | Defense-in-depth call after hosts_map registration. Drive-by: replaced inline \`subprocess generate_inventory.py\` call with the existing \`regenerate_inventory()\` primitive (same one \`destroy.py\` uses) — removes duplicate logic, keeps file under cap |
| \`tools/CLAUDE.md\` | destroy macro now 9-step; \`known_hosts_cleanup.py\` listed in Destroy orchestration primitives table |

## Why both destroy and addHost

- **destroy** is where we know the host keys are about to become stale (the VM is being torn down). This is the load-bearing call.
- **addHost** is defense-in-depth: covers cases where destroy was bypassed (manual virsh undefine), performed on a different controller, or the host was abandoned. Idempotent — silent skip if no stale entries exist.

## Keys cleared

\`hostname\`, \`wg_ip\`, \`virbr0_ip\`. SSH config uses \`HostName=<wg_ip>\` directly (verified \`~/.ssh/config\`), so the IP entry is the load-bearing clear; hostname + virbr0_ip are belt-and-suspenders (the underlying \`ssh-keygen -R\` is idempotent for missing keys).

## Acceptance

- [x] \`bash -n\` / Python AST parse clean
- [x] Imports OK from \`destroy\` macro and \`register_host\`
- [x] Pre-commit size ratchet passes (destroy.py 75 lines, host_registration.py 74 lines, both at baseline; new file 42 lines, well under 80-cap)
- [x] Smoke-tested \`clear_known_hosts\` on this controller:
  - nonexistent keys → \`[SKIP] no stale known_hosts entries to clear\`
  - empty key in list → handled
  - real entry → \`[OK] cleared known_hosts entries: <key>\`
- [ ] e2e: next destroy/rebuild cycle confirms acceptance SSH works without manual \`ssh-keygen -R\` — gated on next session that runs a destroy

## Test plan

- [x] Unit-level smoke tests above
- [ ] Full e2e validation will happen organically in the next session that exercises destroy + addHost (next-agenda V14 path may not — first action there is rebase + bench commands, no destroy. Issue closure based on the unit tests + code review; e2e will confirm in the session that next destroys.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)