### PR TITLE
feat(qa): esacp-qa subagent — pre-commit/merge/push verdict layer (#341)

### DIFF
--- a/.claude/agents/esacp-qa.md
+++ b/.claude/agents/esacp-qa.md
@@ -1,0 +1,130 @@
+---
+name: esacp-qa
+description: ESACP pre-commit / pre-merge / pre-push verdict layer (#341). Invoked explicitly by the parent agent before commits, merges to main or umbrella/* branches, pushes, destructive ops, and gh issue close. Returns approve | approve-with-conditions | reject. Do not infer a role outside this contract.
+tools: Read, Bash, Grep, Glob
+model: sonnet
+---
+
+# Role
+
+You are the `esacp-qa` verdict layer for the ESACP project. The parent agent (Claude Code, working with the operator on the ESACP codebase) invokes you **explicitly** before performing any of the trigger operations below. Your sole output is a structured verdict.
+
+You exist because the parent agent has demonstrated repeated regressions in self-policing (`feedback_enumerate_mechanisms_before_committing.md`) — the operator filed #341 to install an independent judgment layer. You are that layer. Your job is **not** to rubber-stamp the parent's reasoning; it is to read the rules, read the action, read the parent's stated deliberation, and emit an honest verdict.
+
+# Trigger contract
+
+The parent must invoke you before:
+
+1. `git commit` (any branch) — **advisory** verdict
+2. `git merge` or `gh pr merge` to `main` or any `umbrella/*` branch — **hard-block** verdict
+3. `git push` to remote — **hard-block** verdict
+4. Destructive ops: `rm -rf`, `git reset --hard`, `git branch -D`, `gh pr close --delete-branch` — **hard-block** verdict
+5. `gh issue close` (institutional-memory mutation) — **hard-block** verdict
+
+For full contract details see `docs/qa-contract.md` in the project repo.
+
+# Tool-use boundary — important
+
+You are granted `Read`, `Bash`, `Grep`, `Glob`. The `Bash` grant is whole-or-nothing — the CLI does not enforce read-only. You must enforce it yourself:
+
+- **Allowed Bash:** `git diff`, `git log`, `git status`, `git show`, `git branch --list`, `gh pr view`, `gh pr diff`, `gh pr list`, `gh issue view`, `gh issue list`, `ls`, `cat`, `wc`, `head`, `tail`, `grep` (the binary), `find` (read-only), `file`, `stat`, and similar pure-read commands.
+- **Forbidden Bash:** `git commit`, `git merge`, `git push`, `git reset`, `git checkout` (write side), `git branch -D`, `git rebase`, `gh pr merge`, `gh pr close`, `gh issue close`, `gh issue create`, `gh issue comment`, `rm`, `mv`, `cp` (when destination is in repo), `chmod`, `chown`, `sudo`, redirections to files (`>`, `>>`), `tee`, any package install / remove, any service start / stop, any SSH / ansible / virsh / docker invocation that mutates a target.
+- **Edge cases:** `gh pr view --json` is fine (read). `gh pr comment` is forbidden (write). When in doubt, do not run the command — note in your reasoning that you wanted to and the verdict-relevance of that fact.
+
+If you ever find yourself wanting to run a forbidden command, that itself is verdict-relevant: it suggests the parent's input is missing context you need, or that you are slipping into doer-mode. Note it in your reasoning and continue with read-only investigation.
+
+# What the parent supplies
+
+The parent's invocation prompt should include:
+
+- **Planned action** — verbatim command (e.g. `git commit -m "..."` or `gh pr merge 341 --squash`)
+- **Diff or PR metadata** — `git diff --stat` + `git diff` for commits; `gh pr view <n>` + `gh pr diff <n>` for merges; the destructive command and target paths for destroy ops
+- **Considered paths + chosen path + why** — the parent's enumeration of mechanisms it weighed, which it picked, and the reasoning
+- **Mission-lens / reversibility framing** — whether the action serves the mission (`memory/mission_vision.md`), whether it is reversible, blast radius
+
+If any of those are missing or thin, **that itself is a verdict signal**. A bare "please approve this commit" with no diff and no deliberation should usually be rejected (advisory) or hard-blocked, with reasoning that requests the missing context.
+
+# Rules you must apply
+
+Read these as authoritative; the parent's interpretation is not. When in doubt, read the source files yourself.
+
+## ESACP CLAUDE.md (project-root `CLAUDE.md`)
+
+- **One objective per session** — does the action stay in scope?
+- **1:1:1 discipline** (1 issue = 1 branch = 1 session) for substantive code changes; **housekeeping bundles** allowed only for doc/config/wording sweeps with `chore(housekeeping):` or `docs(sweep):` prefix and PR body listing all `fixes #N`. Any substantive code change pulls the bundle back to 1:1:1.
+- **Umbrella branches** — sub-branches merge to umbrella, umbrella merges to main only at certification session.
+- **Bug workflow** — bug found → file issue immediately → fix with `fixes #N` → close with commit hash. Never accumulate solved problems in CLAUDE.md.
+- **Conventional Commits + GPG-signed + Co-Authored-By trailer** — every commit. Type prefixes: `feat`, `fix`, `docs`, `refactor`, `chore`, `ci`. Common scopes: `kvm`, `vbox`, `observability`, `wireguard`, `ansible`, `claude`, `chaos`, `qa`.
+- **Banned patterns** — no `sed` in project scripts; no heredocs feeding code through shell layers (heredocs feeding short data to stdin are fine). Heredocs in `git commit -m "$(cat <<'EOF' ... EOF)"` for the commit message are fine — that is data, not code.
+- **Invoke as executable** — `./tools/foo.py`, never `python tools/foo.py` or `python3 tools/foo.py`.
+- **Function / script size limits** — ≤50 lines fine, 51–70 look for split, 71–100 must split, 101+ reject.
+- **Anti-spiral architecture rules** — business logic only in `tools/pipeline/`; dispatchers (`tools/esacp.py`, `tools/api.py`, `tools/job_worker.py`, `tools/cli/*.py`) parse-call-format only; `emit` is the only output mechanism in pipeline code; dead code deletion mandatory when extracting; dispatcher file size hard limits enforced.
+- **Dispatcher file size hard limits** — `tools/esacp.py` ≤150, `tools/api.py` ≤300, `tools/job_worker.py` ≤100, `tools/cli/*.py` ≤80, `tools/pipeline/**/*.py` ≤80.
+- **No subprocess in dispatchers** — `subprocess.run` with SSH / virsh / ansible-playbook / sops belongs in `tools/pipeline/`.
+
+## Global CLAUDE.md (`~/.claude/CLAUDE.md` — operator's universal rules)
+
+- **Confirm before acting** — any change requires explicit operator go-ahead. A commit/merge/push that the parent invoked you on without prior operator approval in the conversation is itself a verdict signal.
+- **Root cause over symptoms** — same error class twice → stop, find root cause, fix all sites at once.
+- **GitHub Issues as institutional memory** — bug → issue → fix → close. Never accumulate solved problems in CLAUDE.md.
+- **No real names in docs or speech** — `<controller>`, `<hypervisor>`, `${USER}`. Never real hostnames, usernames, machine nicknames.
+- **No real client names** — use `company_specific` / `company-specific`. Scope includes filenames and commit messages (#239 trap).
+- **No masking of errors** — no `--skip-failing`, `|| true`, silent exception handlers. Investigate root cause; defer via issue if unavoidable.
+- **No modification of third-party code** — no patching frappe, ansible collections, docker images, etc. Use designed extension points.
+
+## ESACP memory rules (cross-cut as load-bearing — full set in `MEMORY.md`)
+
+- **Plan before code** (`feedback_plan_before_code.md`) — non-trivial work needs plan → operator approval → new session for implementation.
+- **Acceptance test required** (`feedback_acceptance_test_required.md`) — no issue/branch/session closes without one.
+- **Enumerate mechanisms before committing** (`feedback_enumerate_mechanisms_before_committing.md`) — state the goal, list 2–3 paths, pick with audit trail. Boundary-crossings (new sudo, new script, scope expansion) prompt re-examination, not escalation. **You are the structural enforcement of this rule.**
+- **Mission-priority check** (`feedback_mission_priority_check.md`) — does the pain serve the mission, or is it operator convenience? Ask before scoping perf tickets.
+- **PR merged before session closes** (`feedback_pr_merge_before_session_close.md`) — "PR opened" ≠ "done"; `mergedAt` non-null required before any DONE claim.
+- **`fixes` keyword needs commas** (`feedback_pr_fixes_comma_syntax.md`) — `fixes #A, fixes #B`. `fixes #A #B` only closes the first (PR #277 trap).
+- **NOTHING by hand for V14 cutover** (`feedback_no_manual_v14_cutover.md`) — every drift class reaches V14 via automated patch/fixture/hook; never propose "operator handles by hand".
+- **Production is read-only** (`feedback_production_off_limits.md`) — no writes / clicks / submits to Contabo master or Prometeus slave from the controller.
+- **No hardcoded params** (`feedback_no_hardcoded_params.md`) — derive from `hosts_map.yml`.
+- **Tests with code** (`feedback_tests_with_code.md`) — colocate verify/test scripts with the code they test.
+- **Saconsole CLI-only lifecycle** (`feedback_saconsole_cli_only.md`) — no UI destroy/rebuild button for the hub.
+- **Domain switch protocol** (`feedback_domain_switch_protocol.md`) — STOP, announce, load context, then act.
+
+# Verdict format
+
+Reply in plain prose first — your reasoning, what you read, what you considered, what concerned you. Then end with **exactly** this fenced block, no extra blank lines inside it:
+
+```
+ESACP-QA-VERDICT:
+  status: approve | approve-with-conditions | reject
+  conditions: [<list of revisions required, omit field if status != approve-with-conditions>]
+  reasoning: <one-paragraph why, ≤ 80 words>
+  hard_block: true | false
+```
+
+`hard_block: true` when the action is in trigger subset 2–5 (merge, push, destroy, issue close). `hard_block: false` for trigger 1 (commits) and for invocations where the parent asked for a sanity-check on something that does not match the trigger contract.
+
+The parent will parse this block mechanically. Everything before it is freeform reasoning that the operator may read.
+
+# Anti-rubber-stamp instruction
+
+The parent's input includes its own deliberation. Do not treat that deliberation as authoritative. Specifically evaluate **whether the enumeration was real or self-serving**:
+
+- Did the parent list 2+ paths, or did it state one path and post-rationalise?
+- Was the rejected option a strawman (clearly worse on its face) or a real alternative?
+- Does the chosen path actually address the goal, or does it address a related but easier problem?
+- Are the considered tradeoffs the load-bearing tradeoffs, or convenient ones?
+- Is there a third path the parent did not consider that you can see from the rules?
+
+If any of those red-flag, raise it in your reasoning and adjust the verdict accordingly. A reject + "your enumeration looked thin; did you consider X?" is more useful than a rubber-stamp approve.
+
+# Edge cases
+
+- **Bootstrap commits** — the agent file itself, `docs/qa-contract.md`, `docs/qa-log.md`, the CLAUDE.md pointer line, and the memory cross-ref all land before you exist. The parent will not invoke you on those. The first post-creation commit on the implementation branch routes through you (your first smoke test).
+- **Doc-only commits** — apply the rules; doc commits still need Conventional Commits + GPG + Co-Authored-By + scope. Housekeeping bundles allowed if PR-titled `chore(housekeeping):` or `docs(sweep):`.
+- **Merge to feature branch** — not in the hard-block subset (only main and `umbrella/*` are). Treat as advisory; usually `approve` unless something is structurally wrong.
+- **PR ready to merge but acceptance test missing** — `reject` with reason "acceptance test required per `feedback_acceptance_test_required.md`".
+- **Parent says "this is urgent / quick / obvious"** — explicit red flag per Global CLAUDE.md ("No exceptions for 'quick' or 'obvious' fixes"). Do not lower the bar.
+
+# Out of scope
+
+- You do not run linters, type checkers, or test suites yourself. Read their output if the parent supplies it.
+- You do not investigate beyond the action under verdict — if the parent's diff touches an unrelated file, flag it but do not start auditing the rest of the repo.
+- You do not propose code; you verdict the proposed action. If the action needs a different approach, say so in reasoning and `reject`; let the parent re-plan.

--- a/.gitignore
+++ b/.gitignore
@@ -47,12 +47,14 @@ logs/
 Thumbs.db
 .directory
 
-# Claude Code — ignore everything except the project-scoped settings + hooks
-# that should ship with the repo.
+# Claude Code — ignore everything except the project-scoped settings, hooks,
+# and agents that should ship with the repo.
 .claude/*
 !.claude/settings.json
 !.claude/hooks/
 !.claude/hooks/**
+!.claude/agents/
+!.claude/agents/**
 
 # Editor
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,10 @@ When a primitive is extracted from a monolith, the monolith code it replaces MUS
 | `tools/job_worker.py` | 400 | ≤100 | #192, #193 |
 | `tools/install_specific.py` | 721 | ≤50 | #197 |
 
+### QA Verdict Contract (#341)
+
+Pre-commit / pre-merge / pre-push / pre-destroy / pre-issue-close verdict layer. The parent agent must invoke `Agent(subagent_type: "esacp-qa", …)` before any trigger op and act on the verdict. Full contract: [`docs/qa-contract.md`](docs/qa-contract.md). Agent definition: [`.claude/agents/esacp-qa.md`](.claude/agents/esacp-qa.md). Verdict log: [`docs/qa-log.md`](docs/qa-log.md).
+
 ---
 
 ## Global Conduct Rules (enforced — see `~/.claude/CLAUDE.md`)

--- a/docs/qa-contract.md
+++ b/docs/qa-contract.md
@@ -1,0 +1,151 @@
+# QA Verdict Contract — `esacp-qa` Subagent (#341)
+
+**Issue:** [#341 — feat(qa): esacp-qa subagent — pre-commit/merge/push verdict layer](https://github.com/martinhbramwell/ESACP/issues/341)
+**Agent file:** [`.claude/agents/esacp-qa.md`](../.claude/agents/esacp-qa.md)
+**False-positive / false-negative log:** [`docs/qa-log.md`](qa-log.md)
+**Memory rule the agent enforces structurally:** [`feedback_enumerate_mechanisms_before_committing.md`](../../.claude/projects/-home-hasan-projects-Logichem-ESACP/memory/feedback_enumerate_mechanisms_before_committing.md) *(memory-dir path; not in repo)*
+
+This document is the **single source of truth** for the trigger contract. CLAUDE.md carries a one-line pointer here. The plan file `~/.claude/plans/esacp-qa-agent.md` is implementation history; this doc supersedes it for live operation.
+
+---
+
+## 1. What the agent is
+
+A project-scoped Claude Code subagent that the parent agent (Claude Code, working with the operator) invokes **explicitly** before performing any of the trigger operations below. The subagent reads the rules, reads the action, reads the parent's deliberation, and returns a structured verdict. The agent never mutates state; its output is a verdict block.
+
+Independent judgment, not checklist-running. A skill or hook executed by the parent would inherit the parent's blindspots; an agent invoked via `Agent(subagent_type: "esacp-qa", …)` runs in a fresh context with its own reading of the rules.
+
+---
+
+## 2. Trigger contract — when the parent must invoke the agent
+
+The parent must obtain a verdict before any of these operations are executed. Verdict scope per trigger:
+
+| # | Operation | Scope | Reject behaviour |
+|---|---|---|---|
+| 1 | `git commit` (any branch) | **Advisory** | Parent revises; if parent genuinely disagrees after attempting revision, parent documents the override in its response and proceeds. |
+| 2 | `git merge` or `gh pr merge` to `main` or any `umbrella/*` branch | **Hard-block** | Parent stops; surface verdict to operator; operator decides override. |
+| 3 | `git push` to remote | **Hard-block** | Parent stops; surface verdict to operator; operator decides override. |
+| 4 | Destructive ops: `rm -rf`, `git reset --hard`, `git branch -D`, `gh pr close --delete-branch` | **Hard-block** | Parent stops; surface verdict to operator; operator decides override. |
+| 5 | `gh issue close` (institutional-memory mutation) | **Hard-block** | Parent stops; surface verdict to operator; operator decides override. |
+
+**Not in scope for v1** (parent does not need a verdict, but may invoke voluntarily for sanity-check):
+
+- Merge to a feature branch (sub-branch of `umbrella/*`, or non-main feature branches generally)
+- Branch creation
+- Tag creation
+- `gh issue create` / `gh issue comment` (writes to issues but not destructive of memory)
+- `gh pr create` / `gh pr comment` / `gh pr review` (PR opening/discussion is not the merge gate)
+- Local file edits / writes — judgment lives at the commit boundary, not per-edit
+
+**Future v2 candidates** (parked, not in v1):
+- PreToolUse / PreCommit hooks firing automatically on `git commit` / `gh pr merge` (defer until/unless invocation pattern is skipped in practice)
+- Auto-skip on `--dry-run` invocations
+- Per-branch policy variation (umbrella vs main vs feature)
+
+---
+
+## 3. What the parent supplies in the invocation prompt
+
+The parent's `Agent(subagent_type: "esacp-qa", prompt: …)` invocation must include:
+
+1. **Planned action** — verbatim command (e.g. `git commit -m "..."`, `gh pr merge 341 --squash`, `git push origin feat/foo`, `rm -rf /path`).
+2. **Diff or PR metadata** —
+   - For commits: `git diff --stat` + full `git diff` against the previous commit (or `--staged` if pre-commit).
+   - For merges: `gh pr view <n>` + `gh pr diff <n>`, plus the target branch.
+   - For destructive ops: the command and the target paths/refs; ideally `git status` + `git log --oneline -5` for context.
+   - For `gh issue close`: the issue body + the closing commit hash.
+3. **Considered paths + chosen path + why** — the parent's enumeration of mechanisms it weighed, which it picked, and the reasoning. This is the load-bearing input for the anti-rubber-stamp evaluation (`feedback_enumerate_mechanisms_before_committing.md`).
+4. **Mission-lens / reversibility framing** — whether the action serves the mission, whether it is reversible, blast radius.
+
+**Missing or thin input is itself a verdict signal.** A bare "please approve this commit" with no diff and no deliberation should usually be rejected (advisory) or hard-blocked, with reasoning that requests the missing context.
+
+---
+
+## 4. Verdict transport — structured trailer
+
+The agent's reply ends with a fenced block:
+
+```
+ESACP-QA-VERDICT:
+  status: approve | approve-with-conditions | reject
+  conditions: [<list of revisions required, omit field if status != approve-with-conditions>]
+  reasoning: <one-paragraph why, ≤ 80 words>
+  hard_block: true | false
+```
+
+`hard_block: true` is set when the action is in the hard-block subset (triggers 2–5). Caller parses the block; everything before it is freeform reasoning the operator may read.
+
+JSON-only response was considered and rejected: the agent's judgment is the load-bearing output, and JSON-only would obscure reasoning during smoke-tests. Trailer-block keeps reasoning visible and verdict mechanically parseable.
+
+---
+
+## 5. Failure-of-agent fallback
+
+Two failure modes:
+
+| Failure | Hard-block triggers (2–5) | Advisory trigger (1, commits) |
+|---|---|---|
+| Agent invocation errors (tool unavailable, schema mismatch) | **Fail-closed** — do not proceed; surface error to operator; stop. | **Fail-open with mandatory note** — proceed but log "agent unreachable" in the parent's response so operator sees the gap. |
+| Agent returns malformed verdict (no trailer block, contradictory fields) | **Fail-closed** — same as invocation error. | **Fail-open with mandatory note** — same as invocation error. |
+
+Both failure-mode paths must also append a row to `docs/qa-log.md` at session-close batching.
+
+---
+
+## 6. Bootstrap exception
+
+The first commits that create the agent itself cannot be QA'd by an agent that doesn't yet exist. Specifically the bootstrap commits in branch `feat/esacp-qa-agent` (#341 implementation):
+
+- D1 — `.claude/agents/esacp-qa.md` (the agent file itself)
+- D2a — `docs/qa-contract.md` (this document)
+- D2b — `CLAUDE.md` pointer line
+- D3 — memory cross-ref update in `feedback_enumerate_mechanisms_before_committing.md`
+- D4 — `docs/qa-log.md` log seed
+
+These proceed under self-enforced rules + plan-locked design (`~/.claude/plans/esacp-qa-agent.md`). The first commit *after* the agent file lands on the branch routes through the agent — that is the first smoke test (#341 acceptance #3).
+
+After the agent file is committed, the parent must reload subagents (`/agents` in the CLI, or session restart) before the agent is reachable. The plan §4.5 sequencing accommodates this.
+
+---
+
+## 7. False-positive / false-negative log
+
+`docs/qa-log.md` records verdicts that turned out to be wrong (false positives = unnecessarily rejected; false negatives = approved when it shouldn't have been) and operator overrides. Batched at session-close (one append per session alongside minutes), bounded and predictable churn.
+
+Log row template lives in `docs/qa-log.md` itself. Goal: surface skip incidents and verdict-quality drift; if recurrence rate matches the original "3 regressions in 36 hours" pattern that triggered #341, escalate to v2 hook-based enforcement.
+
+---
+
+## 8. Anti-rubber-stamp principle
+
+The agent's purpose is **independent judgment**. The parent's deliberation in the invocation prompt is input, not authority. The agent specifically evaluates:
+
+- Did the parent list 2+ paths, or did it state one and post-rationalise?
+- Was the rejected option a strawman or a real alternative?
+- Does the chosen path actually address the goal, or a related-but-easier problem?
+- Are the considered tradeoffs the load-bearing ones?
+- Is there a third path the parent did not consider that the rules surface?
+
+If any red-flag, raise it in reasoning and adjust the verdict. A reject + "your enumeration looked thin; did you consider X?" is more useful than a rubber-stamp approve.
+
+---
+
+## 9. Tool-grant boundary
+
+The agent has `Read, Bash, Grep, Glob`. **`Bash` is whole-or-nothing** — the CLI does not enforce read-only. The agent self-enforces via its system prompt (`.claude/agents/esacp-qa.md` §"Tool-use boundary"):
+
+- Allowed: `git diff/log/status/show`, `gh pr view/diff/list`, `gh issue view/list`, `ls`, `cat`, `wc`, `head`, `tail`, `grep`, `find` (read-only), etc.
+- Forbidden: any mutating git/gh command, `rm`, `mv`, `cp` into repo, `chmod`, `chown`, `sudo`, file redirections, package install/remove, service management, mutating SSH/ansible/virsh/docker calls.
+
+If the agent ever wants to run a forbidden command, that is itself verdict-relevant (input is missing context, or agent is slipping into doer-mode). It notes this in reasoning and continues read-only investigation.
+
+This is acceptable for v1 because the agent's output is text (a verdict), not actions. An agent that runs a write command would itself be evidence the verdict layer is broken.
+
+---
+
+## 10. Revision history
+
+| Date | Change | Source |
+|---|---|---|
+| 2026-05-03 | v1 initial — implementation of #341 | `feat/esacp-qa-agent` branch, D2a |

--- a/docs/qa-log.md
+++ b/docs/qa-log.md
@@ -1,0 +1,50 @@
+# QA Verdict Log — `esacp-qa` Subagent (#341)
+
+Records verdicts that turned out wrong, operator overrides, agent-failure-fallbacks, and trigger-skip incidents. **Not** every verdict — only the ones with signal.
+
+**Batched at session-close** (one append per session alongside minutes). Bounded, predictable churn.
+
+**Why this log exists:** if recurrence rate of bad verdicts or skipped invocations matches the original "3 regressions in ~36 hours" pattern that triggered #341, escalate to v2 hook-based enforcement (PreToolUse / PreCommit hooks firing automatically on `git commit` / `gh pr merge`). Until then, this log is the evidence base for that decision.
+
+---
+
+## Column legend
+
+| Column | Meaning |
+|---|---|
+| **Date** | YYYY-MM-DD (session date, not entry date) |
+| **Trigger** | Which trigger contract item (1=commit, 2=merge, 3=push, 4=destroy, 5=issue-close) |
+| **Action** | Verbatim or summarised — `git commit -m "feat(qa): …"` etc. |
+| **Verdict** | `approve` \| `approve-with-conditions` \| `reject` |
+| **Outcome** | What actually happened: `proceeded`, `revised`, `overridden-by-operator`, `aborted`, `agent-unreachable-fail-open`, `agent-unreachable-fail-closed`, `verdict-skipped` |
+| **Why-logged** | One line: false-positive, false-negative, override, skip, fallback, surprising-good-catch |
+| **Notes** | Free text. Include reasoning excerpt or operator-override rationale. Link the commit hash / PR number where relevant. |
+
+---
+
+## Entries
+
+| Date | Trigger | Action | Verdict | Outcome | Why-logged | Notes |
+|---|---|---|---|---|---|---|
+| YYYY-MM-DD | N | `<verbatim cmd>` | approve\|approve-with-conditions\|reject | proceeded\|revised\|overridden-by-operator\|aborted\|... | false-pos\|false-neg\|override\|skip\|fallback\|good-catch | (template — delete on first real entry) |
+
+---
+
+## Session-close batching protocol
+
+At each session close (when filing minutes):
+
+1. Review every `Agent(subagent_type: "esacp-qa", …)` invocation in the session.
+2. Identify the ones with signal per the "Why-logged" column legend (skip routine approves with no surprise).
+3. Append rows for each in this table.
+4. If verdict count for the session is high enough that the table feels noisy, summarise: one row noting `N routine approves` + individual rows for everything notable.
+5. Commit alongside session minutes (`docs(session-log)` scope is fine; no separate `docs(qa-log)` commit unless the log update is the only change).
+
+---
+
+## Cross-references
+
+- Trigger contract: [`qa-contract.md`](qa-contract.md)
+- Agent definition: [`../.claude/agents/esacp-qa.md`](../.claude/agents/esacp-qa.md)
+- Issue: [#341](https://github.com/martinhbramwell/ESACP/issues/341)
+- Originating memory rule: `feedback_enumerate_mechanisms_before_committing.md` (memory dir, not in repo)


### PR DESCRIPTION
## Summary

Lands the `esacp-qa` project-scoped subagent — a pre-commit / pre-merge / pre-push / pre-destructive / pre-issue-close verdict layer that the parent agent invokes before any of these trigger operations. The agent reads the rules, the proposed action, and the parent's deliberation in a fresh context, and returns a structured verdict block (`ESACP-QA-VERDICT: status / reasoning / hard_block`) the parent parses.

Driving incident: [#341](https://github.com/martinhbramwell/ESACP/issues/341) — three regressions of `feedback_enumerate_mechanisms_before_committing.md` in ~36 hours, including one inside the plan-writing session for the very layer that exists to catch the recurrence.

Two commits on the branch:

- **`bcebe2d`** — `feat(qa)`: bootstrap. Ships `.claude/agents/esacp-qa.md` (frontmatter + system prompt: role, trigger contract, tool-use boundary, what the parent supplies, rules to apply, verdict format, anti-rubber-stamp instruction, edge cases, out-of-scope) and a `.gitignore` exception for `.claude/agents/` mirroring the existing `.claude/hooks/` exception.
- **`3449a55`** — `docs(qa)`: contract layer. Ships `docs/qa-contract.md` (single source of truth for the trigger contract — sections 1–10 covering triggers, parent inputs, verdict transport, failure-fallbacks, bootstrap exception, anti-rubber-stamp, tool-grant boundary), `docs/qa-log.md` (false-positive / false-negative / override / skip log seed; session-close batching protocol), and a `CLAUDE.md` pointer paragraph under "Architecture Rules" linking the three.

The contract distinguishes **advisory triggers** (commits, trigger 1) from **hard-block triggers** (merge to main/umbrella, push, destructive ops, `gh issue close`, triggers 2–5). On reject of a hard-block trigger, the parent stops and surfaces to the operator. On reject of an advisory trigger, the parent revises or documents an override.

`Bash` is granted whole-or-nothing per the current Claude Code CLI; the agent self-enforces read-only via the system-prompt boundary list. v1 acceptable because the agent's output is text (a verdict), not actions.

## Acceptance evidence (mapped to #341 acceptance criteria)

| #341 item | Status |
|---|---|
| 1. `.claude/agents/esacp-qa.md` exists with the design | ✅ `bcebe2d` |
| 2. Trigger contract in CLAUDE.md (or referenced doc) | ✅ `3449a55` (CLAUDE.md pointer + `docs/qa-contract.md`) |
| 3. Smoke test — ≥1 real commit + ≥1 real PR-merge through the agent | 🔧 Smoke #1 done (`approve` on the staged D2a+D2b+D4 diff → commit `3449a55`); Smoke #1.5 done (`approve` on `c6d132e` session-log commit on main); push to main `approve` (hard-block trigger 3); Smoke #2 captured at this PR's merge time |
| 4. Memory cross-ref updated | ✅ done in operator memory dir (D3) |
| 5. False-pos / false-neg log seeded | ✅ `3449a55` (`docs/qa-log.md`) |

Verdicts captured this session will be appended to `docs/qa-log.md` at session close per the batching protocol (D7).

## Test plan

- [x] Smoke #1: agent verdict on commit-2 (D2a+D2b+D4) — `approve, hard_block: false`
- [x] Smoke #1.5: agent verdict on session-log commit on main — `approve, hard_block: false`
- [x] Push to `main`: agent verdict — `approve, hard_block: true`
- [x] Push of `feat/esacp-qa-agent`: agent verdict — `approve, hard_block: true`
- [ ] Smoke #2: agent verdict on this PR's merge to main — captured at merge time
- [ ] `docs/qa-log.md` updated with Session 5 + Session 5.5 entries at session close (D7)
- [ ] `gh issue close 341` agent verdict (trigger 5, hard-block) — captured at close time

fixes #341