### PR TITLE
fix(audit): enumerate_only classes emit promotion_strategy=none (#318)

### DIFF
--- a/tools/customisation_audit/discover_custom_doctype.py
+++ b/tools/customisation_audit/discover_custom_doctype.py
@@ -23,7 +23,7 @@ def run(config: AuditConfig) -> list[Drift]:
             drift_class=DRIFT_CLASS, verdict=Verdict.ENUMERATE_ONLY.value,
             doctype=DOCTYPE, name=row["name"], owning_app_proposed="",
             fixture_path_proposed="",
-            promotion_strategy=PromotionStrategy.MANUAL.value,
+            promotion_strategy=PromotionStrategy.NONE.value,
             row_data=row, notes=["Custom DocTypes are out-of-scope per audit D-3."],
         )
         for row in rows

--- a/tools/customisation_audit/discover_server_script.py
+++ b/tools/customisation_audit/discover_server_script.py
@@ -23,7 +23,7 @@ def run(config: AuditConfig) -> list[Drift]:
             drift_class=DRIFT_CLASS, verdict=Verdict.ENUMERATE_ONLY.value,
             doctype=DOCTYPE, name=row["name"], owning_app_proposed="",
             fixture_path_proposed="",
-            promotion_strategy=PromotionStrategy.MANUAL.value,
+            promotion_strategy=PromotionStrategy.NONE.value,
             row_data=row, notes=["Server Scripts require manual review per audit D-5."],
         )
         for row in rows

--- a/tools/customisation_audit/test_discover_custom_doctype.py
+++ b/tools/customisation_audit/test_discover_custom_doctype.py
@@ -18,7 +18,7 @@ def test_enumerate_only_verdict() -> None:
         out = mod.run(cfg)
     assert len(out) == 1
     assert out[0].verdict == "enumerate_only"
-    assert out[0].promotion_strategy == "manual"
+    assert out[0].promotion_strategy == "none"
 
 
 if __name__ == "__main__":

--- a/tools/customisation_audit/test_discover_server_script.py
+++ b/tools/customisation_audit/test_discover_server_script.py
@@ -18,7 +18,7 @@ def test_enumerate_only_verdict() -> None:
         out = mod.run(cfg)
     assert len(out) == 1
     assert out[0].verdict == "enumerate_only"
-    assert out[0].promotion_strategy == "manual"
+    assert out[0].promotion_strategy == "none"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `discover_custom_doctype.py` and `discover_server_script.py` now emit `promotion_strategy: none` instead of `manual`.
- `none` is already a valid strategy in delta-report schema §6 ("discovery-only, no promotion path"), correctly modelling the audit D-3 (custom_doctype, out-of-scope) and D-5 (server_script, manual review always) decisions.
- The 9 affected rows (5 server_script + 4 custom_doctype) no longer pollute the unmapped count consumed by `attribution.stub_unmapped_from_report()`.

## Acceptance — verified on dev01 substrate

| Metric | Pre (post-#320 baseline) | Post | Δ |
|---|---|---|---|
| total drifts | 360 | 360 | 0 |
| by_verdict.enumerate_only | 9 | 9 | 0 |
| by_strategy.manual | 228 | 219 | **−9** |
| by_strategy.none | 120 | 129 | **+9** |
| unmapped (manual + empty owner) | 228 | 219 | **−9** |

Note: issue body's `231→222` numbers were a pre-#320 baseline; transition magnitude (−9) matches exactly.

## Test plan

- [x] Colocated unit tests pass (`test_discover_custom_doctype.py`, `test_discover_server_script.py`)
- [x] Full `tools/customisation_audit/test_*.py` suite green (18/18)
- [x] End-to-end `./tools/identify_bad_customisations.py --substrate dev01` against real-prod-data substrate — acceptance metrics confirmed

fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)