### PR TITLE
fix(ansible): declare packer as a saconsole dependency (#388)

### DIFF
--- a/ansible/roles/packer/defaults/main.yml
+++ b/ansible/roles/packer/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# packer role defaults
+
+# Minimum packer version required by platforms/packer/erpnext-v13.pkr.hcl
+# (`required_version = ">= 1.9.0"`). The role installs whatever the HashiCorp
+# apt repo currently publishes for the host's Ubuntu release; this value is
+# the floor checked by the post-install verification task.
+packer_min_version: "1.9.0"
+
+# HashiCorp apt repo plumbing — kept here so the role is self-contained and
+# build.sh can be cleaned up to assume `apt install packer` works post-bootstrap.
+packer_hashicorp_gpg_url: "https://apt.releases.hashicorp.com/gpg"
+packer_hashicorp_keyring: "/usr/share/keyrings/hashicorp-archive-keyring.gpg"
+packer_hashicorp_apt_list: "/etc/apt/sources.list.d/hashicorp.list"

--- a/ansible/roles/packer/tasks/main.yml
+++ b/ansible/roles/packer/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+# packer role — Declare HashiCorp packer as a first-class saconsole dependency.
+#
+# Why this role exists (ESACP #388):
+#   platforms/packer/build.sh formerly had an inline auto-install fallback
+#   (curl gpg | apt source | apt install) that ran transiently the first time
+#   build.sh was invoked. When saconsole was rebuilt later, packer was absent
+#   because nothing in the bootstrap path declared it. This role makes the
+#   HashiCorp apt repo + packer package an explicit saconsole capability so
+#   future rebuilds restore it with no manual intervention.
+#
+# Applied to the hub only (Play 2 in site-kvm.yml). saconsole == hub.
+
+- name: Ensure HashiCorp GPG keyring directory exists
+  ansible.builtin.file:
+    path: "{{ packer_hashicorp_keyring | dirname }}"
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+
+- name: Install HashiCorp apt signing key (dearmored)
+  ansible.builtin.get_url:
+    url: "{{ packer_hashicorp_gpg_url }}"
+    dest: /tmp/hashicorp-archive-keyring.asc
+    mode: '0644'
+    force: no
+  register: packer_gpg_download
+
+- name: Dearmor HashiCorp GPG key into keyring
+  ansible.builtin.command:
+    cmd: "gpg --batch --yes --dearmor -o {{ packer_hashicorp_keyring }} /tmp/hashicorp-archive-keyring.asc"
+  args:
+    creates: "{{ packer_hashicorp_keyring }}"
+
+- name: Add HashiCorp apt repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by={{ packer_hashicorp_keyring }}] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    filename: "hashicorp"
+    state: present
+    update_cache: yes
+
+- name: Install packer
+  ansible.builtin.apt:
+    name: packer
+    state: present
+
+- name: Capture packer version
+  ansible.builtin.command:
+    cmd: "packer version"
+  register: packer_version_out
+  changed_when: false
+
+- name: Assert packer version meets minimum required by erpnext-v13.pkr.hcl
+  ansible.builtin.assert:
+    that:
+      - packer_version_out.stdout is regex('^Packer v[0-9]+\\.[0-9]+\\.[0-9]+')
+      - (packer_version_out.stdout | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)', '\\1') | first) is version(packer_min_version, '>=')
+    fail_msg: "packer {{ packer_version_out.stdout }} is older than required {{ packer_min_version }} (set in erpnext-v13.pkr.hcl)"
+    success_msg: "packer {{ packer_version_out.stdout | regex_search('v[0-9]+\\.[0-9]+\\.[0-9]+') }} >= {{ packer_min_version }}"

--- a/ansible/site-kvm.yml
+++ b/ansible/site-kvm.yml
@@ -48,6 +48,8 @@
     - desktop
     - control_plane
     - mcp_grafana
+    - role: packer
+      tags: [packer]
     - role: acme_sh
       tags: [acme_sh]
 

--- a/platforms/packer/build.sh
+++ b/platforms/packer/build.sh
@@ -12,7 +12,7 @@
 #   bash platforms/packer/build.sh [--frappe-branch version-13] [--erpnext-branch version-13]
 #
 # Prerequisites (all met after bootstrap_hub.sh):
-#   - packer installed on the hub (this script checks and offers to install)
+#   - packer installed on the hub (declared by ansible/roles/packer/; see #388)
 #   - SSH access from the hub to toshiba: ssh hasan@toshiba
 #   - cloud-image-utils on the hub (cloud-localds)
 #   - Ubuntu 22.04 ISO on toshiba at UBUNTU_ISO_PATH
@@ -146,15 +146,9 @@ trap 'destroy_build_vm' EXIT
 
 step "Phase 1: Preflight"
 
-command -v packer &>/dev/null || {
-    log "packer not found — attempting install ..."
-    curl -fsSL https://apt.releases.hashicorp.com/gpg \
-        | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
-https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
-        | sudo tee /etc/apt/sources.list.d/hashicorp.list
-    sudo apt-get update -qq && sudo apt-get install -y packer
-}
+command -v packer &>/dev/null || die "packer not installed on this host. \
+packer is declared as a saconsole dependency by ansible/roles/packer/ (ESACP #388). \
+Apply with: (cd ansible && ansible-playbook -i inventory/kvm.yml site-kvm.yml --limit saconsole --tags packer)"
 
 command -v cloud-localds &>/dev/null \
     || die "cloud-localds not found — run: sudo apt install cloud-image-utils"


### PR DESCRIPTION
## Summary

- Declares `packer` as a first-class saconsole capability via a dedicated `ansible/roles/packer/` wired into Play 2 of `site-kvm.yml`.
- Replaces the transient inline auto-install in `platforms/packer/build.sh:149-157` with a hard preflight error pointing at the canonical role.
- Unblocks LSKB#20 Path 1 → LSKB#15 → LSKB#16 (Plan-B Phase 4 critical path).

## Acceptance (Session 49, live saconsole 10.10.0.1)

- `ansible-playbook --syntax-check site-kvm.yml --limit saconsole` → PASS.
- Real apply (`--tags packer`): `PLAY RECAP saconsole: ok=7 changed=4 failed=0`.
- Assert task: `packer v1.15.3 >= 1.9.0`.
- Re-run idempotency: `changed=0`.
- `build.sh` new preflight error path validated locally.

## Audit (per #388 design-direction comment)

Survey of other saconsole-side dependencies flagged in the comment:

| Capability | On saconsole | Declared via |
|---|---|---|
| `cloud-localds` | present | `cloud-init/hub-autoinstall.user-data.j2:42` |
| `sops` | present | `control_plane` role |
| `node`/`npm` | present (v20.20.2) | `control_plane` role |
| `gpg` | present | base Ubuntu (implicit) |
| `age` CLI | absent | n/a — not used saconsole-side |
| `gh` CLI | absent | n/a — not used saconsole-side |

No new #388-shape gaps to file.

## Test plan

- [x] `ansible-playbook --syntax-check` clean
- [x] `--check --diff` against live saconsole shows expected diff for `noble`
- [x] HashiCorp publishes `Package: packer` for `noble` (verified via apt repo index)
- [x] Real apply: `changed=4` first run, `changed=0` second run
- [x] `packer version` on saconsole reports `v1.15.3 >= 1.9.0`
- [x] `build.sh` syntax-check (`bash -n`) clean
- [x] New `build.sh` preflight error message validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)