### PR TITLE
test(v14-prep): U6 (dt, fieldname) dedup smoke test — verdict PASS

### DIFF
--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -185,5 +185,6 @@
   "tools/pipeline/stages/wizard_completion/__init__.py": 1,
   "tools/pipeline/stages/wizard_completion/capture_backup.py": 74,
   "tools/pipeline/stages/wizard_completion/restore_backup.py": 76,
-  "tools/vm_scripts/install_specific/__init__.py": 14
+  "tools/vm_scripts/install_specific/__init__.py": 14,
+  "tools/vm_scripts/u6_dedup_smoke_test.py": 70
 }

--- a/tools/vm_scripts/u6_dedup_smoke_test.py
+++ b/tools/vm_scripts/u6_dedup_smoke_test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""U6: Frappe (dt, fieldname) dedup smoke test — martinhbramwell/ESACP#335.
+
+SCP to a target VM, run under the bench Python interpreter:
+
+    sudo -u erpadm BENCH/env/bin/python3 u6_dedup_smoke_test.py \\
+        --site SITE --bench BENCH
+
+Pass: every probed field has exactly one get_meta entry. Read-only.
+"""
+import argparse
+import json
+import os
+import sys
+
+PROBES = [
+    ("Customer", "forma_de_pago_preferida"),
+    ("Address", "barrio"),
+    ("Address", "delivery_route"),
+    ("Sales Invoice", "comission_entry_created"),
+    ("Sales Invoice", "sales_partner_supplier"),
+    ("Sales Invoice", "break_down"),
+    ("Sales Invoice", "commission_paid"),
+    ("Sales Invoice", "forma_de_pago_especificada"),
+    ("Sales Order", "data_90"),
+    ("Sales Order", "customer_special_note"),
+    ("Delivery Note", "saldo_del_cliente"),
+    ("Supplier", "purchase_taxes_and_charges_template"),
+    ("Purchase Order Item", "comprobante_interno"),
+    ("Purchase Order Item", "tipo_comprobante"),
+]
+
+
+def probe(frappe, dt, fieldname):
+    cf = frappe.db.sql(
+        "SELECT name, fieldtype FROM `tabCustom Field` WHERE dt=%s AND fieldname=%s",
+        (dt, fieldname), as_dict=True)
+    meta = frappe.get_meta(dt)
+    matches = [{"fieldname": f.fieldname, "fieldtype": f.fieldtype, "label": f.label,
+                "is_custom_field": bool(getattr(f, "is_custom_field", 0))}
+               for f in meta.fields if f.fieldname == fieldname]
+    return {"dt": dt, "fieldname": fieldname,
+            "tabCustomField_rows": len(cf), "tabCustomField_detail": cf,
+            "get_meta_total_fields": len(meta.fields),
+            "get_meta_match_count": len(matches), "get_meta_matches": matches}
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--site", required=True)
+    p.add_argument("--bench", required=True)
+    a = p.parse_args()
+
+    os.chdir(os.path.join(a.bench, "sites"))
+    import frappe
+    frappe.init(site=a.site)
+    frappe.connect()
+    frappe.clear_cache()
+
+    results = [probe(frappe, dt, fn) for dt, fn in PROBES]
+    summary = {"site": a.site, "probes": len(results),
+               "passed": all(r["get_meta_match_count"] == 1 for r in results),
+               "duplicate_count": sum(1 for r in results if r["get_meta_match_count"] != 1),
+               "results": results}
+    print(json.dumps(summary, indent=2, default=str))
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/vm_scripts/u6_dedup_smoke_test.py` — read-only Frappe metadata probe verifying `frappe.get_meta(dt).fields` returns a single entry per `(dt, fieldname)` when both a source-tree edit and a `tabCustom Field` row exist.
- Smoke-test verdict on dev01 substrate (production backup `20260502_091736`): **14 / 14 probes pass**, `is_custom_field=true` on all matches.
- DOM evidence on the Customer form confirms one `frappe-control` wrapper per fieldname, identical to stock fields.

## Disposition

Phase 5 Q-G safety prerequisite for P2 / P3 is met. Q-G stays open — operator chooses P1 / P2 / P3 on substantive merits at Session 3 entry.

A useful side-finding for Phase 5: source-tree edits to standard doctype JSONs are silently shadowed at meta-resolution time by matching `tabCustom Field` rows. The 14 catalogued `in_place_core_edit` field-add drifts already have dual presence on the production substrate — `tabCustom Field` is the authoritative source; source-tree edits are inert residue.

Verdict comment with full evidence: https://github.com/martinhbramwell/ESACP/issues/335#issuecomment-4364758504

fixes #335

## Test plan

- [x] Probe runs cleanly under bench Python on dev01 (`sudo -u erpadm /home/erpadm/frappe-bench/env/bin/python3 …`)
- [x] All 14 probes return `get_meta_match_count: 1`
- [x] DOM check on Customer form shows `wrapperCount: 1` per fieldname (parity with stock fields)
- [x] No state mutation on dev01 (read-only); script residue removed after run
- [x] Anti-spiral size check passes (script 70 lines, under 80-line cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)