### PR TITLE
feat(audit): discovery library + identify_bad_customisations.py — Phase 1 (#315)

### DIFF
--- a/config/customisation_attribution.yml
+++ b/config/customisation_attribution.yml
@@ -1,0 +1,31 @@
+# Operator-curated customisation attribution.
+#
+# When a discover_*.py module finds a DB-only customisation row that lacks
+# a `module` column on the substrate (Frappe v13 schema), it consults this
+# file to determine which bespoke app should own the row and how Phase 2
+# should promote it.
+#
+# Format: drift_class -> row_name -> { owning_app, promotion_strategy }
+#
+# Run `./tools/identify_bad_customisations.py --substrate <vm> --write-stubs`
+# to append TODO placeholders for newly-discovered unmapped names; then
+# replace each TODO with the appropriate value:
+#
+#   owning_app:          ce_sri | returnable | route_planner
+#   promotion_strategy:  fixture_json | fixtures_custom_scripts | v14_patch_script | manual
+#
+# Entries with TODO in either field are treated as unresolved (audit emits
+# `manual` strategy and counts the row as needing attribution).
+#
+# Limitation: classes whose `name` column is an opaque hash (notably Custom
+# DocPerm) are keyed by that hash here — unfriendly for human attribution.
+# Phase 2 will revisit with a richer (parent + role + permlevel) schema.
+
+custom_field: {}
+property_setter: {}
+client_script: {}
+print_format: {}
+workflow: {}
+custom_docperm: {}
+translation: {}
+server_script: {}

--- a/tools/customisation_audit/__init__.py
+++ b/tools/customisation_audit/__init__.py
@@ -1,0 +1,9 @@
+"""Customisation discovery library — read-only audit of a dev VM substrate.
+
+Phase 1 of the customisation discovery + promotion + V14 plan
+(`~/.claude/plans/customisation-discovery-promotion.md`).
+
+Each per-class `discover_*.py` module exposes ``run(config) -> list[Drift]``.
+The package is consumed by the ``tools/identify_bad_customisations.py``
+dispatcher; nothing here mutates state on the VM or in the source tree.
+"""

--- a/tools/customisation_audit/_remote_query.py
+++ b/tools/customisation_audit/_remote_query.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Run on a dev VM: read site_config.json, execute SQL, emit JSON to stdout.
+
+Invoked by ``db_query.py`` over SSH. Single argv:
+    python3 /tmp/_audit_query.py <site_config.json> <sql>
+
+Emits ``{"rows": [{col: value, ...}, ...]}`` on success, exits 1 on failure
+with the mysql stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    site_config_path, sql = sys.argv[1], sys.argv[2]
+    with open(site_config_path) as f:
+        cfg = json.load(f)
+    env = {**os.environ, "MYSQL_PWD": cfg.get("db_password", "")}
+    proc = subprocess.run(
+        ["mysql", "-AD", cfg["db_name"], "-u" + cfg["db_name"], "-B", "-e", sql],
+        capture_output=True, text=True, env=env,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        sys.exit(1)
+    lines = proc.stdout.splitlines()
+    if not lines:
+        json.dump({"rows": []}, sys.stdout)
+        return
+    cols = lines[0].split("\t")
+    rows = [dict(zip(cols, ln.split("\t"))) for ln in lines[1:]]
+    json.dump({"rows": rows}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/customisation_audit/_test_support.py
+++ b/tools/customisation_audit/_test_support.py
@@ -1,0 +1,21 @@
+"""Test helpers used by colocated test_*.py modules.
+
+Each test file MUST add repo root to sys.path itself before importing this
+module — otherwise ``from tools.customisation_audit._test_support import …``
+fails before ``_test_support`` runs.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+
+@contextlib.contextmanager
+def patched(obj: object, attr: str, value: object):
+    """Temporarily replace obj.attr with value; restore on exit."""
+    original = getattr(obj, attr)
+    setattr(obj, attr, value)
+    try:
+        yield
+    finally:
+        setattr(obj, attr, original)

--- a/tools/customisation_audit/app_inventory.py
+++ b/tools/customisation_audit/app_inventory.py
@@ -1,0 +1,48 @@
+"""Parse <app>/<app>/hooks.py:fixtures and enumerate fixture files."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from tools.bespoke_root import BESPOKE_ROOT
+
+
+def _snake(name: str) -> str:
+    """'Custom Field' → 'custom_field'."""
+    return re.sub(r"\W+", "_", name).lower()
+
+
+def app_dir(app_name: str) -> Path:
+    return BESPOKE_ROOT / app_name
+
+
+def fixture_path(app_name: str, doctype: str) -> Path:
+    return app_dir(app_name) / app_name / "fixtures" / f"{_snake(doctype)}.json"
+
+
+def parse_fixtures(app_name: str) -> list[Any]:
+    """Read hooks.py and return its fixtures list (literal-only)."""
+    hooks = app_dir(app_name) / app_name / "hooks.py"
+    if not hooks.exists():
+        return []
+    tree = ast.parse(hooks.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "fixtures":
+                    try:
+                        return ast.literal_eval(node.value)
+                    except (ValueError, SyntaxError):
+                        return []
+    return []
+
+
+def load_fixture_file(app_name: str, doctype: str) -> list[dict]:
+    p = fixture_path(app_name, doctype)
+    if not p.exists():
+        return []
+    return json.loads(p.read_text())

--- a/tools/customisation_audit/attribution.py
+++ b/tools/customisation_audit/attribution.py
@@ -1,0 +1,47 @@
+"""Operator-curated attribution map. Read-only at audit time; --write-stubs
+appends TODO placeholders. Schema in config/customisation_attribution.yml."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+DEFAULT_PATH = "config/customisation_attribution.yml"
+TODO_TOKEN = "TODO"
+
+
+def load(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def lookup(amap: dict, drift_class: str, name: str) -> Optional[dict]:
+    """Return entry only when both fields are operator-resolved (not TODO)."""
+    entry = (amap.get(drift_class) or {}).get(name)
+    if not entry or TODO_TOKEN in (entry.get("owning_app"), entry.get("promotion_strategy")):
+        return None
+    return entry
+
+
+def append_stubs(path: Path, drift_class: str, names: list[str]) -> int:
+    amap = load(path)
+    cls = amap.setdefault(drift_class, {}) or {}
+    new = [n for n in names if n not in cls]
+    for n in new:
+        cls[n] = {"owning_app": TODO_TOKEN, "promotion_strategy": TODO_TOKEN}
+    amap[drift_class] = cls
+    path.write_text(yaml.safe_dump(amap, sort_keys=True))
+    return len(new)
+
+
+def stub_unmapped_from_report(path: Path, report: dict) -> dict[str, int]:
+    """Append TODO stubs for every (class, name) the report flagged unmapped."""
+    by_class: dict[str, list[str]] = defaultdict(list)
+    for d in report["drifts"]:
+        if d["promotion_strategy"] == "manual" and d["owning_app_proposed"] == "":
+            by_class[d["class"]].append(d["name"])
+    return {cls: append_stubs(path, cls, sorted(set(ns))) for cls, ns in by_class.items()}

--- a/tools/customisation_audit/audit_config.py
+++ b/tools/customisation_audit/audit_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -13,3 +13,5 @@ class AuditConfig:
     site_config_path: str   # remote absolute path to site_config.json
     bespoke_apps: list[str] # e.g. ["ce_sri", "returnable", "route_planner"]
     substrate_meta: dict    # populated into the report's "substrate" header
+    attribution_map: dict = field(default_factory=dict)
+    """Operator-curated drift-class → name → {owning_app, strategy}; see attribution.py."""

--- a/tools/customisation_audit/audit_config.py
+++ b/tools/customisation_audit/audit_config.py
@@ -1,0 +1,15 @@
+"""Runtime configuration for discovery — passed to each discover_*.run()."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AuditConfig:
+    """Runtime settings consumed by every discover_*.py module."""
+
+    ssh_host: str           # SSH alias, e.g. "dev01-erp"
+    site_config_path: str   # remote absolute path to site_config.json
+    bespoke_apps: list[str] # e.g. ["ce_sri", "returnable", "route_planner"]
+    substrate_meta: dict    # populated into the report's "substrate" header

--- a/tools/customisation_audit/db_query.py
+++ b/tools/customisation_audit/db_query.py
@@ -1,0 +1,39 @@
+"""Controller-side wrapper that runs ``_remote_query.py`` on a dev VM via SSH.
+
+SSH joins argv with spaces and re-parses on the remote shell, so the SQL
+must be ``shlex.quote``-d into a single shell-safe token before transport.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+_REMOTE_SCRIPT = Path(__file__).parent / "_remote_query.py"
+_REMOTE_PATH = "/tmp/_audit_query.py"
+
+
+def deploy_runner(ssh_host: str) -> None:
+    """SCP _remote_query.py to /tmp on the substrate VM."""
+    subprocess.run(
+        ["scp", "-q", str(_REMOTE_SCRIPT), f"{ssh_host}:{_REMOTE_PATH}"],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def run_query(ssh_host: str, site_config_path: str, sql: str) -> list[dict]:
+    """Execute SQL on substrate; return rows as list[dict].
+
+    Raises CalledProcessError if SSH or mysql fails.
+    """
+    remote_cmd = (
+        f"python3 {shlex.quote(_REMOTE_PATH)} "
+        f"{shlex.quote(site_config_path)} {shlex.quote(sql)}"
+    )
+    proc = subprocess.run(
+        ["ssh", ssh_host, remote_cmd],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(proc.stdout)["rows"]

--- a/tools/customisation_audit/delta_report.py
+++ b/tools/customisation_audit/delta_report.py
@@ -1,0 +1,40 @@
+"""Build + serialise the delta report. Schema per plan §6."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any
+
+from tools.customisation_audit.drift import Drift
+
+SCHEMA_VERSION = "1"
+
+
+def _drift_to_dict(d: Drift) -> dict[str, Any]:
+    out = asdict(d)
+    out["class"] = out.pop("drift_class")
+    return out
+
+
+def emit(drifts: list[Drift], substrate: dict[str, str]) -> dict[str, Any]:
+    """Build the report dict. Drifts sorted by id for stable output."""
+    sorted_drifts = sorted(drifts, key=lambda d: d.id)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "substrate": substrate,
+        "summary": {
+            "total_drifts": len(sorted_drifts),
+            "by_class": dict(Counter(d.drift_class for d in sorted_drifts)),
+            "by_verdict": dict(Counter(d.verdict for d in sorted_drifts)),
+        },
+        "drifts": [_drift_to_dict(d) for d in sorted_drifts],
+    }
+
+
+def to_json(report: dict[str, Any]) -> str:
+    """Stable serialisation: sort_keys ensures byte-identical round-trip."""
+    return json.dumps(report, sort_keys=True, indent=2, ensure_ascii=False)

--- a/tools/customisation_audit/discover_client_script.py
+++ b/tools/customisation_audit/discover_client_script.py
@@ -1,0 +1,46 @@
+"""Class 5.4 — Client Script. DB scan vs <app>/fixtures/custom_scripts/<DocType>.js."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import app_inventory, db_query, target_resolution
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "client_script"
+DOCTYPE = "Client Script"
+SQL = "SELECT name, dt, view, script, enabled FROM `tabClient Script`"
+# v13 has no `module` column on tabClient Script.
+
+
+def _file_exists_for(apps: list[str], dt: str) -> str | None:
+    """Return owning app if <app>/<app>/fixtures/custom_scripts/<dt>.js exists, else None."""
+    for app in apps:
+        path = app_inventory.app_dir(app) / app / "fixtures" / "custom_scripts" / f"{dt}.js"
+        if path.exists():
+            return app
+    return None
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    mapping = target_resolution.module_to_app(config.bespoke_apps)
+    drifts: list[Drift] = []
+    for row in rows:
+        if _file_exists_for(config.bespoke_apps, row.get("dt", "")):
+            continue
+        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        proposed = (
+            f"{owning}/{owning}/fixtures/custom_scripts/{row.get('dt', '')}.js"
+            if owning else ""
+        )
+        drifts.append(Drift(
+            id=stable_id(DRIFT_CLASS, row["name"], row.get("dt", "")),
+            drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
+            doctype=row.get("dt", ""), name=row["name"], owning_app_proposed=owning,
+            fixture_path_proposed=proposed,
+            promotion_strategy=(PromotionStrategy.FIXTURES_CUSTOM_SCRIPTS if owning
+                                else PromotionStrategy.MANUAL).value,
+            row_data=row,
+        ))
+    return drifts

--- a/tools/customisation_audit/discover_client_script.py
+++ b/tools/customisation_audit/discover_client_script.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tools.customisation_audit import app_inventory, db_query, target_resolution
+from tools.customisation_audit import app_inventory, attribution, db_query, target_resolution
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.customisation_audit.drift import Drift, stable_id
 from tools.customisation_audit.verdict import PromotionStrategy, Verdict
@@ -14,12 +14,19 @@ SQL = "SELECT name, dt, view, script, enabled FROM `tabClient Script`"
 
 
 def _file_exists_for(apps: list[str], dt: str) -> str | None:
-    """Return owning app if <app>/<app>/fixtures/custom_scripts/<dt>.js exists, else None."""
     for app in apps:
         path = app_inventory.app_dir(app) / app / "fixtures" / "custom_scripts" / f"{dt}.js"
         if path.exists():
             return app
     return None
+
+
+def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
+    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    if entry:
+        return entry["owning_app"], entry["promotion_strategy"]
+    owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+    return owning, (PromotionStrategy.FIXTURES_CUSTOM_SCRIPTS if owning else PromotionStrategy.MANUAL).value
 
 
 def run(config: AuditConfig) -> list[Drift]:
@@ -29,18 +36,13 @@ def run(config: AuditConfig) -> list[Drift]:
     for row in rows:
         if _file_exists_for(config.bespoke_apps, row.get("dt", "")):
             continue
-        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
-        proposed = (
-            f"{owning}/{owning}/fixtures/custom_scripts/{row.get('dt', '')}.js"
-            if owning else ""
-        )
+        owning, strategy = _resolve(row["name"], row, mapping, config.attribution_map)
+        proposed = f"{owning}/{owning}/fixtures/custom_scripts/{row.get('dt', '')}.js" if owning else ""
         drifts.append(Drift(
             id=stable_id(DRIFT_CLASS, row["name"], row.get("dt", "")),
             drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
-            doctype=row.get("dt", ""), name=row["name"], owning_app_proposed=owning,
-            fixture_path_proposed=proposed,
-            promotion_strategy=(PromotionStrategy.FIXTURES_CUSTOM_SCRIPTS if owning
-                                else PromotionStrategy.MANUAL).value,
-            row_data=row,
+            doctype=row.get("dt", ""), name=row["name"],
+            owning_app_proposed=owning, fixture_path_proposed=proposed,
+            promotion_strategy=strategy, row_data=row,
         ))
     return drifts

--- a/tools/customisation_audit/discover_custom_docperm.py
+++ b/tools/customisation_audit/discover_custom_docperm.py
@@ -1,0 +1,33 @@
+"""Class 5.9 — Custom DocPerm. DB scan; no fixture mechanism — all rows db_only."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import db_query, target_resolution
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "custom_docperm"
+DOCTYPE = "Custom DocPerm"
+SQL = (
+    "SELECT name, parent, role, permlevel, `read`, `write`, `create`, `delete`, "
+    "submit, `cancel`, amend, `if_owner` FROM `tabCustom DocPerm`"
+)  # tabCustom DocPerm has no module column (it's a child of DocType).
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    mapping = target_resolution.module_to_app(config.bespoke_apps)
+    drifts: list[Drift] = []
+    for row in rows:
+        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        drifts.append(Drift(
+            id=stable_id(DRIFT_CLASS, row["name"], row.get("parent", ""), row.get("role", "")),
+            drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
+            doctype=row.get("parent", ""), name=row["name"], owning_app_proposed=owning,
+            fixture_path_proposed="",
+            promotion_strategy=(PromotionStrategy.V14_PATCH_SCRIPT if owning
+                                else PromotionStrategy.MANUAL).value,
+            row_data=row,
+        ))
+    return drifts

--- a/tools/customisation_audit/discover_custom_docperm.py
+++ b/tools/customisation_audit/discover_custom_docperm.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tools.customisation_audit import db_query, target_resolution
+from tools.customisation_audit import attribution, db_query, target_resolution
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.customisation_audit.drift import Drift, stable_id
 from tools.customisation_audit.verdict import PromotionStrategy, Verdict
@@ -15,19 +15,25 @@ SQL = (
 )  # tabCustom DocPerm has no module column (it's a child of DocType).
 
 
+def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
+    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    if entry:
+        return entry["owning_app"], entry["promotion_strategy"]
+    owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+    return owning, (PromotionStrategy.V14_PATCH_SCRIPT if owning else PromotionStrategy.MANUAL).value
+
+
 def run(config: AuditConfig) -> list[Drift]:
     rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
     mapping = target_resolution.module_to_app(config.bespoke_apps)
     drifts: list[Drift] = []
     for row in rows:
-        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        owning, strategy = _resolve(row["name"], row, mapping, config.attribution_map)
         drifts.append(Drift(
             id=stable_id(DRIFT_CLASS, row["name"], row.get("parent", ""), row.get("role", "")),
             drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
-            doctype=row.get("parent", ""), name=row["name"], owning_app_proposed=owning,
-            fixture_path_proposed="",
-            promotion_strategy=(PromotionStrategy.V14_PATCH_SCRIPT if owning
-                                else PromotionStrategy.MANUAL).value,
-            row_data=row,
+            doctype=row.get("parent", ""), name=row["name"],
+            owning_app_proposed=owning, fixture_path_proposed="",
+            promotion_strategy=strategy, row_data=row,
         ))
     return drifts

--- a/tools/customisation_audit/discover_custom_doctype.py
+++ b/tools/customisation_audit/discover_custom_doctype.py
@@ -1,0 +1,30 @@
+"""Class 5.3 — Custom DocType. Enumerate-only (out-of-scope per audit D-3)."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import db_query
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "custom_doctype"
+DOCTYPE = "DocType"
+SQL = (
+    "SELECT name, custom, module, issingle, istable, is_submittable "
+    "FROM `tabDocType` WHERE custom = 1"
+)
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    return [
+        Drift(
+            id=stable_id(DRIFT_CLASS, row["name"]),
+            drift_class=DRIFT_CLASS, verdict=Verdict.ENUMERATE_ONLY.value,
+            doctype=DOCTYPE, name=row["name"], owning_app_proposed="",
+            fixture_path_proposed="",
+            promotion_strategy=PromotionStrategy.MANUAL.value,
+            row_data=row, notes=["Custom DocTypes are out-of-scope per audit D-3."],
+        )
+        for row in rows
+    ]

--- a/tools/customisation_audit/discover_custom_field.py
+++ b/tools/customisation_audit/discover_custom_field.py
@@ -1,0 +1,45 @@
+"""Class 5.1 — Custom Field. DB scan vs all bespoke apps' custom_field.json."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import app_inventory, db_query, drift_builder, target_resolution
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift
+from tools.customisation_audit.verdict import PromotionStrategy
+
+DRIFT_CLASS = "custom_field"
+DOCTYPE = "Custom Field"
+KEY_FIELDS = ("dt", "fieldname")
+SQL = (
+    "SELECT name, dt, fieldname, label, fieldtype, options "
+    "FROM `tabCustom Field`"
+)
+# Note: v13 tabCustom Field has no `module` column. Owning-app attribution
+# for db_only entries falls back to "" (manual promotion); fixture-indexed
+# entries derive ownership from which app's custom_field.json contains them.
+
+
+def _index_fixtures(apps: list[str]) -> dict[str, tuple[str, dict]]:
+    """name → (owning_app, fixture_row) across every app's custom_field.json."""
+    out: dict[str, tuple[str, dict]] = {}
+    for app in apps:
+        for entry in app_inventory.load_fixture_file(app, DOCTYPE):
+            out[entry["name"]] = (app, entry)
+    return out
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    fixtures = _index_fixtures(config.bespoke_apps)
+    mapping = target_resolution.module_to_app(config.bespoke_apps)
+    seen = {r["name"] for r in rows}
+    drifts = [
+        drift_builder.db_only(DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
+                              PromotionStrategy.FIXTURE_JSON)
+        for r in rows if r["name"] not in fixtures
+    ]
+    drifts += [
+        drift_builder.orphan_fixture(DRIFT_CLASS, DOCTYPE, n, a, e, KEY_FIELDS)
+        for n, (a, e) in fixtures.items() if n not in seen
+    ]
+    return drifts

--- a/tools/customisation_audit/discover_custom_field.py
+++ b/tools/customisation_audit/discover_custom_field.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from tools.customisation_audit import app_inventory, db_query, drift_builder, target_resolution
+from tools.customisation_audit import (
+    app_inventory, attribution, db_query, drift_builder, target_resolution,
+)
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.customisation_audit.drift import Drift
 from tools.customisation_audit.verdict import PromotionStrategy
@@ -34,8 +36,11 @@ def run(config: AuditConfig) -> list[Drift]:
     mapping = target_resolution.module_to_app(config.bespoke_apps)
     seen = {r["name"] for r in rows}
     drifts = [
-        drift_builder.db_only(DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
-                              PromotionStrategy.FIXTURE_JSON)
+        drift_builder.db_only(
+            DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
+            PromotionStrategy.FIXTURE_JSON,
+            attribution.lookup(config.attribution_map, DRIFT_CLASS, r["name"]),
+        )
         for r in rows if r["name"] not in fixtures
     ]
     drifts += [

--- a/tools/customisation_audit/discover_naming_series.py
+++ b/tools/customisation_audit/discover_naming_series.py
@@ -1,0 +1,27 @@
+"""Class 5.8 — Naming Series counters. Informational; no promotion required."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import db_query
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "naming_series"
+DOCTYPE = "Series"
+SQL = "SELECT name, current FROM `tabSeries`"
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    return [
+        Drift(
+            id=stable_id(DRIFT_CLASS, row["name"]),
+            drift_class=DRIFT_CLASS, verdict=Verdict.INFORMATIONAL.value,
+            doctype=DOCTYPE, name=row["name"], owning_app_proposed="",
+            fixture_path_proposed="",
+            promotion_strategy=PromotionStrategy.NONE.value,
+            row_data=row,
+        )
+        for row in rows
+    ]

--- a/tools/customisation_audit/discover_print_format.py
+++ b/tools/customisation_audit/discover_print_format.py
@@ -1,0 +1,37 @@
+"""Class 5.6 — Print Format. DB scan; no fixture mechanism — all rows db_only.
+
+Promotion strategy for promoted entries is V14_PATCH_SCRIPT (Phase 2 will
+generate a per-app patch that re-creates these rows on a fresh substrate).
+"""
+
+from __future__ import annotations
+
+from tools.customisation_audit import db_query, target_resolution
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "print_format"
+DOCTYPE = "Print Format"
+SQL = (
+    "SELECT name, doc_type, module, standard, disabled "
+    "FROM `tabPrint Format` WHERE standard != 'Yes'"
+)
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    mapping = target_resolution.module_to_app(config.bespoke_apps)
+    drifts: list[Drift] = []
+    for row in rows:
+        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        drifts.append(Drift(
+            id=stable_id(DRIFT_CLASS, row["name"], row.get("doc_type", "")),
+            drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
+            doctype=row.get("doc_type", ""), name=row["name"], owning_app_proposed=owning,
+            fixture_path_proposed="",
+            promotion_strategy=(PromotionStrategy.V14_PATCH_SCRIPT if owning
+                                else PromotionStrategy.MANUAL).value,
+            row_data=row,
+        ))
+    return drifts

--- a/tools/customisation_audit/discover_print_format.py
+++ b/tools/customisation_audit/discover_print_format.py
@@ -6,7 +6,7 @@ generate a per-app patch that re-creates these rows on a fresh substrate).
 
 from __future__ import annotations
 
-from tools.customisation_audit import db_query, target_resolution
+from tools.customisation_audit import attribution, db_query, target_resolution
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.customisation_audit.drift import Drift, stable_id
 from tools.customisation_audit.verdict import PromotionStrategy, Verdict
@@ -19,19 +19,25 @@ SQL = (
 )
 
 
+def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
+    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    if entry:
+        return entry["owning_app"], entry["promotion_strategy"]
+    owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+    return owning, (PromotionStrategy.V14_PATCH_SCRIPT if owning else PromotionStrategy.MANUAL).value
+
+
 def run(config: AuditConfig) -> list[Drift]:
     rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
     mapping = target_resolution.module_to_app(config.bespoke_apps)
     drifts: list[Drift] = []
     for row in rows:
-        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        owning, strategy = _resolve(row["name"], row, mapping, config.attribution_map)
         drifts.append(Drift(
             id=stable_id(DRIFT_CLASS, row["name"], row.get("doc_type", "")),
             drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
-            doctype=row.get("doc_type", ""), name=row["name"], owning_app_proposed=owning,
-            fixture_path_proposed="",
-            promotion_strategy=(PromotionStrategy.V14_PATCH_SCRIPT if owning
-                                else PromotionStrategy.MANUAL).value,
-            row_data=row,
+            doctype=row.get("doc_type", ""), name=row["name"],
+            owning_app_proposed=owning, fixture_path_proposed="",
+            promotion_strategy=strategy, row_data=row,
         ))
     return drifts

--- a/tools/customisation_audit/discover_property_setter.py
+++ b/tools/customisation_audit/discover_property_setter.py
@@ -1,0 +1,41 @@
+"""Class 5.2 — Property Setter. DB scan vs ce_sri's property_setter.json."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import app_inventory, db_query, drift_builder, target_resolution
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift
+from tools.customisation_audit.verdict import PromotionStrategy
+
+DRIFT_CLASS = "property_setter"
+DOCTYPE = "Property Setter"
+KEY_FIELDS = ("doc_type", "field_name", "property")
+SQL = (
+    "SELECT name, doc_type, field_name, property, value, property_type "
+    "FROM `tabProperty Setter`"
+)  # v13 has no `module` column on tabProperty Setter.
+
+
+def _index_fixtures(apps: list[str]) -> dict[str, tuple[str, dict]]:
+    out: dict[str, tuple[str, dict]] = {}
+    for app in apps:
+        for entry in app_inventory.load_fixture_file(app, DOCTYPE):
+            out[entry["name"]] = (app, entry)
+    return out
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    fixtures = _index_fixtures(config.bespoke_apps)
+    mapping = target_resolution.module_to_app(config.bespoke_apps)
+    seen = {r["name"] for r in rows}
+    drifts = [
+        drift_builder.db_only(DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
+                              PromotionStrategy.FIXTURE_JSON)
+        for r in rows if r["name"] not in fixtures
+    ]
+    drifts += [
+        drift_builder.orphan_fixture(DRIFT_CLASS, DOCTYPE, n, a, e, KEY_FIELDS)
+        for n, (a, e) in fixtures.items() if n not in seen
+    ]
+    return drifts

--- a/tools/customisation_audit/discover_property_setter.py
+++ b/tools/customisation_audit/discover_property_setter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from tools.customisation_audit import app_inventory, db_query, drift_builder, target_resolution
+from tools.customisation_audit import (
+    app_inventory, attribution, db_query, drift_builder, target_resolution,
+)
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.customisation_audit.drift import Drift
 from tools.customisation_audit.verdict import PromotionStrategy
@@ -30,8 +32,11 @@ def run(config: AuditConfig) -> list[Drift]:
     mapping = target_resolution.module_to_app(config.bespoke_apps)
     seen = {r["name"] for r in rows}
     drifts = [
-        drift_builder.db_only(DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
-                              PromotionStrategy.FIXTURE_JSON)
+        drift_builder.db_only(
+            DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
+            PromotionStrategy.FIXTURE_JSON,
+            attribution.lookup(config.attribution_map, DRIFT_CLASS, r["name"]),
+        )
         for r in rows if r["name"] not in fixtures
     ]
     drifts += [

--- a/tools/customisation_audit/discover_server_script.py
+++ b/tools/customisation_audit/discover_server_script.py
@@ -1,0 +1,30 @@
+"""Class 5.5 — Server Script. Enumerate-only (manual promotion per audit D-5)."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import db_query
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "server_script"
+DOCTYPE = "Server Script"
+SQL = (
+    "SELECT name, script_type, reference_doctype, disabled "
+    "FROM `tabServer Script`"
+)  # v13 has no `module` column on tabServer Script.
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    return [
+        Drift(
+            id=stable_id(DRIFT_CLASS, row["name"], row.get("script_type", "")),
+            drift_class=DRIFT_CLASS, verdict=Verdict.ENUMERATE_ONLY.value,
+            doctype=DOCTYPE, name=row["name"], owning_app_proposed="",
+            fixture_path_proposed="",
+            promotion_strategy=PromotionStrategy.MANUAL.value,
+            row_data=row, notes=["Server Scripts require manual review per audit D-5."],
+        )
+        for row in rows
+    ]

--- a/tools/customisation_audit/discover_translation.py
+++ b/tools/customisation_audit/discover_translation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tools.customisation_audit import app_inventory, db_query
+from tools.customisation_audit import app_inventory, attribution, db_query
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.customisation_audit.drift import Drift, stable_id
 from tools.customisation_audit.verdict import PromotionStrategy, Verdict
@@ -36,12 +36,13 @@ def run(config: AuditConfig) -> list[Drift]:
             csv_cache[lang] = _csv_sources(config.bespoke_apps, lang)
         if row.get("source_text", "") in csv_cache[lang]:
             continue
+        entry = attribution.lookup(config.attribution_map, DRIFT_CLASS, row["name"])
+        owning = entry["owning_app"] if entry else ""
+        strategy = entry["promotion_strategy"] if entry else PromotionStrategy.APP_TRANSLATIONS_CSV.value
         drifts.append(Drift(
             id=stable_id(DRIFT_CLASS, row["name"], lang, row.get("source_text", "")),
             drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
-            doctype=DOCTYPE, name=row["name"], owning_app_proposed="",
-            fixture_path_proposed="",
-            promotion_strategy=PromotionStrategy.APP_TRANSLATIONS_CSV.value,
-            row_data=row,
+            doctype=DOCTYPE, name=row["name"], owning_app_proposed=owning,
+            fixture_path_proposed="", promotion_strategy=strategy, row_data=row,
         ))
     return drifts

--- a/tools/customisation_audit/discover_translation.py
+++ b/tools/customisation_audit/discover_translation.py
@@ -1,0 +1,47 @@
+"""Class 5.10 — Translation. DB scan vs <app>/translations/<lang>.csv."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import app_inventory, db_query
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "translation"
+DOCTYPE = "Translation"
+SQL = "SELECT name, language, source_text, translated_text FROM `tabTranslation`"
+
+
+def _csv_sources(apps: list[str], lang: str) -> set[str]:
+    """Set of source_text values present in any bespoke app's <lang>.csv."""
+    out: set[str] = set()
+    for app in apps:
+        path = app_inventory.app_dir(app) / app / "translations" / f"{lang}.csv"
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            cells = line.split(",", 1)
+            if cells:
+                out.add(cells[0].strip().strip('"'))
+    return out
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    drifts: list[Drift] = []
+    csv_cache: dict[str, set[str]] = {}
+    for row in rows:
+        lang = row.get("language", "")
+        if lang not in csv_cache:
+            csv_cache[lang] = _csv_sources(config.bespoke_apps, lang)
+        if row.get("source_text", "") in csv_cache[lang]:
+            continue
+        drifts.append(Drift(
+            id=stable_id(DRIFT_CLASS, row["name"], lang, row.get("source_text", "")),
+            drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
+            doctype=DOCTYPE, name=row["name"], owning_app_proposed="",
+            fixture_path_proposed="",
+            promotion_strategy=PromotionStrategy.APP_TRANSLATIONS_CSV.value,
+            row_data=row,
+        ))
+    return drifts

--- a/tools/customisation_audit/discover_unknown.py
+++ b/tools/customisation_audit/discover_unknown.py
@@ -1,0 +1,20 @@
+"""Catch-all — anything DM-suspect not covered by the 11 audited classes.
+
+Phase 1 ships this as a stub. The audit (`docs/upgrade/DMCustomisationCapabilityAudit.md`)
+identifies 11 classes; future runs that surface table types not in that list should
+extend this module with class-specific detection. For now it returns an empty list.
+
+When extended (Phase 2+ feedback), the convention is:
+    - Probe DB for tables with rows whose ``modified_by != "Administrator"``
+      (or other DM-suspect heuristic).
+    - Emit ``Drift`` entries with ``drift_class="unknown"`` and the table name in notes.
+"""
+
+from __future__ import annotations
+
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    return []

--- a/tools/customisation_audit/discover_workflow.py
+++ b/tools/customisation_audit/discover_workflow.py
@@ -1,0 +1,31 @@
+"""Class 5.7 — Workflow. DB scan; no fixture mechanism — all rows db_only."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import db_query, target_resolution
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+DRIFT_CLASS = "workflow"
+DOCTYPE = "Workflow"
+SQL = "SELECT name, document_type, is_active FROM `tabWorkflow`"
+# v13 has no `module` column on tabWorkflow.
+
+
+def run(config: AuditConfig) -> list[Drift]:
+    rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
+    mapping = target_resolution.module_to_app(config.bespoke_apps)
+    drifts: list[Drift] = []
+    for row in rows:
+        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        drifts.append(Drift(
+            id=stable_id(DRIFT_CLASS, row["name"], row.get("document_type", "")),
+            drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
+            doctype=row.get("document_type", ""), name=row["name"], owning_app_proposed=owning,
+            fixture_path_proposed="",
+            promotion_strategy=(PromotionStrategy.V14_PATCH_SCRIPT if owning
+                                else PromotionStrategy.MANUAL).value,
+            row_data=row,
+        ))
+    return drifts

--- a/tools/customisation_audit/discover_workflow.py
+++ b/tools/customisation_audit/discover_workflow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tools.customisation_audit import db_query, target_resolution
+from tools.customisation_audit import attribution, db_query, target_resolution
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.customisation_audit.drift import Drift, stable_id
 from tools.customisation_audit.verdict import PromotionStrategy, Verdict
@@ -13,19 +13,26 @@ SQL = "SELECT name, document_type, is_active FROM `tabWorkflow`"
 # v13 has no `module` column on tabWorkflow.
 
 
+def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
+    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    if entry:
+        return entry["owning_app"], entry["promotion_strategy"]
+    owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+    strategy = (PromotionStrategy.V14_PATCH_SCRIPT if owning else PromotionStrategy.MANUAL).value
+    return owning, strategy
+
+
 def run(config: AuditConfig) -> list[Drift]:
     rows = db_query.run_query(config.ssh_host, config.site_config_path, SQL)
     mapping = target_resolution.module_to_app(config.bespoke_apps)
     drifts: list[Drift] = []
     for row in rows:
-        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        owning, strategy = _resolve(row["name"], row, mapping, config.attribution_map)
         drifts.append(Drift(
             id=stable_id(DRIFT_CLASS, row["name"], row.get("document_type", "")),
             drift_class=DRIFT_CLASS, verdict=Verdict.DB_ONLY.value,
-            doctype=row.get("document_type", ""), name=row["name"], owning_app_proposed=owning,
-            fixture_path_proposed="",
-            promotion_strategy=(PromotionStrategy.V14_PATCH_SCRIPT if owning
-                                else PromotionStrategy.MANUAL).value,
-            row_data=row,
+            doctype=row.get("document_type", ""), name=row["name"],
+            owning_app_proposed=owning, fixture_path_proposed="",
+            promotion_strategy=strategy, row_data=row,
         ))
     return drifts

--- a/tools/customisation_audit/drift.py
+++ b/tools/customisation_audit/drift.py
@@ -1,0 +1,28 @@
+"""Drift dataclass + stable_id helper. Schema per plan §6."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Drift:
+    id: str
+    drift_class: str   # serialised as "class" in JSON (Python keyword)
+    verdict: str
+    doctype: str
+    name: str
+    owning_app_proposed: str
+    fixture_path_proposed: str
+    promotion_strategy: str
+    row_data: dict[str, Any] = field(default_factory=dict)
+    diff: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+def stable_id(drift_class: str, name: str, *key_fields: str) -> str:
+    """Hash class+name+key-fields → 12-char prefix. Deterministic across runs."""
+    blob = "".join((drift_class, name, *key_fields)).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:12]

--- a/tools/customisation_audit/drift_builder.py
+++ b/tools/customisation_audit/drift_builder.py
@@ -8,17 +8,22 @@ from tools.customisation_audit.verdict import PromotionStrategy, Verdict
 
 
 def db_only(drift_class: str, doctype: str, row: dict, key_fields: tuple[str, ...],
-            mapping: dict[str, str], strategy: PromotionStrategy) -> Drift:
-    """Build a DB_ONLY drift entry from a DB row, resolving owning app via row.module."""
-    owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+            mapping: dict[str, str], strategy: PromotionStrategy,
+            attribution_entry: dict | None = None) -> Drift:
+    """Build a DB_ONLY drift. Attribution-map entry overrides module-based lookup."""
+    if attribution_entry:
+        owning = attribution_entry["owning_app"]
+        chosen = PromotionStrategy(attribution_entry["promotion_strategy"])
+    else:
+        owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+        chosen = strategy if owning else PromotionStrategy.MANUAL
     fixture_path = str(app_inventory.fixture_path(owning, doctype)) if owning else ""
     return Drift(
         id=stable_id(drift_class, row["name"], *(row.get(k, "") for k in key_fields)),
         drift_class=drift_class, verdict=Verdict.DB_ONLY.value,
         doctype=doctype, name=row["name"], owning_app_proposed=owning,
         fixture_path_proposed=fixture_path,
-        promotion_strategy=(strategy if owning else PromotionStrategy.MANUAL).value,
-        row_data=row,
+        promotion_strategy=chosen.value, row_data=row,
     )
 
 

--- a/tools/customisation_audit/drift_builder.py
+++ b/tools/customisation_audit/drift_builder.py
@@ -1,0 +1,34 @@
+"""Shared Drift constructors used by discover_*.py modules."""
+
+from __future__ import annotations
+
+from tools.customisation_audit import app_inventory, target_resolution
+from tools.customisation_audit.drift import Drift, stable_id
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict
+
+
+def db_only(drift_class: str, doctype: str, row: dict, key_fields: tuple[str, ...],
+            mapping: dict[str, str], strategy: PromotionStrategy) -> Drift:
+    """Build a DB_ONLY drift entry from a DB row, resolving owning app via row.module."""
+    owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)
+    fixture_path = str(app_inventory.fixture_path(owning, doctype)) if owning else ""
+    return Drift(
+        id=stable_id(drift_class, row["name"], *(row.get(k, "") for k in key_fields)),
+        drift_class=drift_class, verdict=Verdict.DB_ONLY.value,
+        doctype=doctype, name=row["name"], owning_app_proposed=owning,
+        fixture_path_proposed=fixture_path,
+        promotion_strategy=(strategy if owning else PromotionStrategy.MANUAL).value,
+        row_data=row,
+    )
+
+
+def orphan_fixture(drift_class: str, doctype: str, name: str, app: str, entry: dict,
+                   key_fields: tuple[str, ...]) -> Drift:
+    """Build an ORPHAN_FIXTURE drift entry from a fixture row with no DB match."""
+    return Drift(
+        id=stable_id(drift_class, name, *(entry.get(k, "") for k in key_fields)),
+        drift_class=drift_class, verdict=Verdict.ORPHAN_FIXTURE.value,
+        doctype=doctype, name=name, owning_app_proposed=app,
+        fixture_path_proposed=str(app_inventory.fixture_path(app, doctype)),
+        promotion_strategy=PromotionStrategy.NONE.value, row_data=entry,
+    )

--- a/tools/customisation_audit/runner.py
+++ b/tools/customisation_audit/runner.py
@@ -6,10 +6,11 @@ import yaml
 from pathlib import Path
 
 from tools.customisation_audit import (
-    db_query, delta_report, discover_client_script, discover_custom_docperm,
-    discover_custom_doctype, discover_custom_field, discover_naming_series,
-    discover_print_format, discover_property_setter, discover_server_script,
-    discover_translation, discover_unknown, discover_workflow,
+    attribution, db_query, delta_report, discover_client_script,
+    discover_custom_docperm, discover_custom_doctype, discover_custom_field,
+    discover_naming_series, discover_print_format, discover_property_setter,
+    discover_server_script, discover_translation, discover_unknown,
+    discover_workflow,
 )
 from tools.customisation_audit.audit_config import AuditConfig
 from tools.pipeline.stages.common.config import build_config
@@ -31,11 +32,13 @@ def _build_audit_config(hostname: str, project_root: str) -> AuditConfig:
         raise RuntimeError(f"{hostname!r} not found in hosts_map.yml/groups/kvm")
     cfg = build_config(hostname, host_cfg, project_root, use_wg=True)
     site_config = f"{cfg.bench_dir}/sites/{cfg.site_url}/site_config.json"
+    amap = attribution.load(Path(project_root) / attribution.DEFAULT_PATH)
     return AuditConfig(
         ssh_host=f"{hostname}-erp",
         site_config_path=site_config,
         bespoke_apps=BESPOKE_APPS,
         substrate_meta={"vm": hostname, "site_url": cfg.site_url},
+        attribution_map=amap,
     )
 
 

--- a/tools/customisation_audit/runner.py
+++ b/tools/customisation_audit/runner.py
@@ -1,0 +1,47 @@
+"""Audit orchestration — load substrate config, iterate discover modules, emit report."""
+
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+from tools.customisation_audit import (
+    db_query, delta_report, discover_client_script, discover_custom_docperm,
+    discover_custom_doctype, discover_custom_field, discover_naming_series,
+    discover_print_format, discover_property_setter, discover_server_script,
+    discover_translation, discover_unknown, discover_workflow,
+)
+from tools.customisation_audit.audit_config import AuditConfig
+from tools.pipeline.stages.common.config import build_config
+
+DISCOVER_MODULES = [
+    discover_custom_field, discover_property_setter, discover_client_script,
+    discover_print_format, discover_workflow, discover_custom_docperm,
+    discover_translation, discover_server_script, discover_custom_doctype,
+    discover_naming_series, discover_unknown,
+]
+BESPOKE_APPS = ["ce_sri", "returnable", "route_planner"]
+
+
+def _build_audit_config(hostname: str, project_root: str) -> AuditConfig:
+    with open(Path(project_root) / "hosts_map.yml") as fh:
+        hosts = yaml.safe_load(fh)
+    host_cfg = hosts.get("groups", {}).get("kvm", {}).get(hostname)
+    if not host_cfg:
+        raise RuntimeError(f"{hostname!r} not found in hosts_map.yml/groups/kvm")
+    cfg = build_config(hostname, host_cfg, project_root, use_wg=True)
+    site_config = f"{cfg.bench_dir}/sites/{cfg.site_url}/site_config.json"
+    return AuditConfig(
+        ssh_host=f"{hostname}-erp",
+        site_config_path=site_config,
+        bespoke_apps=BESPOKE_APPS,
+        substrate_meta={"vm": hostname, "site_url": cfg.site_url},
+    )
+
+
+def run_audit(hostname: str, project_root: str) -> dict:
+    """Discover all customisation drifts on hostname; return delta-report dict."""
+    cfg = _build_audit_config(hostname, project_root)
+    db_query.deploy_runner(cfg.ssh_host)
+    drifts = [d for module in DISCOVER_MODULES for d in module.run(cfg)]
+    return delta_report.emit(drifts, cfg.substrate_meta)

--- a/tools/customisation_audit/target_resolution.py
+++ b/tools/customisation_audit/target_resolution.py
@@ -1,0 +1,24 @@
+"""Heuristic: which bespoke app should own a discovered DB row?"""
+
+from __future__ import annotations
+
+from tools.bespoke_root import BESPOKE_ROOT
+
+
+def module_to_app(app_names: list[str]) -> dict[str, str]:
+    """Build module_name → app_name mapping from each app's modules.txt."""
+    out: dict[str, str] = {}
+    for name in app_names:
+        modules_txt = BESPOKE_ROOT / name / name / "modules.txt"
+        if not modules_txt.exists():
+            continue
+        for line in modules_txt.read_text().splitlines():
+            mod = line.strip()
+            if mod:
+                out[mod] = name
+    return out
+
+
+def resolve_owning_app(row_module: str, mapping: dict[str, str]) -> str:
+    """Look up the owning app by row's module field; '' if not bespoke."""
+    return mapping.get(row_module, "")

--- a/tools/customisation_audit/test_app_inventory.py
+++ b/tools/customisation_audit/test_app_inventory.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Tests for app_inventory — hooks.py parsing + fixture file discovery."""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import app_inventory  # noqa: E402
+from tools.customisation_audit._test_support import patched  # noqa: E402
+
+
+def _scaffold(root: Path, name: str, hooks: str, fix: dict[str, list]) -> None:
+    inner = root / name / name
+    (inner / "fixtures").mkdir(parents=True)
+    (inner / "hooks.py").write_text(hooks)
+    for fn, content in fix.items():
+        (inner / "fixtures" / fn).write_text(json.dumps(content))
+
+
+def test_parse_fixtures_literal_list() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _scaffold(root, "ce_sri", 'fixtures = ["Custom Field", "Property Setter"]\n', {})
+        with patched(app_inventory, "BESPOKE_ROOT", root):
+            assert app_inventory.parse_fixtures("ce_sri") == ["Custom Field", "Property Setter"]
+
+
+def test_parse_fixtures_missing_hooks_returns_empty() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        with patched(app_inventory, "BESPOKE_ROOT", Path(td)):
+            assert app_inventory.parse_fixtures("nonexistent") == []
+
+
+def test_load_fixture_file_returns_parsed_json() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _scaffold(root, "ce_sri", "fixtures = []\n",
+                  {"custom_field.json": [{"name": "X", "dt": "Sales Invoice"}]})
+        with patched(app_inventory, "BESPOKE_ROOT", root):
+            assert app_inventory.load_fixture_file("ce_sri", "Custom Field") == \
+                [{"name": "X", "dt": "Sales Invoice"}]
+
+
+if __name__ == "__main__":
+    test_parse_fixtures_literal_list()
+    test_parse_fixtures_missing_hooks_returns_empty()
+    test_load_fixture_file_returns_parsed_json()
+    print("OK test_app_inventory")

--- a/tools/customisation_audit/test_attribution.py
+++ b/tools/customisation_audit/test_attribution.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Tests for attribution — load, lookup, append_stubs, stub_unmapped_from_report."""
+
+import sys
+import tempfile
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import attribution  # noqa: E402
+
+_RESOLVED = {"owning_app": "ce_sri", "promotion_strategy": "fixture_json"}
+_TODO_OWNING = {"owning_app": "TODO", "promotion_strategy": "fixture_json"}
+
+
+def test_lookup_resolved_entry() -> None:
+    assert attribution.lookup({"custom_field": {"X": _RESOLVED}}, "custom_field", "X") == _RESOLVED
+
+
+def test_lookup_todo_returns_none() -> None:
+    assert attribution.lookup({"custom_field": {"X": _TODO_OWNING}}, "custom_field", "X") is None
+    assert attribution.lookup({}, "custom_field", "X") is None
+    assert attribution.lookup({"custom_field": {}}, "custom_field", "X") is None
+
+
+def test_append_stubs_only_adds_new() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "attr.yml"
+        assert attribution.append_stubs(path, "custom_field", ["A", "B"]) == 2
+        assert attribution.append_stubs(path, "custom_field", ["A", "C"]) == 1
+
+
+def test_stub_unmapped_picks_only_unmapped() -> None:
+    rpt = {"drifts": [
+        {"class": "custom_field", "name": "X", "promotion_strategy": "manual", "owning_app_proposed": ""},
+        {"class": "custom_field", "name": "Y", "promotion_strategy": "fixture_json", "owning_app_proposed": "ce_sri"},
+        {"class": "workflow", "name": "Z", "promotion_strategy": "manual", "owning_app_proposed": ""},
+    ]}
+    with tempfile.TemporaryDirectory() as td:
+        assert attribution.stub_unmapped_from_report(Path(td) / "x.yml", rpt) == {"custom_field": 1, "workflow": 1}
+
+
+if __name__ == "__main__":
+    test_lookup_resolved_entry()
+    test_lookup_todo_returns_none()
+    test_append_stubs_only_adds_new()
+    test_stub_unmapped_picks_only_unmapped()
+    print("OK test_attribution")

--- a/tools/customisation_audit/test_delta_report.py
+++ b/tools/customisation_audit/test_delta_report.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Tests for delta_report.emit + to_json — round-trip stability."""
+
+import json
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit.delta_report import emit, to_json  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def _sample_drifts() -> list[Drift]:
+    return [
+        Drift(id="zzz", drift_class="custom_field", verdict="db_only",
+              doctype="Sales Invoice", name="A", owning_app_proposed="ce_sri",
+              fixture_path_proposed="", promotion_strategy="fixture_json"),
+        Drift(id="aaa", drift_class="workflow", verdict="db_only",
+              doctype="Workflow", name="B", owning_app_proposed="",
+              fixture_path_proposed="", promotion_strategy="manual"),
+    ]
+
+
+def test_round_trip_byte_identical() -> None:
+    substrate = {"vm": "dev01", "frappe_version": "13.x", "erpnext_version": "13.x"}
+    report = emit(_sample_drifts(), substrate)
+    s1 = to_json(report)
+    s2 = to_json(json.loads(s1))
+    assert s1 == s2, "round-trip not byte-identical"
+
+
+def test_drifts_sorted_by_id() -> None:
+    report = emit(_sample_drifts(), {"vm": "dev01"})
+    ids = [d["id"] for d in report["drifts"]]
+    assert ids == sorted(ids), f"drifts not sorted by id: {ids}"
+
+
+def test_summary_counts_correct() -> None:
+    report = emit(_sample_drifts(), {"vm": "dev01"})
+    assert report["summary"]["total_drifts"] == 2
+    assert report["summary"]["by_class"] == {"custom_field": 1, "workflow": 1}
+
+
+if __name__ == "__main__":
+    test_round_trip_byte_identical()
+    test_drifts_sorted_by_id()
+    test_summary_counts_correct()
+    print("OK test_delta_report")

--- a/tools/customisation_audit/test_discover_client_script.py
+++ b/tools/customisation_audit/test_discover_client_script.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Tests for discover_client_script."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import (  # noqa: E402
+    db_query, discover_client_script as mod, target_resolution,
+)
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def test_db_only_when_no_js_file() -> None:
+    cfg = AuditConfig("x", "x", ["ce_sri"], {})
+    rows = [{"name": "Sales Invoice-validate", "dt": "Sales Invoice",
+             "view": "Form", "script": "frappe.ui.form.on(...)", "enabled": "1",
+             "module": "CE-SRI"}]
+    # _file_exists_for returns None because no scaffolded apps; resolve returns "ce_sri"
+    with patched(db_query, "run_query", lambda *a, **k: rows), \
+         patched(target_resolution, "module_to_app", lambda apps: {"CE-SRI": "ce_sri"}):
+        out = mod.run(cfg)
+    assert len(out) == 1 and isinstance(out[0], Drift)
+    assert out[0].verdict == "db_only"
+    assert out[0].promotion_strategy == "fixtures_custom_scripts"
+
+
+if __name__ == "__main__":
+    test_db_only_when_no_js_file()
+    print("OK test_discover_client_script")

--- a/tools/customisation_audit/test_discover_custom_docperm.py
+++ b/tools/customisation_audit/test_discover_custom_docperm.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Tests for discover_custom_docperm."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import (  # noqa: E402
+    db_query, discover_custom_docperm as mod, target_resolution,
+)
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def test_db_only_with_manual_strategy_when_no_owning_app() -> None:
+    cfg = AuditConfig("x", "x", [], {})
+    rows = [{"name": "perm-1", "parent": "Sales Invoice", "role": "Accounts User",
+             "permlevel": "0", "read": "1", "write": "1", "create": "1", "delete": "0",
+             "submit": "1", "cancel": "0", "amend": "0", "if_owner": "0"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows), \
+         patched(target_resolution, "module_to_app", lambda apps: {}):
+        out = mod.run(cfg)
+    assert len(out) == 1 and isinstance(out[0], Drift)
+    assert out[0].verdict == "db_only"
+    assert out[0].promotion_strategy == "manual"
+
+
+if __name__ == "__main__":
+    test_db_only_with_manual_strategy_when_no_owning_app()
+    print("OK test_discover_custom_docperm")

--- a/tools/customisation_audit/test_discover_custom_doctype.py
+++ b/tools/customisation_audit/test_discover_custom_doctype.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Tests for discover_custom_doctype — enumerate-only verdict."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import db_query, discover_custom_doctype as mod  # noqa: E402
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+
+
+def test_enumerate_only_verdict() -> None:
+    cfg = AuditConfig("x", "x", [], {})
+    rows = [{"name": "Custom Invoice Type", "custom": "1", "module": "CE-SRI",
+             "issingle": "0", "istable": "0", "is_submittable": "0"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows):
+        out = mod.run(cfg)
+    assert len(out) == 1
+    assert out[0].verdict == "enumerate_only"
+    assert out[0].promotion_strategy == "manual"
+
+
+if __name__ == "__main__":
+    test_enumerate_only_verdict()
+    print("OK test_discover_custom_doctype")

--- a/tools/customisation_audit/test_discover_custom_field.py
+++ b/tools/customisation_audit/test_discover_custom_field.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Tests for discover_custom_field — DB scan vs fixture index."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import (  # noqa: E402
+    app_inventory, db_query, discover_custom_field as mod, target_resolution,
+)
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def test_db_only_when_no_fixture_match() -> None:
+    cfg = AuditConfig("x", "x", ["ce_sri"], {})
+    rows = [{"name": "Sales Invoice-x", "dt": "Sales Invoice", "fieldname": "x",
+             "label": "X", "fieldtype": "Data", "options": "", "module": "CE-SRI"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows), \
+         patched(app_inventory, "load_fixture_file", lambda *a, **k: []), \
+         patched(target_resolution, "module_to_app", lambda apps: {"CE-SRI": "ce_sri"}):
+        out = mod.run(cfg)
+    assert isinstance(out, list) and len(out) == 1
+    assert isinstance(out[0], Drift)
+    assert out[0].verdict == "db_only"
+    assert out[0].owning_app_proposed == "ce_sri"
+
+
+if __name__ == "__main__":
+    test_db_only_when_no_fixture_match()
+    print("OK test_discover_custom_field")

--- a/tools/customisation_audit/test_discover_naming_series.py
+++ b/tools/customisation_audit/test_discover_naming_series.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Tests for discover_naming_series — informational verdict."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import db_query, discover_naming_series as mod  # noqa: E402
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+
+
+def test_informational_verdict() -> None:
+    cfg = AuditConfig("x", "x", [], {})
+    rows = [{"name": "001-004-.#####", "current": "264"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows):
+        out = mod.run(cfg)
+    assert len(out) == 1
+    assert out[0].verdict == "informational"
+    assert out[0].promotion_strategy == "none"
+
+
+if __name__ == "__main__":
+    test_informational_verdict()
+    print("OK test_discover_naming_series")

--- a/tools/customisation_audit/test_discover_print_format.py
+++ b/tools/customisation_audit/test_discover_print_format.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Tests for discover_print_format."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import (  # noqa: E402
+    db_query, discover_print_format as mod, target_resolution,
+)
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def test_db_only_with_v14_patch_strategy() -> None:
+    cfg = AuditConfig("x", "x", ["ce_sri"], {})
+    rows = [{"name": "Custom Invoice PF", "doc_type": "Sales Invoice",
+             "module": "CE-SRI", "standard": "No", "disabled": "0"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows), \
+         patched(target_resolution, "module_to_app", lambda apps: {"CE-SRI": "ce_sri"}):
+        out = mod.run(cfg)
+    assert len(out) == 1 and isinstance(out[0], Drift)
+    assert out[0].verdict == "db_only"
+    assert out[0].promotion_strategy == "v14_patch_script"
+
+
+if __name__ == "__main__":
+    test_db_only_with_v14_patch_strategy()
+    print("OK test_discover_print_format")

--- a/tools/customisation_audit/test_discover_property_setter.py
+++ b/tools/customisation_audit/test_discover_property_setter.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Tests for discover_property_setter."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import (  # noqa: E402
+    app_inventory, db_query, discover_property_setter as mod, target_resolution,
+)
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def test_db_only_emitted() -> None:
+    cfg = AuditConfig("x", "x", ["ce_sri"], {})
+    rows = [{"name": "Sales Invoice-status-options", "doc_type": "Sales Invoice",
+             "field_name": "status", "property": "options", "value": "X\nY",
+             "property_type": "Text", "module": "CE-SRI"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows), \
+         patched(app_inventory, "load_fixture_file", lambda *a, **k: []), \
+         patched(target_resolution, "module_to_app", lambda apps: {"CE-SRI": "ce_sri"}):
+        out = mod.run(cfg)
+    assert len(out) == 1 and isinstance(out[0], Drift)
+    assert out[0].verdict == "db_only"
+
+
+if __name__ == "__main__":
+    test_db_only_emitted()
+    print("OK test_discover_property_setter")

--- a/tools/customisation_audit/test_discover_server_script.py
+++ b/tools/customisation_audit/test_discover_server_script.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Tests for discover_server_script — enumerate-only verdict."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import db_query, discover_server_script as mod  # noqa: E402
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+
+
+def test_enumerate_only_verdict() -> None:
+    cfg = AuditConfig("x", "x", [], {})
+    rows = [{"name": "ss-1", "script_type": "DocType Event",
+             "reference_doctype": "Sales Invoice", "disabled": "0", "module": "CE-SRI"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows):
+        out = mod.run(cfg)
+    assert len(out) == 1
+    assert out[0].verdict == "enumerate_only"
+    assert out[0].promotion_strategy == "manual"
+
+
+if __name__ == "__main__":
+    test_enumerate_only_verdict()
+    print("OK test_discover_server_script")

--- a/tools/customisation_audit/test_discover_translation.py
+++ b/tools/customisation_audit/test_discover_translation.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Tests for discover_translation."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import (  # noqa: E402
+    db_query, discover_translation as mod,
+)
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def test_db_only_when_csv_lacks_source() -> None:
+    cfg = AuditConfig("x", "x", ["ce_sri"], {})
+    rows = [{"name": "trans-1", "language": "es", "source_text": "Custom Phrase",
+             "translated_text": "Frase Personalizada"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows), \
+         patched(mod, "_csv_sources", lambda apps, lang: set()):
+        out = mod.run(cfg)
+    assert len(out) == 1 and isinstance(out[0], Drift)
+    assert out[0].verdict == "db_only"
+    assert out[0].promotion_strategy == "app_translations_csv"
+
+
+if __name__ == "__main__":
+    test_db_only_when_csv_lacks_source()
+    print("OK test_discover_translation")

--- a/tools/customisation_audit/test_discover_unknown.py
+++ b/tools/customisation_audit/test_discover_unknown.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Tests for discover_unknown — Phase 1 stub returns empty list."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import discover_unknown as mod  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+
+
+def test_stub_returns_empty_list() -> None:
+    cfg = AuditConfig("x", "x", [], {})
+    assert mod.run(cfg) == []
+
+
+if __name__ == "__main__":
+    test_stub_returns_empty_list()
+    print("OK test_discover_unknown")

--- a/tools/customisation_audit/test_discover_workflow.py
+++ b/tools/customisation_audit/test_discover_workflow.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Tests for discover_workflow."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import (  # noqa: E402
+    db_query, discover_workflow as mod, target_resolution,
+)
+from tools.customisation_audit._test_support import patched  # noqa: E402
+from tools.customisation_audit.audit_config import AuditConfig  # noqa: E402
+from tools.customisation_audit.drift import Drift  # noqa: E402
+
+
+def test_db_only_with_v14_patch_strategy() -> None:
+    cfg = AuditConfig("x", "x", ["ce_sri"], {})
+    rows = [{"name": "Approval Workflow", "document_type": "Sales Invoice",
+             "is_active": "1", "module": "CE-SRI"}]
+    with patched(db_query, "run_query", lambda *a, **k: rows), \
+         patched(target_resolution, "module_to_app", lambda apps: {"CE-SRI": "ce_sri"}):
+        out = mod.run(cfg)
+    assert len(out) == 1 and isinstance(out[0], Drift)
+    assert out[0].verdict == "db_only"
+    assert out[0].promotion_strategy == "v14_patch_script"
+
+
+if __name__ == "__main__":
+    test_db_only_with_v14_patch_strategy()
+    print("OK test_discover_workflow")

--- a/tools/customisation_audit/test_drift.py
+++ b/tools/customisation_audit/test_drift.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Tests for drift.Drift + stable_id."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit.drift import Drift, stable_id  # noqa: E402
+
+
+def test_stable_id_deterministic() -> None:
+    a = stable_id("custom_field", "Sales Invoice-foo", "Sales Invoice", "foo")
+    b = stable_id("custom_field", "Sales Invoice-foo", "Sales Invoice", "foo")
+    assert a == b, "stable_id is not deterministic"
+    assert len(a) == 12, f"expected 12-char id, got {len(a)}"
+
+
+def test_stable_id_distinct_inputs() -> None:
+    a = stable_id("custom_field", "X", "Y")
+    b = stable_id("property_setter", "X", "Y")
+    assert a != b, "stable_id must distinguish drift_class"
+
+
+def test_drift_dataclass_default_factories() -> None:
+    d = Drift(id="x", drift_class="custom_field", verdict="db_only",
+              doctype="Sales Invoice", name="X", owning_app_proposed="ce_sri",
+              fixture_path_proposed="", promotion_strategy="fixture_json")
+    assert d.row_data == {} and d.notes == [] and d.diff is None
+
+
+if __name__ == "__main__":
+    test_stable_id_deterministic()
+    test_stable_id_distinct_inputs()
+    test_drift_dataclass_default_factories()
+    print("OK test_drift")

--- a/tools/customisation_audit/test_drift_builder.py
+++ b/tools/customisation_audit/test_drift_builder.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Tests for drift_builder.db_only + orphan_fixture."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import drift_builder  # noqa: E402
+from tools.customisation_audit.verdict import PromotionStrategy  # noqa: E402
+
+
+def test_db_only_with_owning_app_uses_strategy() -> None:
+    row = {"name": "X", "dt": "Sales Invoice", "fieldname": "f", "module": "CE-SRI"}
+    d = drift_builder.db_only("custom_field", "Custom Field", row, ("dt", "fieldname"),
+                              {"CE-SRI": "ce_sri"}, PromotionStrategy.FIXTURE_JSON)
+    assert d.verdict == "db_only"
+    assert d.owning_app_proposed == "ce_sri"
+    assert d.promotion_strategy == "fixture_json"
+
+
+def test_db_only_unknown_module_falls_back_to_manual() -> None:
+    row = {"name": "X", "module": "ERPNext"}
+    d = drift_builder.db_only("custom_field", "Custom Field", row, (),
+                              {}, PromotionStrategy.FIXTURE_JSON)
+    assert d.owning_app_proposed == ""
+    assert d.promotion_strategy == "manual"
+
+
+def test_orphan_fixture_emitted_with_app() -> None:
+    entry = {"name": "X", "dt": "Sales Invoice", "fieldname": "f"}
+    d = drift_builder.orphan_fixture("custom_field", "Custom Field", "X", "ce_sri",
+                                     entry, ("dt", "fieldname"))
+    assert d.verdict == "orphan_fixture"
+    assert d.owning_app_proposed == "ce_sri"
+    assert d.promotion_strategy == "none"
+
+
+if __name__ == "__main__":
+    test_db_only_with_owning_app_uses_strategy()
+    test_db_only_unknown_module_falls_back_to_manual()
+    test_orphan_fixture_emitted_with_app()
+    print("OK test_drift_builder")

--- a/tools/customisation_audit/test_target_resolution.py
+++ b/tools/customisation_audit/test_target_resolution.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Tests for target_resolution — module_to_app + resolve_owning_app."""
+
+import sys
+import tempfile
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import target_resolution  # noqa: E402
+from tools.customisation_audit._test_support import patched  # noqa: E402
+
+
+def _scaffold(root: Path, app: str, modules: list[str]) -> None:
+    inner = root / app / app
+    inner.mkdir(parents=True)
+    (inner / "modules.txt").write_text("\n".join(modules) + "\n")
+
+
+def test_module_to_app_builds_mapping() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _scaffold(root, "ce_sri", ["CE-SRI", "Returnable"])
+        _scaffold(root, "route_planner", ["Route Planner"])
+        with patched(target_resolution, "BESPOKE_ROOT", root):
+            mapping = target_resolution.module_to_app(["ce_sri", "route_planner"])
+        assert mapping == {"CE-SRI": "ce_sri", "Returnable": "ce_sri", "Route Planner": "route_planner"}
+
+
+def test_resolve_owning_app_known_and_unknown() -> None:
+    mapping = {"CE-SRI": "ce_sri"}
+    assert target_resolution.resolve_owning_app("CE-SRI", mapping) == "ce_sri"
+    assert target_resolution.resolve_owning_app("ERPNext", mapping) == ""
+
+
+if __name__ == "__main__":
+    test_module_to_app_builds_mapping()
+    test_resolve_owning_app_known_and_unknown()
+    print("OK test_target_resolution")

--- a/tools/customisation_audit/test_verdict.py
+++ b/tools/customisation_audit/test_verdict.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Tests for verdict + promotion-strategy enums.
+
+Pins the string values to the plan §6 contract — Phase 2 + 4 consume these.
+"""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit.verdict import PromotionStrategy, Verdict  # noqa: E402
+
+
+def test_verdict_strings_match_plan() -> None:
+    expected = {
+        "in_fixture_correct", "drifted", "db_only", "orphan_fixture",
+        "discardable_core_edit", "fixture_equivalent_core_edit",
+        "human_review_core_edit", "enumerate_only", "informational",
+    }
+    assert {v.value for v in Verdict} == expected
+
+
+def test_promotion_strategy_strings_match_plan() -> None:
+    expected = {
+        "fixture_json", "fixtures_custom_scripts", "app_translations_csv",
+        "v14_patch_script", "manual", "none",
+    }
+    assert {p.value for p in PromotionStrategy} == expected
+
+
+if __name__ == "__main__":
+    test_verdict_strings_match_plan()
+    test_promotion_strategy_strings_match_plan()
+    print("OK test_verdict")

--- a/tools/customisation_audit/verdict.py
+++ b/tools/customisation_audit/verdict.py
@@ -1,0 +1,26 @@
+"""Verdict + PromotionStrategy enums per plan §6."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Verdict(str, Enum):
+    IN_FIXTURE_CORRECT = "in_fixture_correct"
+    DRIFTED = "drifted"
+    DB_ONLY = "db_only"
+    ORPHAN_FIXTURE = "orphan_fixture"
+    DISCARDABLE_CORE_EDIT = "discardable_core_edit"
+    FIXTURE_EQUIVALENT_CORE_EDIT = "fixture_equivalent_core_edit"
+    HUMAN_REVIEW_CORE_EDIT = "human_review_core_edit"
+    ENUMERATE_ONLY = "enumerate_only"
+    INFORMATIONAL = "informational"
+
+
+class PromotionStrategy(str, Enum):
+    FIXTURE_JSON = "fixture_json"
+    FIXTURES_CUSTOM_SCRIPTS = "fixtures_custom_scripts"
+    APP_TRANSLATIONS_CSV = "app_translations_csv"
+    V14_PATCH_SCRIPT = "v14_patch_script"
+    MANUAL = "manual"
+    NONE = "none"

--- a/tools/identify_bad_customisations.py
+++ b/tools/identify_bad_customisations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Phase 1 dispatcher — read-only customisation discovery (#315; plan §5).
 
-Usage: ./tools/identify_bad_customisations.py --substrate dev01 [--output FILE]
+Usage: ./tools/identify_bad_customisations.py --substrate dev01 [--output FILE] [--write-stubs]
 Exit:  0 = success, 1 = substrate/pipeline failure, 2 = invalid args (argparse).
 """
 
@@ -15,7 +15,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from tools.customisation_audit import delta_report  # noqa: E402
+from tools.customisation_audit import attribution, delta_report  # noqa: E402
 from tools.customisation_audit.runner import run_audit  # noqa: E402
 
 
@@ -23,20 +23,22 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Customisation discovery (Phase 1, #315)")
     ap.add_argument("--substrate", required=True, help="VM hostname (e.g. dev01)")
     ap.add_argument("--output", default="delta_report.json", help="Output JSON path")
+    ap.add_argument("--write-stubs", action="store_true",
+                    help=f"Append TODO entries for unmapped names to {attribution.DEFAULT_PATH}")
     args = ap.parse_args()
-
     try:
         report = run_audit(args.substrate, str(REPO_ROOT))
     except (RuntimeError, subprocess.CalledProcessError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
-
     Path(args.output).write_text(delta_report.to_json(report))
-    summary = report["summary"]
-    print(f"Wrote {args.output}")
-    print(f"  total_drifts: {summary['total_drifts']}")
-    for cls, n in sorted(summary["by_class"].items()):
+    s = report["summary"]
+    print(f"Wrote {args.output}\n  total_drifts: {s['total_drifts']}")
+    for cls, n in sorted(s["by_class"].items()):
         print(f"  {cls}: {n}")
+    if args.write_stubs:
+        added = attribution.stub_unmapped_from_report(REPO_ROOT / attribution.DEFAULT_PATH, report)
+        print(f"\nAppended {sum(added.values())} stubs to {attribution.DEFAULT_PATH}: {dict(added)}")
     return 0
 
 

--- a/tools/identify_bad_customisations.py
+++ b/tools/identify_bad_customisations.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Phase 1 dispatcher — read-only customisation discovery (#315; plan §5).
+
+Usage: ./tools/identify_bad_customisations.py --substrate dev01 [--output FILE]
+Exit:  0 = success, 1 = substrate/pipeline failure, 2 = invalid args (argparse).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.customisation_audit import delta_report  # noqa: E402
+from tools.customisation_audit.runner import run_audit  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Customisation discovery (Phase 1, #315)")
+    ap.add_argument("--substrate", required=True, help="VM hostname (e.g. dev01)")
+    ap.add_argument("--output", default="delta_report.json", help="Output JSON path")
+    args = ap.parse_args()
+
+    try:
+        report = run_audit(args.substrate, str(REPO_ROOT))
+    except (RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    Path(args.output).write_text(delta_report.to_json(report))
+    summary = report["summary"]
+    print(f"Wrote {args.output}")
+    print(f"  total_drifts: {summary['total_drifts']}")
+    for cls, n in sorted(summary["by_class"].items()):
+        print(f"  {cls}: {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 1 of the customisation discovery + promotion + V14 migration plan
(`~/.claude/plans/customisation-discovery-promotion.md`). Closes #315.

Delivers `./tools/identify_bad_customisations.py` — a read-only,
unattended audit of any dev VM substrate that emits a `delta_report.json`
covering every audited customisation class (Custom Field, Property Setter,
Client Script, Print Format, Workflow, Custom DocPerm, Translation,
Server Script, Custom DocType, Naming Series, plus an `unknown` catch-all).

The dispatcher is a thin (≤50-line) wrapper around the new
`tools/customisation_audit/` library, which is decomposed into focused
≤50-line modules per CLAUDE.md anti-spiral rules.

## What's in the report

`delta_report.json` (schema in plan §6) per row:

| Field | Meaning |
|---|---|
| `id` | 12-char sha256 of class+name+key-fields — stable across runs |
| `class` | One of 11 audited classes plus `unknown` |
| `verdict` | `db_only` / `orphan_fixture` / `enumerate_only` / `informational` (Phase 1 emits these; Phase 2/4 add `drifted` / core-edit verdicts) |
| `owning_app_proposed` | ce_sri / returnable / route_planner / "" |
| `promotion_strategy` | fixture_json / fixtures_custom_scripts / app_translations_csv / v14_patch_script / manual / none |
| `row_data` | Full DB row (or fixture entry) for downstream phases |

## Operator-curated attribution

Frappe v13 customisation tables don't carry a `module` column on most
classes (only `tabPrint Format` does), so module-based ownership lookup
fails on v13. The audit consults `config/customisation_attribution.yml`
as a fallback — operator-curated mapping `drift_class → row_name →
{owning_app, promotion_strategy}`.

`--write-stubs` appends `TODO` placeholder entries for newly-discovered
unmapped names so the operator's edit scope is bounded. Default
(no flag) is read-only.

## Acceptance — dev01 substrate (real-prod-data)

Substrate prep: `destroy dev01 → addHost dev01 → provision dev01` (state
landed in main as `d91b2c4`). Production BKP: April 19 from
`~/projects/Logichem/ce_sri/BKP/20260419_072801-erp_logichem_solutions.tgz`.

Discovery run:

```
total_drifts: 360
by_class:    custom_field=8 property_setter=0 client_script=7
             print_format=4 workflow=0 custom_docperm=203
             translation=10 server_script=5 custom_doctype=4
             naming_series=119
by_verdict:  db_only=232 enumerate_only=9 informational=119
```

All §5.4 plan acceptance criteria pass:

- [x] `./tools/identify_bad_customisations.py --substrate dev01` runs without error
- [x] Emits `delta_report.json` matching the schema in §6
- [x] Per-class row counts visible on stdout
- [x] Round-trip stable: byte-identical re-emit; IDs identical across two runs
- [x] Every module ≤50 lines (mechanical check)
- [x] Each per-class module has at least one colocated test (18 test files total, all pass)
- [x] No source-tree mutation; no production interaction

## Architecture

| Path | Lines | Role |
|---|---|---|
| `tools/identify_bad_customisations.py` | 49 | CLI dispatcher |
| `tools/customisation_audit/runner.py` | 50 | Single library entry point |
| `tools/customisation_audit/drift.py` | 28 | `Drift` dataclass + `stable_id` |
| `tools/customisation_audit/verdict.py` | 26 | `Verdict` + `PromotionStrategy` enums |
| `tools/customisation_audit/delta_report.py` | 40 | `emit` + `to_json` (sort_keys round-trip) |
| `tools/customisation_audit/audit_config.py` | 17 | Per-run config |
| `tools/customisation_audit/db_query.py` | 39 | SSH wrapper + remote runner deploy |
| `tools/customisation_audit/_remote_query.py` | 41 | SCP'd onto substrate; mysql → JSON |
| `tools/customisation_audit/app_inventory.py` | 47 | Parse `<app>/hooks.py:fixtures` |
| `tools/customisation_audit/target_resolution.py` | 24 | `module_to_app` from `modules.txt` |
| `tools/customisation_audit/attribution.py` | 50 | Operator-curated overrides |
| `tools/customisation_audit/drift_builder.py` | 38 | `db_only` / `orphan_fixture` constructors |
| `tools/customisation_audit/discover_*.py` (11) | 26-49 | Per-class detection |
| `tools/customisation_audit/test_*.py` (18) | 21-47 | Colocated tests, no pytest |
| `config/customisation_attribution.yml` | — | Operator-curated YAML |

The remote runner deploy + `shlex.quote`d SQL transport satisfies the
project ban on heredoc-feeding-code (CLAUDE.md). Tests are runnable as
standalone executables per the project's no-pytest-dependency convention.

## Known limitations (deferred to later phases)

1. Field-by-field drift comparison (`drifted` verdict) is deferred to
   Phase 2 — Phase 1 only does name-presence comparison.
2. In-place core-tree edit classification (class 5.11 / `in_place_core_edit`
   verdict) is Phase 4's job; reserved in the schema, no entries emitted yet.
3. Custom DocPerm rows are keyed by their opaque hash `name` — unfriendly
   for human attribution. Phase 2 will replace with a richer
   (parent + role + permlevel) attribution schema.
4. v14 schema reintroduces `module` columns on most customisation tables;
   when the V14 migration lands (Phase 5), this gap closes for V14
   substrates.

## Test plan

- [x] All 18 colocated tests pass (`for t in tools/customisation_audit/test_*.py; do "$t"; done`)
- [x] End-to-end discovery against dev01 — 360 drifts, valid JSON, console summary correct
- [x] Round-trip byte-identical (verified via `to_json(json.loads(to_json(report)))`)
- [x] Cross-run ID stability (verified by running twice and comparing sorted ID lists)
- [x] `--write-stubs` flow (appended 231 stubs across 6 classes; restored config to empty defaults pre-commit)
- [x] No source-tree mutation in default mode (verified `git status` clean after run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)