### PR TITLE
chore(hosts): correct martinhbramwell/returnable → martinhbramwell/BtlMng in tenant_business_apps bucket

### DIFF
--- a/platforms/kvm/bucket_survey.py
+++ b/platforms/kvm/bucket_survey.py
@@ -10,7 +10,7 @@ BUCKETS = {
     'logisolu_knowbase': ['martinhbramwell/LogiSoluKnowBase'],
     'ce_sri': ['martinhbramwell/ce_sri', 'martinhbramwell/ce_sri_svc'],
     'tenant_business_apps': [
-        'martinhbramwell/route_planner', 'martinhbramwell/returnable',
+        'martinhbramwell/route_planner', 'martinhbramwell/BtlMng',
     ],
     'logisolu_memory': ['martinhbramwell/LogiSoluMemory'],
     'logisolu_validations': ['martinhbramwell/LogiSoluValidations'],


### PR DESCRIPTION
## Summary

One-line correction to `platforms/kvm/bucket_survey.py:13`. The bespoke app
named `returnable` lives in the repo `martinhbramwell/BtlMng` on GitHub, not
`martinhbramwell/returnable`. The latter does not exist and would 404 if
`session_buckets.txt` ever enabled the `tenant_business_apps` bucket.

Discovered Session 33 during ESACP #377 pre-flight, when the agenda's
implicit reference `martinhbramwell/returnable` produced a 404. Repo identity
verified against `gh repo list martinhbramwell` and the production-mode bench
remote on dev02 (both confirm `BtlMng`).

## Change

```diff
     'tenant_business_apps': [
-        'martinhbramwell/route_planner', 'martinhbramwell/returnable',
+        'martinhbramwell/route_planner', 'martinhbramwell/BtlMng',
     ],
```

## Smoke test (manual acceptance per esacp-qa Trigger 1+3 condition)

\`\`\`
python3 -c \"from bucket_survey import survey_buckets; print(survey_buckets(['tenant_business_apps']))\"
\`\`\`

Returns real bucket-survey output with both apps queried successfully —
`martinhbramwell/route_planner` and `martinhbramwell/BtlMng` (including the
`8bd4462` BtlMng master tip just merged this session via #377). No 404 on
either repo.

## Tracker linkage

- Closes #378 (auto-close via `fixes` keyword in commit body)
- Sibling: #377 (BtlMng Phase-2 consolidation; this session) — discovery context
- Related: #369 (`bucket_survey.py` implementation)
- Related: #358 (three-bucket architecture)

## Companion commit

`bucket_definitions.md` (human-readable mirror in LogiSoluMemory) gets the
matching one-line correction in a sibling commit on that repo. Both repos
end the session with consistent bucket maps.

## Test plan

- [x] Smoke test: `survey_buckets(['tenant_business_apps'])` returns successfully against real GitHub
- [ ] PR merges to main (`mergedAt` non-null)
- [ ] #378 auto-closed (verify; manual close fallback)
- [ ] LogiSoluMemory `bucket_definitions.md` mirror updated in companion commit