### PR TITLE
fix(packer): use uv override for yanked transitive deps (#392)

### DIFF
--- a/platforms/packer/scripts/02_bench_install.sh
+++ b/platforms/packer/scripts/02_bench_install.sh
@@ -21,12 +21,22 @@ FRAPPE_BRANCH="${FRAPPE_BRANCH:-version-13}"
 ERPNEXT_BRANCH="${ERPNEXT_BRANCH:-version-13}"
 BENCH_DIR="${HOME}/frappe-bench"
 
-# Allow uv pip to resolve pre-release transitive deps. Frappe v13.41.3 pins
-# braintree>=4.8.0,<4.9.dev0; PyPI yanked 4.8.0, leaving only a pre-release
-# as the satisfiable version, which uv refuses by default. (#392)
-export UV_PRERELEASE=allow
-
 log() { echo "[02_bench $(date '+%H:%M:%S')] $*"; }
+
+# ── Yanked-transitive-dep overrides ───────────────────────────────────────────
+# Frappe pins transitive deps by range; some later get yanked from PyPI. uv
+# accepts yanked versions only when pinned exactly (PEP 592). Tag-gated because
+# the override would downgrade transitive deps on tags that don't need it. (#392)
+
+case "${FRAPPE_BRANCH}" in
+    v13.41.3)
+        log "applying uv override for ${FRAPPE_BRANCH}: braintree==4.8.0 (yanked, only candidate)"
+        mkdir -p "${HOME}/.config/uv"
+        cat > "${HOME}/.config/uv/uv.toml" <<'UV_TOML'
+override-dependencies = ["braintree==4.8.0"]
+UV_TOML
+        ;;
+esac
 
 # ── Sanity checks ──────────────────────────────────────────────────────────────
 

--- a/platforms/packer/scripts/02_bench_install.sh
+++ b/platforms/packer/scripts/02_bench_install.sh
@@ -21,6 +21,11 @@ FRAPPE_BRANCH="${FRAPPE_BRANCH:-version-13}"
 ERPNEXT_BRANCH="${ERPNEXT_BRANCH:-version-13}"
 BENCH_DIR="${HOME}/frappe-bench"
 
+# Allow uv pip to resolve pre-release transitive deps. Frappe v13.41.3 pins
+# braintree>=4.8.0,<4.9.dev0; PyPI yanked 4.8.0, leaving only a pre-release
+# as the satisfiable version, which uv refuses by default. (#392)
+export UV_PRERELEASE=allow
+
 log() { echo "[02_bench $(date '+%H:%M:%S')] $*"; }
 
 # ── Sanity checks ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Tag-gated uv override config writes `~/.config/uv/uv.toml` with `override-dependencies = ["braintree==4.8.0"]` before `bench init` runs, when `FRAPPE_BRANCH=v13.41.3`. Forces the yanked exact pin through uv's PEP 592 resolver behaviour.

This PR contains **two commits** that will squash-merge:

1. `e481ac3` — first attempt (`UV_PRERELEASE=allow`) — applied issue body's Option B, proved no-op by acceptance test.
2. `6cc33fc` — **corrected mechanism** — superseded the env var with the `uv.toml` override config.

## Root cause (corrected)

Frappe `v13.41.3` pins `braintree>=4.8.0,<4.9.dev0`. PyPI yanked `braintree==4.8.0`. uv excludes yanked versions from **range** constraints but accepts them when pinned **exactly** by `==` (PEP 592). The available pool is `<=4.8.0` (excluding the yanked 4.8.0) and `>4.9.dev0` — neither end satisfies frappe's pin. uv's own diagnostic hint (`--prerelease=allow`) was misleading; the version isn't a pre-release, it's yanked.

## Mechanism verification — direct test on dev02 (uv 0.9.30)

| Invocation | Result |
|---|---|
| `uv pip install "braintree>=4.8.0,<4.9.dev0"` | unsatisfiable |
| `UV_PRERELEASE=allow uv pip install ...` | unsatisfiable (env var no-op) |
| `uv pip install --prerelease=allow ...` | unsatisfiable (CLI flag no-op) |
| `uv pip install "braintree==4.8.0"` | installs (yanked warning) |
| `uv.toml` with `override-dependencies = ["braintree==4.8.0"]` | installs (yanked warning) |

## Acceptance — in-scope mechanism only

Per [`feedback_no_downstream_of_merge_acceptance.md`](https://github.com/martinhbramwell/LogiSoluMemory/blob/main/feedback_no_downstream_of_merge_acceptance.md), `fixes`-closed issues must not gate on post-merge steps. #392's scope is "uv refuses frappe v13.41.3 over braintree pre-release constraint" → mechanism: force the yanked exact pin via uv override config.

- [x] **Direct test on dev02 (uv 0.9.30)** — override config resolves the braintree constraint; build fails without it, succeeds with it. Five-row matrix above.
- [x] **End-to-end packer build on saconsole** (build v2, `/tmp/build-392-v2.log`) — override applies as designed: `applying uv override for v13.41.3: braintree==4.8.0 (yanked, only candidate)` marker present; braintree no longer mentioned as a failure cause anywhere in the log; the resolver moves past the braintree barrier.
- [x] **Tag-gating** verified — `case` block triggers only on `FRAPPE_BRANCH=v13.41.3`; other tags get no override.

Downstream pyyaml 5.4.1 build failure (next blocker after braintree clears) is tracked separately in #395 — out-of-scope of #392.

## Strategic context

Operator chose Plan-C for LSKB#20 (substrate-version-alignment): pivot Path-1 to a later frappe v13 tag where upstream has cleaned both pins, rather than peel each v13.41.3 decayed-pinned-dep individually. See LSKB#20 comment. PR#393's mechanism still ships — tag-gated to v13.41.3, harmless on other tags, useful institutional record for future yanked-dep situations.

## Related

- Fixes #392
- Follow-up: #394 (packer-scripts size-band coordinated decomposition)
- Follow-up: #395 (pyyaml 5.4.1 Cython 3 build failure — Plan-C makes it moot)
- LSKB#20 (substrate-version-alignment — pivot decision pending)
- Successor to: #390 (env-var passing flaw — fixed in PR#391, Session 51)
- Sibling: #331 (similar uv-vs-frappe-vN dep issue, V14-era)
- Parent epic: #353 (Plan B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)