### PR TITLE
fix(packer): pass FRAPPE_BRANCH/ERPNEXT_BRANCH through sudo env (#390)

### DIFF
--- a/platforms/packer/erpnext-v13.pkr.hcl
+++ b/platforms/packer/erpnext-v13.pkr.hcl
@@ -74,7 +74,7 @@ build {
   # Reboots the VM at the end — Packer waits for SSH to return before proceeding.
   provisioner "shell" {
     script          = "${path.root}/scripts/01_os_prep.sh"
-    execute_command = "sudo env ERP_USER=${var.erp_user} bash {{ .Path }}"
+    execute_command = "sudo env ERP_USER=${var.erp_user} FRAPPE_BRANCH=${var.frappe_branch} ERPNEXT_BRANCH=${var.erpnext_branch} bash {{ .Path }}"
     expect_disconnect = true   # VM reboots at end of this script
     pause_after     = "30s"
   }
@@ -82,13 +82,11 @@ build {
   # Phase 2: Bench + frappe + erpnext apps
   # bench init → bench get-app frappe → bench get-app erpnext → bench setup requirements
   # Stops BEFORE bench new-site — no site, no data.
+  # NOTE: branch vars must be passed inside `env` here — `sudo -H` strips environment_vars,
+  # so Packer's `environment_vars` block alone would silently drop them. See #390.
   provisioner "shell" {
     script          = "${path.root}/scripts/02_bench_install.sh"
-    execute_command = "sudo -Hu ${var.erp_user} env ERP_USER=${var.erp_user} bash {{ .Path }}"
-    environment_vars = [
-      "FRAPPE_BRANCH=${var.frappe_branch}",
-      "ERPNEXT_BRANCH=${var.erpnext_branch}",
-    ]
+    execute_command = "sudo -Hu ${var.erp_user} env ERP_USER=${var.erp_user} FRAPPE_BRANCH=${var.frappe_branch} ERPNEXT_BRANCH=${var.erpnext_branch} bash {{ .Path }}"
     timeout = "60m"
   }
 
@@ -97,13 +95,13 @@ build {
   # See feedback_frappe_v13_deps.md for full explanation.
   provisioner "shell" {
     script          = "${path.root}/scripts/03_dep_fix.sh"
-    execute_command = "sudo -Hu ${var.erp_user} env ERP_USER=${var.erp_user} bash {{ .Path }}"
+    execute_command = "sudo -Hu ${var.erp_user} env ERP_USER=${var.erp_user} FRAPPE_BRANCH=${var.frappe_branch} ERPNEXT_BRANCH=${var.erpnext_branch} bash {{ .Path }}"
   }
 
   # Phase 4: Cleanup — remove SSH host keys, machine-id, apt caches
   # Ensures each VM deployed from this image gets a fresh identity.
   provisioner "shell" {
     script          = "${path.root}/scripts/04_generalise.sh"
-    execute_command = "sudo env ERP_USER=${var.erp_user} bash {{ .Path }}"
+    execute_command = "sudo env ERP_USER=${var.erp_user} FRAPPE_BRANCH=${var.frappe_branch} ERPNEXT_BRANCH=${var.erpnext_branch} bash {{ .Path }}"
   }
 }


### PR DESCRIPTION
## Summary

Fixes [#390](https://github.com/martinhbramwell/ESACP/issues/390) — packer `execute_command` lines silently strip `FRAPPE_BRANCH`/`ERPNEXT_BRANCH` because `sudo -H ... env ERP_USER=... bash` re-sanitises environment.

## Why

Discovered in Session 50 attempting [LSKB#20](https://github.com/martinhbramwell/LogiSoluKnowBase/issues/20) Path-1 substrate-version-alignment. `build.sh --frappe-branch v13.41.3 --erpnext-branch v13.39.2` produced a qcow2 at version-13 tip; the metadata file recorded the requested versions but the qcow2 contents did not match — silent misleading artifact.

Root cause: Packer's `environment_vars` block sets variables in the caller-side shell, but `execute_command` invokes `sudo -H`, which strips environment. The `env ERP_USER=...` re-sets only that single variable, silently dropping the branch vars. Inside `02_bench_install.sh` the `${FRAPPE_BRANCH:-version-13}` defaults take over.

## Diff

- All four `execute_command` lines now explicitly pass `FRAPPE_BRANCH`/`ERPNEXT_BRANCH` (and `ERP_USER`) through `sudo … env … bash`.
- Phase 2's redundant `environment_vars` block removed (was a no-op given the strip).
- Phase 1/3/4 don't currently read the branch vars but uniform `execute_command` avoids future copy-paste hazard.
- Added a one-line `NOTE:` comment at Phase 2 explaining why the vars must be in `env`, not in `environment_vars`.

1 file changed, 6 insertions(+), 8 deletions(-).

## Pre-commit validation

`packer validate` on saconsole: **configuration is valid**.
`packer fmt -check`: exit 3, but the unmodified original on `main` returns the same exit — pre-existing whitespace drift, not introduced by this PR. Out of scope.

## Acceptance test (operator-gated, ~60 min)

- [ ] `bash platforms/packer/build.sh --frappe-branch v13.41.3 --erpnext-branch v13.39.2` on saconsole
- [ ] Build log shows `git clone … --branch v13.41.3` (frappe) and `--branch v13.39.2` (erpnext)
- [ ] `bench list-apps` on a VM provisioned from the resulting template reports `frappe 13.41.3 / erpnext 13.39.2`
- [ ] Metadata file in `out/` matches reality

## Unblocks

- LSKB#20 (substrate-version-alignment) Path-1 retry
- Plan-B Phase 4 ladder: LSKB#20 → LSKB#15 → LSKB#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)