### PR TITLE
feat(audit): auto_rules pattern matching in customisation_attribution.yml (#319)

### DIFF
--- a/config/customisation_attribution.yml
+++ b/config/customisation_attribution.yml
@@ -25,6 +25,46 @@
 # Limitation: classes whose `name` column is an opaque hash (notably Custom
 # DocPerm) are keyed by that hash here — unfriendly for human attribution.
 # Phase 2 will revisit with a richer (parent + role + permlevel) schema.
+#
+# auto_rules (#319): consulted AFTER per-name lookup. Each rule has a
+# `class`, a `when:` block (matchers), and a `then:` block (resolution).
+# All matchers in a rule's `when:` must pass (AND). First matching rule
+# wins. Per-name operator-resolved entries override auto-rules.
+#
+# Supported matchers:
+#   dt_in:        list — row["dt"] must be in the list
+#   name_pattern: str  — drift name must match SQL LIKE pattern (% → .*)
+#   view:         str  — exact match on row["view"]
+#   standard:     str  — exact match on row["standard"]
+
+auto_rules:
+  - class: custom_field
+    when:
+      dt_in: [Sales Order, Customer, Quotation, Sales Invoice, Purchase Invoice, Delivery Note]
+    then:
+      owning_app: ce_sri
+      promotion_strategy: fixture_json
+  - class: client_script
+    when:
+      name_pattern: '%-Form'
+      view: Form
+    then:
+      owning_app: ce_sri
+      promotion_strategy: fixtures_custom_scripts
+  - class: print_format
+    when:
+      standard: 'No'
+      name_pattern: 'PF:%'
+    then:
+      owning_app: ce_sri
+      promotion_strategy: v14_patch_script
+  - class: print_format
+    when:
+      standard: 'No'
+      name_pattern: 'FdI:%'
+    then:
+      owning_app: ce_sri
+      promotion_strategy: v14_patch_script
 
 custom_field:
   Customer-compras:

--- a/tools/customisation_audit/attribution.py
+++ b/tools/customisation_audit/attribution.py
@@ -9,6 +9,8 @@ from typing import Optional
 
 import yaml
 
+from tools.customisation_audit import auto_rules
+
 DEFAULT_PATH = "config/customisation_attribution.yml"
 TODO_TOKEN = "TODO"
 
@@ -25,6 +27,14 @@ def lookup(amap: dict, drift_class: str, name: str) -> Optional[dict]:
     if not entry or TODO_TOKEN in (entry.get("owning_app"), entry.get("promotion_strategy")):
         return None
     return entry
+
+
+def resolve(amap: dict, drift_class: str, name: str, row: dict) -> Optional[dict]:
+    """Per-name operator-resolved entry takes precedence; otherwise auto-rule (#319)."""
+    entry = lookup(amap, drift_class, name)
+    if entry:
+        return entry
+    return auto_rules.match(amap, drift_class, name, row)
 
 
 def append_stubs(path: Path, drift_class: str, names: list[str]) -> int:

--- a/tools/customisation_audit/auto_rules.py
+++ b/tools/customisation_audit/auto_rules.py
@@ -1,0 +1,57 @@
+"""Auto-rule pattern matching for customisation_attribution.yml (#319).
+
+Consulted by attribution.resolve() AFTER per-name lookup. Each rule has
+a `class`, a `when:` block (matchers), and a `then:` block (resolution).
+All matchers in a rule's `when:` must pass (AND). First matching rule wins.
+
+Supported matchers:
+  dt_in:        list — row["dt"] must be in the list
+  name_pattern: str  — drift name must match SQL LIKE pattern (% → .*)
+  view:         str  — exact match on row["view"]
+  standard:     str  — exact match on row["standard"]
+
+Malformed rules (missing class/when/then, unknown matcher key) are skipped
+silently — preserves audit-time forgiveness; manual count surfaces the gap."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+def _like_to_regex(pattern: str) -> str:
+    """Translate SQL LIKE % wildcard to a Python regex."""
+    return re.escape(pattern).replace("%", ".*")
+
+
+_MATCHERS = {
+    "dt_in": lambda v, name, row: isinstance(v, list) and row.get("dt") in v,
+    "name_pattern": lambda v, name, row: isinstance(v, str) and bool(re.fullmatch(_like_to_regex(v), name)),
+    "view": lambda v, name, row: row.get("view") == v,
+    "standard": lambda v, name, row: row.get("standard") == v,
+}
+
+
+def _rule_matches(when: dict, name: str, row: dict) -> bool:
+    if not when:
+        return False
+    for key, val in when.items():
+        matcher = _MATCHERS.get(key)
+        if matcher is None or not matcher(val, name, row):
+            return False
+    return True
+
+
+def _valid_then(then: object) -> bool:
+    return isinstance(then, dict) and "owning_app" in then and "promotion_strategy" in then
+
+
+def match(amap: dict, drift_class: str, name: str, row: dict) -> Optional[dict]:
+    """First auto-rule whose `class` matches and whose `when` matches the row.
+    Returns the rule's `then:` dict, or None."""
+    for rule in amap.get("auto_rules") or []:
+        if not isinstance(rule, dict) or rule.get("class") != drift_class:
+            continue
+        if _rule_matches(rule.get("when") or {}, name, row) and _valid_then(rule.get("then")):
+            return rule["then"]
+    return None

--- a/tools/customisation_audit/discover_client_script.py
+++ b/tools/customisation_audit/discover_client_script.py
@@ -22,7 +22,7 @@ def _file_exists_for(apps: list[str], dt: str) -> str | None:
 
 
 def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
-    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    entry = attribution.resolve(amap, DRIFT_CLASS, name, row)
     if entry:
         return entry["owning_app"], entry["promotion_strategy"]
     owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)

--- a/tools/customisation_audit/discover_custom_docperm.py
+++ b/tools/customisation_audit/discover_custom_docperm.py
@@ -16,7 +16,7 @@ SQL = (
 
 
 def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
-    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    entry = attribution.resolve(amap, DRIFT_CLASS, name, row)
     if entry:
         return entry["owning_app"], entry["promotion_strategy"]
     owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)

--- a/tools/customisation_audit/discover_custom_field.py
+++ b/tools/customisation_audit/discover_custom_field.py
@@ -39,7 +39,7 @@ def run(config: AuditConfig) -> list[Drift]:
         drift_builder.db_only(
             DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
             PromotionStrategy.FIXTURE_JSON,
-            attribution.lookup(config.attribution_map, DRIFT_CLASS, r["name"]),
+            attribution.resolve(config.attribution_map, DRIFT_CLASS, r["name"], r),
         )
         for r in rows if r["name"] not in fixtures
     ]

--- a/tools/customisation_audit/discover_print_format.py
+++ b/tools/customisation_audit/discover_print_format.py
@@ -20,7 +20,7 @@ SQL = (
 
 
 def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
-    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    entry = attribution.resolve(amap, DRIFT_CLASS, name, row)
     if entry:
         return entry["owning_app"], entry["promotion_strategy"]
     owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)

--- a/tools/customisation_audit/discover_property_setter.py
+++ b/tools/customisation_audit/discover_property_setter.py
@@ -35,7 +35,7 @@ def run(config: AuditConfig) -> list[Drift]:
         drift_builder.db_only(
             DRIFT_CLASS, DOCTYPE, r, KEY_FIELDS, mapping,
             PromotionStrategy.FIXTURE_JSON,
-            attribution.lookup(config.attribution_map, DRIFT_CLASS, r["name"]),
+            attribution.resolve(config.attribution_map, DRIFT_CLASS, r["name"], r),
         )
         for r in rows if r["name"] not in fixtures
     ]

--- a/tools/customisation_audit/discover_translation.py
+++ b/tools/customisation_audit/discover_translation.py
@@ -36,7 +36,7 @@ def run(config: AuditConfig) -> list[Drift]:
             csv_cache[lang] = _csv_sources(config.bespoke_apps, lang)
         if row.get("source_text", "") in csv_cache[lang]:
             continue
-        entry = attribution.lookup(config.attribution_map, DRIFT_CLASS, row["name"])
+        entry = attribution.resolve(config.attribution_map, DRIFT_CLASS, row["name"], row)
         owning = entry["owning_app"] if entry else ""
         strategy = entry["promotion_strategy"] if entry else PromotionStrategy.APP_TRANSLATIONS_CSV.value
         drifts.append(Drift(

--- a/tools/customisation_audit/discover_workflow.py
+++ b/tools/customisation_audit/discover_workflow.py
@@ -14,7 +14,7 @@ SQL = "SELECT name, document_type, is_active FROM `tabWorkflow`"
 
 
 def _resolve(name: str, row: dict, mapping: dict, amap: dict) -> tuple[str, str]:
-    entry = attribution.lookup(amap, DRIFT_CLASS, name)
+    entry = attribution.resolve(amap, DRIFT_CLASS, name, row)
     if entry:
         return entry["owning_app"], entry["promotion_strategy"]
     owning = target_resolution.resolve_owning_app(row.get("module", ""), mapping)

--- a/tools/customisation_audit/test_attribution.py
+++ b/tools/customisation_audit/test_attribution.py
@@ -39,9 +39,33 @@ def test_stub_unmapped_picks_only_unmapped() -> None:
         assert attribution.stub_unmapped_from_report(Path(td) / "x.yml", rpt) == {"custom_field": 1, "workflow": 1}
 
 
+_RULE = {"class": "custom_field", "when": {"dt_in": ["Sales Order"]},
+         "then": {"owning_app": "ce_sri", "promotion_strategy": "fixture_json"}}
+
+
+def test_resolve_per_name_wins_over_rule() -> None:
+    amap = {"custom_field": {"X": _RESOLVED}, "auto_rules": [_RULE]}
+    assert attribution.resolve(amap, "custom_field", "X", {"dt": "Sales Order"}) == _RESOLVED
+
+
+def test_resolve_todo_falls_through_to_rule() -> None:
+    amap = {"custom_field": {"X": _TODO_OWNING}, "auto_rules": [_RULE]}
+    out = attribution.resolve(amap, "custom_field", "X", {"dt": "Sales Order"})
+    assert out == _RULE["then"]
+
+
+def test_resolve_no_match_returns_none() -> None:
+    amap = {"auto_rules": [_RULE]}
+    assert attribution.resolve(amap, "custom_field", "X", {"dt": "Item"}) is None
+
+
+def test_resolve_rule_match_when_no_per_name_entry() -> None:
+    amap = {"auto_rules": [_RULE]}
+    assert attribution.resolve(amap, "custom_field", "X", {"dt": "Sales Order"}) == _RULE["then"]
+
+
 if __name__ == "__main__":
-    test_lookup_resolved_entry()
-    test_lookup_todo_returns_none()
-    test_append_stubs_only_adds_new()
-    test_stub_unmapped_picks_only_unmapped()
+    for n, fn in list(globals().items()):
+        if n.startswith("test_") and callable(fn):
+            fn()
     print("OK test_attribution")

--- a/tools/customisation_audit/test_auto_rules.py
+++ b/tools/customisation_audit/test_auto_rules.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for auto_rules — matcher dispatch, AND semantics, malformed-skip, precedence."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.customisation_audit import auto_rules  # noqa: E402
+
+_THEN_CE_FIX = {"owning_app": "ce_sri", "promotion_strategy": "fixture_json"}
+_THEN_CE_PATCH = {"owning_app": "ce_sri", "promotion_strategy": "v14_patch_script"}
+
+
+def test_like_to_regex_percent_wildcard() -> None:
+    assert auto_rules._like_to_regex("PF:%") == "PF:.*"
+    assert auto_rules._like_to_regex("%-Form") == "%\\-Form".replace("%", ".*")
+
+
+def test_dt_in_matches_list_membership() -> None:
+    rule = {"class": "custom_field", "when": {"dt_in": ["Sales Order", "Customer"]}, "then": _THEN_CE_FIX}
+    amap = {"auto_rules": [rule]}
+    assert auto_rules.match(amap, "custom_field", "X", {"dt": "Sales Order"}) == _THEN_CE_FIX
+    assert auto_rules.match(amap, "custom_field", "X", {"dt": "Item"}) is None
+
+
+def test_name_pattern_sql_like() -> None:
+    rule = {"class": "client_script", "when": {"name_pattern": "%-Form"}, "then": _THEN_CE_FIX}
+    amap = {"auto_rules": [rule]}
+    assert auto_rules.match(amap, "client_script", "Address-Form", {}) == _THEN_CE_FIX
+    assert auto_rules.match(amap, "client_script", "Address", {}) is None
+
+
+def test_view_exact_match() -> None:
+    rule = {"class": "client_script", "when": {"view": "Form"}, "then": _THEN_CE_FIX}
+    amap = {"auto_rules": [rule]}
+    assert auto_rules.match(amap, "client_script", "X", {"view": "Form"}) == _THEN_CE_FIX
+    assert auto_rules.match(amap, "client_script", "X", {"view": "List"}) is None
+
+
+def test_standard_exact_match() -> None:
+    rule = {"class": "print_format", "when": {"standard": "No"}, "then": _THEN_CE_PATCH}
+    amap = {"auto_rules": [rule]}
+    assert auto_rules.match(amap, "print_format", "X", {"standard": "No"}) == _THEN_CE_PATCH
+    assert auto_rules.match(amap, "print_format", "X", {"standard": "Yes"}) is None
+
+
+def test_and_semantics_all_must_match() -> None:
+    rule = {"class": "client_script", "when": {"name_pattern": "%-Form", "view": "Form"}, "then": _THEN_CE_FIX}
+    amap = {"auto_rules": [rule]}
+    assert auto_rules.match(amap, "client_script", "Address-Form", {"view": "Form"}) == _THEN_CE_FIX
+    assert auto_rules.match(amap, "client_script", "Address-Form", {"view": "List"}) is None
+    assert auto_rules.match(amap, "client_script", "Address", {"view": "Form"}) is None
+
+
+def test_class_filter() -> None:
+    rule = {"class": "custom_field", "when": {"dt_in": ["Sales Order"]}, "then": _THEN_CE_FIX}
+    amap = {"auto_rules": [rule]}
+    assert auto_rules.match(amap, "client_script", "X", {"dt": "Sales Order"}) is None
+
+
+def test_first_matching_rule_wins() -> None:
+    r1 = {"class": "print_format", "when": {"name_pattern": "PF:%"}, "then": _THEN_CE_PATCH}
+    r2 = {"class": "print_format", "when": {"name_pattern": "PF:%"}, "then": _THEN_CE_FIX}
+    assert auto_rules.match({"auto_rules": [r1, r2]}, "print_format", "PF: O. de V.", {}) == _THEN_CE_PATCH
+
+
+def test_malformed_rules_skipped() -> None:
+    bad = [
+        "not a dict",
+        {"class": "x"},  # no when, no then
+        {"class": "x", "when": {"unknown_matcher": "v"}, "then": _THEN_CE_FIX},  # unknown matcher
+        {"class": "x", "when": {"dt_in": ["A"]}, "then": "not a dict"},  # invalid then
+        {"class": "x", "when": {"dt_in": ["A"]}, "then": {"owning_app": "y"}},  # missing strategy
+    ]
+    good = {"class": "x", "when": {"dt_in": ["A"]}, "then": _THEN_CE_FIX}
+    assert auto_rules.match({"auto_rules": bad + [good]}, "x", "n", {"dt": "A"}) == _THEN_CE_FIX
+
+
+def test_no_auto_rules_section() -> None:
+    assert auto_rules.match({}, "custom_field", "X", {"dt": "Sales Order"}) is None
+    assert auto_rules.match({"auto_rules": None}, "custom_field", "X", {"dt": "Sales Order"}) is None
+    assert auto_rules.match({"auto_rules": []}, "custom_field", "X", {"dt": "Sales Order"}) is None
+
+
+if __name__ == "__main__":
+    for n, fn in list(globals().items()):
+        if n.startswith("test_") and callable(fn):
+            fn()
+    print("OK test_auto_rules")


### PR DESCRIPTION
## Summary

- Adds an `auto_rules:` section to `config/customisation_attribution.yml`, consulted by `attribution.resolve()` AFTER per-name lookup. Each rule has a `class`, a `when:` block of matchers (`dt_in`, `name_pattern`, `view`, `standard`), and a `then:` block of `(owning_app, promotion_strategy)`. AND inside a rule; first matching rule wins; per-name operator-resolved entries override.
- New module `tools/customisation_audit/auto_rules.py` (57 lines) + colocated tests. `attribution.py` grows by 10 lines for the `resolve()` composer. Seven `discover_*.py` modules updated (one-line each) to call `resolve()` instead of `lookup()` — the `row` dict was already in scope at every call site.
- Four rules ship covering 16 of 16 non-`custom_docperm` manual rows on dev01.

## Acceptance — verified on dev01 substrate

```
total_drifts: 360 (unchanged), by_class unchanged.
by_strategy.manual:                 219 → 203  (custom_docperm only;
                                                out of scope per plan
                                                §7 Phase 2 design Q3)
by_strategy.fixture_json:             1 →   8  (+7)
by_strategy.fixtures_custom_scripts:  1 →   7  (+6)
by_strategy.v14_patch_script:         0 →   3  (+3)
```

Round-trip stable (re-run byte-identical bar timestamp). All 19 colocated audit tests green.

## Out of scope (deferred)

- `custom_docperm` auto-rule — depends on Phase 2's richer (parent + role + permlevel) attribution schema (plan §7 Q3).
- 3 edge cases (Customer-compras, Delivery Trip-Form, IRS 1099 Form) — already operator-resolved by name in #320.
- #322 (`yaml.safe_dump()` strips comments on stub-write) is independent: #319 is read-only for the YAML.

## Test plan

- [x] `./tools/customisation_audit/test_auto_rules.py` green standalone (matcher dispatch, AND semantics, malformed-skip, precedence, no-section).
- [x] `./tools/customisation_audit/test_attribution.py` green (per-name wins, TODO falls through to rule, rule-only match, no-match returns None).
- [x] All 19 audit-module colocated tests green.
- [x] `./tools/identify_bad_customisations.py --substrate dev01` green; numbers above match design predictions exactly.
- [x] Round-trip stable (re-run produces byte-identical JSON modulo `generated_at`).
- [x] Pre-commit size check (`tools/pre_commit_size_check.py`) exit 0.

fixes #319