### PR TITLE
config(pipeline): default dev VM RAM 4 → 6 GiB (fixes #308)

### DIFF
--- a/tools/pipeline/stages/stage_1_vm_creation/test_virt_install_ram.py
+++ b/tools/pipeline/stages/stage_1_vm_creation/test_virt_install_ram.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Test: virt_install_import emits ``--ram 6144``.
+
+Run directly: ``./tools/pipeline/stages/stage_1_vm_creation/test_virt_install_ram.py``
+Exit 0 on pass, 1 on fail. No pytest dependency.
+
+Regression guard for #308: dev VMs need 6 GiB to survive ERPNext build phases
+(yarn / asset compilation OOM at 4 GiB on V14 ladder).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.pipeline.stages.env_kvm import KvmEnv  # noqa: E402
+from tools.pipeline.stages.stage_1_vm_creation import virt_install  # noqa: E402
+
+
+def test_virt_install_emits_6144_mib_ram() -> bool:
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    original = virt_install.subprocess.run
+    virt_install.subprocess.run = fake_run
+    try:
+        virt_install.virt_install_import(
+            hostname="dev03",
+            remote_seed="/tmp/seed-dev03.iso",
+            env=KvmEnv.from_project_root(REPO_ROOT),
+            emit=lambda _msg: None,
+        )
+    finally:
+        virt_install.subprocess.run = original
+
+    if not captured:
+        print("FAIL: subprocess.run was not invoked")
+        return False
+    ssh_argv = captured[0]
+    if len(ssh_argv) < 3:
+        print(f"FAIL: ssh argv malformed: {ssh_argv!r}")
+        return False
+    virt_cmd = ssh_argv[2]
+    if "--ram 6144" not in virt_cmd:
+        print(f"FAIL: expected '--ram 6144' in virt-install command, got:\n{virt_cmd}")
+        return False
+    if "--ram 4096" in virt_cmd:
+        print(f"FAIL: stale '--ram 4096' still present:\n{virt_cmd}")
+        return False
+    print("PASS: virt-install command emits --ram 6144")
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(0 if test_virt_install_emits_6144_mib_ram() else 1)

--- a/tools/pipeline/stages/stage_1_vm_creation/virt_install.py
+++ b/tools/pipeline/stages/stage_1_vm_creation/virt_install.py
@@ -15,7 +15,7 @@ def virt_install_import(
     virt_cmd = (
         f"virt-install --connect qemu:///system"
         f" --name {hostname}"
-        f" --ram 4096"
+        f" --ram 6144"
         f" --vcpus 2"
         f" --disk vol={env.pool}/{hostname}.qcow2"
         f" --disk path={remote_seed},device=cdrom,readonly=on"

--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -122,6 +122,7 @@
   "tools/pipeline/stages/stage_1_vm_creation/cleanup_residue.py": 59,
   "tools/pipeline/stages/stage_1_vm_creation/clone_template.py": 39,
   "tools/pipeline/stages/stage_1_vm_creation/seed_iso.py": 83,
+  "tools/pipeline/stages/stage_1_vm_creation/test_virt_install_ram.py": 62,
   "tools/pipeline/stages/stage_1_vm_creation/upload_seed.py": 25,
   "tools/pipeline/stages/stage_1_vm_creation/verify.py": 131,
   "tools/pipeline/stages/stage_1_vm_creation/virt_install.py": 34,


### PR DESCRIPTION
## Summary

- `tools/pipeline/stages/stage_1_vm_creation/virt_install.py:18` — `--ram 4096` → `--ram 6144`. New default for all `virt-install --import` provisions.
- Adds colocated `test_virt_install_ram.py` regression guard.

## Why

V13→V14 on dev02 OOM-killed yarn / asset compilation at 4 GiB. With RAM bumped to 6 GiB and `NODE_OPTIONS=--max-old-space-size=4096`, the build completed cleanly. Future rungs (v14→v15, v15→v16) will have similar or greater build-phase memory pressure, so 6 GiB is adopted as the new pipeline default.

## Why unconditional (and not role-conditional, despite the issue body's suggestion)

- Target VMs sharing the default pay no real cost: the strict 1-VM-at-a-time rule (`memory/feedback_one_vm_at_a_time.md`) prevents concurrent dev/target runs on the 16 GiB toshy hypervisor.
- Per-role RAM defaults are a better fit for the `templates.yml` mechanism that will land alongside #202 (cloud-init generation from `hosts_map.yml` + templates) — not threaded through the stage 1 orchestrator on the way out.
- `memory_guard.check_memory()` reads RAM from `virsh dominfo` dynamically; no constant to update there.

## Test plan

- [x] `./tools/pipeline/stages/stage_1_vm_creation/test_virt_install_ram.py` — invokes `virt_install_import` with `subprocess.run` stubbed; asserts assembled ssh argv contains `--ram 6144` and no stale `--ram 4096`. **PASS**.
- [ ] Issue's stated dev0N e2e checkbox (cold provision → `virsh dominfo` shows 6 GiB) — left to land opportunistically on the next cold provision; not gating per `feedback_not_perfection_project.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)