### PR TITLE
fix(#398): document tabPatch Log pre-seeding (revert misdirected packer change + add procedure doc)

### DIFF
--- a/docs/FrappePatchLogPreseeding.md
+++ b/docs/FrappePatchLogPreseeding.md
@@ -1,0 +1,70 @@
+# Frappe `tabPatch Log` pre-seeding (substrate-apply technique)
+
+When a Frappe upgrade target carries a patch with a date-suffix in
+`patches.txt` (`# YYYY-MM-DD` re-run-trigger), and an older tag has already
+run that patch in un-suffixed form on the data being restored, `bench migrate`
+will re-run the patch — because `frappe.modules.patch_handler.executed()`
+does an exact string match against the `patch` column of `tabPatch Log`.
+
+If the patch is purely structural (no-op against already-migrated data) but
+trips a runtime error against the current MariaDB substrate (e.g. cross-schema
+`information_schema.tables` queries that pick up `performance_schema`
+compatibility tables), pre-seeding `tabPatch Log` with the suffixed patch
+name is a truthful resolution: the data work the patch would do has already
+been done, so marking it executed reflects the actual state.
+
+## Procedure
+
+1. Identify the exact suffixed patch string in the target version's
+   `apps/frappe/frappe/patches.txt`:
+   ```bash
+   ssh <dev-vm> "grep -n '<patch-base-name>' \
+     /home/<erp-user>/frappe-bench/apps/frappe/frappe/patches.txt"
+   ```
+   Copy the line verbatim, including the two-space gap before `#` and the
+   date.
+
+2. Confirm the un-suffixed equivalent is already in `tabPatch Log` (i.e. the
+   patch ran at the older tag on the source data):
+   ```sql
+   SELECT name, patch FROM `tabPatch Log`
+     WHERE patch LIKE '<patch-base-name>%';
+   ```
+   At least one row with the un-suffixed name should exist.
+
+3. Mark the suffixed version as executed using the frappe-native helper:
+   ```bash
+   bench --site <site> execute \
+     frappe.modules.patch_handler.update_patch_log \
+     --args '["<exact suffixed patch string from step 1>"]'
+   ```
+   The helper does
+   `frappe.get_doc({"doctype": "Patch Log", "patch": ...}).insert(...)` —
+   it handles auto-naming, timestamps, and Administrator owner.
+
+4. Retry `bench migrate`. The pre-seeded row makes `executed()` return
+   truthy and the patch is skipped.
+
+## When NOT to use
+
+- The patch makes data changes that would not have been captured by the
+  older un-suffixed run. Re-running is required; the bug is elsewhere
+  (likely in the patch's compatibility with the current MariaDB version).
+- The patch's date-suffix marks a deliberate re-run because the patch
+  logic itself changed. Skipping risks data corruption.
+- You haven't verified the un-suffixed equivalent ran cleanly on the
+  source data (`tabPatch Log` doesn't show a pre-existing row).
+
+In all three cases, pre-seeding masks a real problem.
+
+## Historical context
+
+This technique was developed for [ESACP#398](https://github.com/martinhbramwell/ESACP/issues/398)
+during Plan-C pinned-tag substrate-apply (frappe `v13.58.22` / erpnext
+`v13.55.2`) where `frappe.patches.v12_0.delete_duplicate_indexes`
+re-triggered on `# 2022-12-15` and hit MariaDB-10.6-internal
+`performance_schema` compatibility tables that
+`frappe.db.get_tables()` returns without `table_schema` filtering. The
+substrate-config approach (disabling `performance_schema`) was attempted
+and reverted: those compatibility tables remain visible in
+`information_schema.tables` regardless of `performance_schema = OFF`.

--- a/platforms/packer/scripts/01_os_prep.sh
+++ b/platforms/packer/scripts/01_os_prep.sh
@@ -46,6 +46,13 @@ character-set-client-handshake = FALSE
 character-set-server            = utf8mb4
 collation-server                = utf8mb4_unicode_ci
 
+# performance_schema OFF — ESACP#398
+# frappe v12_0 delete_duplicate_indexes patch calls frappe.db.get_tables()
+# which doesn't filter by table_schema; with performance_schema visible to
+# the site DB user, SHOW INDEX FROM global_status fails with 1146 against
+# the site DB.
+performance_schema = OFF
+
 [mysql]
 default-character-set = utf8mb4
 MYCNF

--- a/platforms/packer/scripts/01_os_prep.sh
+++ b/platforms/packer/scripts/01_os_prep.sh
@@ -46,13 +46,6 @@ character-set-client-handshake = FALSE
 character-set-server            = utf8mb4
 collation-server                = utf8mb4_unicode_ci
 
-# performance_schema OFF — ESACP#398
-# frappe v12_0 delete_duplicate_indexes patch calls frappe.db.get_tables()
-# which doesn't filter by table_schema; with performance_schema visible to
-# the site DB user, SHOW INDEX FROM global_status fails with 1146 against
-# the site DB.
-performance_schema = OFF
-
 [mysql]
 default-character-set = utf8mb4
 MYCNF


### PR DESCRIPTION
## Summary

Closes #398. Three commits net to a single docs file:

1. `5946e2d` — initial `fix(packer): disable MariaDB performance_schema` attempt. Based on S54's "PUBLIC default" hypothesis. Misdirected.
2. `fbc1299` — revert of (1). Post-apply investigation showed that `performance_schema = OFF` is already the MariaDB-10.6 default on this packer-baked substrate and does not remove the three MariaDB-internal compatibility tables (`global_status`, `session_account_connect_attrs`, `session_status`) from `information_schema.tables`. The site user holds no explicit grants on performance_schema. `frappe.db.get_tables()` (database.py:974-987) does not filter by `table_schema`, so those rows are returned alongside site-DB tables, and the v12_0 `delete_duplicate_indexes` patch trips `SHOW INDEX FROM <pst>` against the site DB with 1146 regardless of substrate config.
3. `0797d47` — adds `docs/FrappePatchLogPreseeding.md` documenting the actual fix (Path X): pre-seed `tabPatch Log` with the date-suffixed re-run-trigger patch name via `frappe.modules.patch_handler.update_patch_log`. The technique is truthful only when the un-suffixed equivalent already ran on the source data (the #398 scenario) — the doc's "When NOT to use" section spells out the masking-risk cases.

## Acceptance evidence (#398)

Path X executed on dev02:
- `PATCHLOG00570` inserted via `bench --site dev02.iridium.blue execute frappe.modules.patch_handler.update_patch_log --args '["frappe.patches.v12_0.delete_duplicate_indexes  # 2022-12-15"]'`.
- `bench migrate` retry: `delete_duplicate_indexes  # 2022-12-15` skipped cleanly; all 7 remaining will-run patches from S54 Path β survey ran to completion (`remove_share_for_std_users`, `clear_large_email_queues`, `update_schedule_type_in_loans`, `update_asset_value_for_manual_depr_entries`, `update_docs_link`, `correct_asset_value_if_je_with_workflow`, `frankfurter.app` set_value).
- Log: `dev02:/tmp/lskb15-S55-migrate-pathx.log`.

## Downstream (out of scope for #398)

Bench migrate then failed in the fixtures-import phase on a ce_sri Custom Field collision (`forma_de_pago_preferida` on Customer). Filed as **[ce_sri#10](https://github.com/martinhbramwell/ce_sri/issues/10)** — bucket-3 (the field is owned by `apps/ce_sri/ce_sri/fixtures/custom_field.json`). LSKB#15 substrate-apply now pauses on that, not on #398.

## Test plan

- [x] `bench migrate` against dev02 with Path X applied — passes the #398-specific phase (patches.txt clears).
- [x] QA T1 verdicts approved for all three commits (`5946e2d`: approve-with-conditions; `fbc1299`: approve; `0797d47`: approve).
- [ ] QA T2 verdict (pre-merge) — pending on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)