### PR TITLE
feat(audit): operator-resolved attribution for cross-app edge cases (#320)

### DIFF
--- a/config/customisation_attribution.yml
+++ b/config/customisation_attribution.yml
@@ -11,20 +11,34 @@
 # to append TODO placeholders for newly-discovered unmapped names; then
 # replace each TODO with the appropriate value:
 #
-#   owning_app:          ce_sri | returnable | route_planner
-#   promotion_strategy:  fixture_json | fixtures_custom_scripts | v14_patch_script | manual
+#   owning_app:          ce_sri | returnable | route_planner | not_ours
+#   promotion_strategy:  fixture_json | fixtures_custom_scripts | v14_patch_script | manual | none
 #
 # Entries with TODO in either field are treated as unresolved (audit emits
 # `manual` strategy and counts the row as needing attribution).
+#
+# Use `owning_app: not_ours` + `promotion_strategy: none` to explicitly
+# acknowledge a row as not-our-customisation (e.g. a Frappe regional artifact
+# present in the production DB but not business-load-bearing). The audit then
+# surfaces it with `none` strategy, distinguishing it from unresolved rows.
 #
 # Limitation: classes whose `name` column is an opaque hash (notably Custom
 # DocPerm) are keyed by that hash here — unfriendly for human attribution.
 # Phase 2 will revisit with a richer (parent + role + permlevel) schema.
 
-custom_field: {}
+custom_field:
+  Customer-compras:
+    owning_app: returnable
+    promotion_strategy: fixture_json
 property_setter: {}
-client_script: {}
-print_format: {}
+client_script:
+  Delivery Trip-Form:
+    owning_app: route_planner
+    promotion_strategy: fixtures_custom_scripts
+print_format:
+  IRS 1099 Form:
+    owning_app: not_ours
+    promotion_strategy: none
 workflow: {}
 custom_docperm: {}
 translation: {}


### PR DESCRIPTION
## Summary

Three per-name attribution entries in `config/customisation_attribution.yml` for the cross-app edge cases that fall outside any clean auto-rule. Surfaced during the 2026-04-29 attribution walkthrough on top of the Phase 1 (#315) delta report.

## Operator decisions

| Edge case | Class | Decision | Reasoning |
|---|---|---|---|
| `Customer-compras` (+ `Bought Returnable` coupling) | custom_field | `returnable` / `fixture_json` | Bought Returnable is conceptually the returnable-bottles tracking domain that gave the app its name; Customer.compras is the Table field referencing it. Coupled ownership preserved (Bought Returnable itself is enumerate_only D-3, no YAML entry). |
| `Delivery Trip-Form` | client_script | `route_planner` / `fixtures_custom_scripts` | Delivery Trip is the natural domain of the route_planner app rather than the catch-all ce_sri. |
| `IRS 1099 Form` | print_format | `not_ours` / `none` | US Supplier 1099 reporting form. Present in production DB but not business-load-bearing for the Ecuador operation. Acknowledged as not-our-customisation rather than left in perpetual unmapped status. |

## Schema extension

Adds `not_ours` (owning_app sentinel) and `none` (promotion_strategy) to `customisation_attribution.yml`'s comment block. Both already work mechanically — `attribution.lookup()` only filters out `TODO` placeholders; any other value passes through. This PR makes the new encoding explicit + documents when to use it.

`promotion_strategy: none` was already canonical per plan §6 ("discovery-only, no promotion path") but undocumented in the YAML's own comment block until now.

## Acceptance test (per CLAUDE.md "no issue closes without one")

```
$ ./tools/identify_bad_customisations.py --substrate dev01 --output /tmp/delta_report_dev01_post320.json
Wrote /tmp/delta_report_dev01_post320.json
  total_drifts: 360

Unmapped count: 231 → 228 (drop of 3) ✓
Strategy distribution: manual 231 → 228; fixture_json 0 → 1; fixtures_custom_scripts 0 → 1; none 119 → 120
```

All three drift records carry the new attribution:
- `Customer-compras`: `owning_app_proposed='returnable', promotion_strategy='fixture_json'`
- `Delivery Trip-Form`: `owning_app_proposed='route_planner', promotion_strategy='fixtures_custom_scripts'`
- `IRS 1099 Form`: `owning_app_proposed='not_ours', promotion_strategy='none'`

## Cross-references

- Related issues filed in same session: #317 (Phase 4 — V14 safety classifier), #318 (enumerate_only mis-categorization fix), #319 (auto_rules pattern matching), #322 (--write-stubs strips comments).
- Plan: `~/.claude/plans/customisation-discovery-promotion.md` (Phase 2 design Q3 territory).
- Phase 1 acceptance: PR #316 / commit `5024ae5`.

## Latent bug now tracked: #322

`yaml.safe_dump()` in `attribution.append_stubs()` (called by `--write-stubs`) does not preserve YAML comments. The schema documentation block this PR extended survives until someone runs `--write-stubs`, after which it's stripped on rewrite. Pre-existing behaviour, not a regression introduced here. Filed as #322 for tracking.

## Test plan

- [x] YAML loads cleanly via `yaml.safe_load()`
- [x] Audit re-runs without error on dev01
- [x] Unmapped count drops by 3 (231 → 228)
- [x] All three attributions propagate to drift records
- [ ] CI sync_check (run on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)