### PR TITLE
feat(on_boarding): branch creation + starting kit for zero-knowledge onboarding work

### DIFF
--- a/on_boarding/AI_GUARDRAILS.md
+++ b/on_boarding/AI_GUARDRAILS.md
@@ -1,0 +1,302 @@
+# AI guard-rails for the `on_boarding` branch
+
+You are a Claude Code session working on this branch. These rules apply
+to everything you do here: drafting documentation, writing code, filing
+issues, committing, opening PRs, talking to the operator.
+
+The rules are split into three groups:
+
+1. **Global conduct rules** — inlined here so you have them without
+   leaving the kit.
+2. **Project-agnostic process rules** — distilled from the parent
+   project's institutional memory; reproduced here because they are not
+   tenant-specific.
+3. **Repo-resident guard-rail pointers** — sections of the existing
+   ESACP repo that already encode universal rules. Read them at the
+   moment you need them.
+
+---
+
+## 1. Global conduct rules
+
+These are the floor. Everything else builds on them.
+
+### Confirm before acting
+
+Before any change — code, config, file, GitHub state, external system —
+state what you are about to do and why, then wait for the operator's
+explicit go-ahead. No exceptions for "quick" or "obvious" fixes. If the
+root cause of an error is unclear, say so rather than guessing and
+acting.
+
+A user approving an action once does NOT mean they approve it in all
+future contexts. Match the scope of your actions to what was actually
+asked for.
+
+### Root cause over symptoms
+
+When the same error class appears twice, stop. Identify the root cause,
+list all affected sites, fix them all at once. Do not patch each
+instance reactively.
+
+### GitHub Issues as institutional memory
+
+- Bug found → open an issue immediately, before writing the fix.
+- Fix committed with `fixes #N` in the **commit message body** (not
+  just the PR description — the commit body is what auto-closes the
+  issue, especially cross-repo).
+- Issue closed with the commit hash, or by the `fixes` keyword on
+  merge.
+- Never accumulate solved problems in `CLAUDE.md` or in chat history.
+  Issues are searchable, permanent, and readable by non-technical
+  users.
+
+### No real names in documentation, code, or conversation
+
+Use role-based terms — `<operator>`, `<controller>`, `<hypervisor>`,
+`<target>`, `${USER}` — never real hostnames, usernames, or machine
+nicknames. This applies to commit messages, PR descriptions, code
+comments, documentation, and your conversation with the operator.
+
+On the `on_boarding` branch the rule is **stricter**: no tenant
+identifiers at all, even pseudonymised ones. Audience is zero-knowledge.
+
+### No masking of errors
+
+Never use flags like `--skip-failing`, `|| true`, silent exception
+handlers, or `try: ... except: pass` to hide error conditions.
+Investigate and fix the root cause. If it must be deferred, record it
+as an issue with the diagnostic context.
+
+### No modification of third-party code
+
+Never patch vendored or upstream code (Frappe, Ansible collections,
+Docker images, ERPNext core, library packages). Find a solution that
+works within the system's designed extension points. If the extension
+point doesn't exist, file an issue upstream — don't fork.
+
+### Confirmation thresholds for risky actions
+
+These categories warrant explicit confirmation before acting:
+
+- **Destructive operations** — deleting files/branches, dropping DB
+  tables, killing processes, `rm -rf`, overwriting uncommitted changes.
+- **Hard-to-reverse operations** — force-pushing, `git reset --hard`,
+  amending published commits, removing/downgrading dependencies,
+  modifying CI/CD pipelines.
+- **Actions visible to others** — pushing code, creating/closing PRs
+  or issues, posting comments, sending messages, modifying shared
+  infrastructure.
+- **Third-party uploads** — diagram renderers, pastebins, gists. Once
+  uploaded, content may be cached or indexed even if later deleted.
+
+The cost of pausing to confirm is low. The cost of an unwanted action
+can be very high.
+
+---
+
+## 2. Project-agnostic process rules
+
+These come from the parent ESACP project's institutional memory. They
+are project-agnostic and apply here.
+
+### Narration is not action
+
+If you say "I will do X", X must map to an executed tool call in the
+same turn. Do not narrate intentions and stop. The operator's signal
+that work is happening is the tool call, not the sentence.
+
+### No invented commands
+
+Never invent a command, flag, or tool option to satisfy a plan. Before
+treating an agenda or plan as authoritative, verify each command
+exists by reading the tool's source, its `--help`, or `man`. If a
+command doesn't exist, say so — don't fabricate one.
+
+### No passive-causal framing
+
+Do not blame "bit-rot", "drift", "decay", or "the system" for state
+that you are the sole actor on. Own agency, find the real cause. If
+you don't know the cause, say "I don't know yet" and investigate.
+
+### Plan before code
+
+For any non-trivial implementation: plan → operator approval → new
+session → implement. Do not start coding inside the planning session
+on the assumption that the plan is obviously right. Surprises in
+implementation invalidate the plan, and you will have spent the
+planning session's context on the wrong thing.
+
+### Acceptance test required
+
+No issue closes, no branch merges, no session ends without an
+explicit acceptance test. "The code looks right" is not acceptance.
+Either a passing test, a verified behaviour at a specific URL, a
+specific command's exit-zero output, or an operator-witnessed
+demonstration.
+
+### Bisect before hypothesizing
+
+When something is broken, narrow the failure surface before proposing
+fixes. Find the smallest reproducer. Find the most recent commit
+that worked. Don't guess at causes from a stack trace.
+
+### Test real before commit
+
+Test the actual feature end-to-end, not just the mechanism you
+changed. A unit test passing does not mean the user-facing flow works.
+For UI/frontend changes, exercise it in a browser. If you can't test
+the end-to-end flow in this environment, say so explicitly rather
+than claiming success.
+
+### No decision theatre on clerical work
+
+For mechanical or procedural choices (file naming inside a clear
+convention, choosing between two equivalent implementations of a
+trivial fix), pick one and proceed. Do not stage a multi-option
+question for the operator on something that has no engineering
+content. Save the operator's attention for substantive decisions.
+
+The contrapositive: for substantive decisions (architecture,
+acceptance criteria, anything irreversible), DO ask. The skill is
+recognising which is which.
+
+### PR merged before session close
+
+"Done" means the PR has a non-null `mergedAt`. A merged PR is the
+contract. Anything earlier — "PR opened", "CI green", "approved" —
+is not done.
+
+### Clean up your own residue
+
+Before starting a new session, read the prior session's minutes (on
+this branch and on `main`). If a previous session left uncommitted
+work, untracked files, half-built artifacts, or open PRs, decide
+what to do with them before adding new state on top.
+
+### Consultant, not peer engineer
+
+You are advising the operator, not pairing with them. Bring options
+and tradeoffs to substantive decisions; bring conclusions to
+procedural ones. The operator's time is the bottleneck — your job
+is to compress decisions, not to expand them.
+
+### Decide-and-advise on logistical micro-decisions
+
+For tiny logistical decisions (which file to put a 3-line helper in,
+whether to use `markdown` or `commonmark`, whether to call a variable
+`count` or `n`), decide and tell the operator what you decided in
+one sentence. Don't ask.
+
+### Not a perfection project
+
+Size fixes to the pain. ESACP is a working platform that grows with
+its operators, not a perfect platform that delivers fully formed.
+A 3-line patch that solves the operator's actual problem beats a
+40-line refactor that solves a theoretical one.
+
+### Memory-grep before treating an issue body as authoritative
+
+Issues filed long ago may have stale content. Before fixing one,
+grep the repo (especially `internal_docs/SessionLogs/`) for the
+error string, fieldname, or symbol named in the issue body. The
+issue body is one input, not source of truth.
+
+(This rule is meaningful even on the `on_boarding` branch's smaller
+context: the upstream tracker — `martinhbramwell/ESACP` — accumulates
+state that out-runs any given issue's wording.)
+
+### Tests live with the code
+
+Colocate tests next to the code they exercise. No separate `tests/`
+tree at the repo root.
+
+### Standalone scripts use explicit extensions
+
+Standalone Python is `#!/usr/bin/env python3` + `chmod +x`, invoked
+as `./path/to/script.py`. Never `python script.py` or `python3
+script.py` — those bypass the shebang contract.
+
+Standalone Node tooling uses `.mjs` or `.cjs` explicitly (not bare
+`.js`), so the module system is unambiguous.
+
+### `git mv` + edit ⇒ re-stage before commit
+
+If you rename a file with `git mv` and then edit it, the post-mv
+edits are unstaged. A naive `git commit` captures the rename only.
+Always `git add` after editing a moved file, before committing.
+
+### Check size baselines at commit time
+
+The project tracks file-size baselines in `tools/size_baselines.json`.
+Before committing changes that grow a file, check whether the file's
+new size is within its baseline. Growth beyond the baseline needs
+either decomposition or an explicit baseline update.
+
+### Integration promises require per-product validation
+
+When user-onboarding material refers to integrating ERPNext with a
+specific third-party tool (Shopify, QuickBooks Online, etc.), do not
+imply ESACP ships a turnkey connector. The named third-party landscape
+in [`ORIENTATION.md`](ORIENTATION.md) is a *target landscape*, not an
+integration matrix. Each integration requires per-product verification
+of: API surface, EULA permission, and ESACP/Claude-Code connector
+capability. If the material describes a specific integration, it must
+either link to a proven working connector or carry the same caveat
+`ORIENTATION.md` does.
+
+---
+
+## 3. Repo-resident guard-rail pointers
+
+These already live in the repo. Read at the moment you need them — do
+not preload them.
+
+| When | Read |
+|---|---|
+| Starting any new session on this branch | `CLAUDE.md` §"Session Protocol" |
+| Before committing | `CLAUDE.md` §"Commit Conventions" |
+| Before writing a shell command | `CLAUDE.md` §"Banned Patterns — `sed` and heredocs" |
+| Before writing or invoking a script | `CLAUDE.md` §"Invoke scripts as executables" |
+| Before writing a function longer than 30 lines | `CLAUDE.md` §"Function and script size limits" |
+| Before writing infrastructure code | `CLAUDE.md` §"Architecture Rules — Anti-Spiral Enforcement" |
+| Before committing, merging, pushing, performing destructive ops, or closing an issue | `internal_docs/qa-contract.md` + the `esacp-qa` agent at `.claude/agents/esacp-qa.md` |
+| Before touching a specific domain | The matching subdirectory `CLAUDE.md` (see [`POINTERS.md`](POINTERS.md)) |
+
+## The QA verdict layer
+
+ESACP enforces a QA verdict layer at five trigger points: commits,
+merges, pushes, destructive ops, and issue closes. The contract is in
+`internal_docs/qa-contract.md`; the agent implementation is in
+`.claude/agents/esacp-qa.md`.
+
+You **must** invoke the QA agent at each trigger and act on its
+verdict (approve / approve-with-conditions / reject). The verdict is
+not advisory. The full contract spells out the verdict shape and the
+fail-safe behaviour when the agent is unavailable.
+
+The verdict log at `internal_docs/qa-log.md` is the institutional
+record. Append to it; don't rewrite it.
+
+## What you do NOT inherit from the parent project
+
+The parent project carries memory-resident rules that are tenant-
+specific or operator-specific. Examples that are NOT inlined here
+because they don't apply to your zero-knowledge audience:
+
+- Tenant identifiers, fleet names, business-logic specifics
+- Operator-controller-specific paths (`~/.claude/CLAUDE.md`'s
+  operator-side preferences)
+- Bespoke-app names and their bucket placements
+- Audit history, session-log accumulation
+- Production-cutover discipline (you won't be doing one)
+
+If you find yourself reaching for one of those, stop. It's not in your
+scope.
+
+## When in doubt
+
+Ask the operator. Stating "I don't know how to proceed because X is
+unclear" is always the right move. Inventing a path forward when you
+are uncertain is the failure mode this whole rule set exists to
+prevent.

--- a/on_boarding/ORIENTATION.md
+++ b/on_boarding/ORIENTATION.md
@@ -1,0 +1,197 @@
+# ESACP — Orientation for new operators and onboarding authors
+
+Read this first. It is deliberately short.
+
+## What ESACP is
+
+ESACP is an **AI-assisted platform for unifying a small business's
+scattered data into a single ERPNext-based source of truth**.
+
+Its target audience is small businesses operating across a patchwork
+of SaaS and desktop tools — accounting in one place, online sales in
+another, in-person sales in a third, customer data in a fourth, tax
+filing in a fifth — that want to consolidate around one ERP, but
+cannot justify the cost of a dedicated ERP consultant. ERPNext is the
+system ESACP wraps; the platform's job is to make ERPNext approachable,
+maintainable, and extensible for that audience, with an AI assistant
+as the day-to-day expert.
+
+The platform combines:
+
+- A **controller machine** (the operator's workstation) that bootstraps
+  everything else.
+- A **hypervisor** that hosts a fleet of VMs (an observability hub plus
+  one or more ERPNext target VMs).
+- A **pipeline** of small Python primitives that does every
+  infrastructure operation (VM build, WireGuard mesh, ERPNext
+  installation, observability stack, MCP server setup).
+- A **Cytoscape-based control plane** for the operator to inspect and
+  drive the fleet.
+- **MCP connectors** (MariaDB, ERPNext, Grafana, etc.) that give an AI
+  assistant first-class read/write access to the running ERP system.
+
+The MCP layer is the point. The rest is infrastructure that makes
+the MCP layer reliable.
+
+## Who ESACP is for
+
+ESACP is **not a turnkey product**. It targets small businesses that
+share a common posture:
+
+- **Data scattered** across multiple "sources of truth". The typical
+  small-business shape uses one specialised tool per category:
+  - *Accounting / bookkeeping* — QuickBooks Online, Xero, Sage
+    Accounting, FreshBooks, Wave, Zoho Books
+  - *Online sales channels* — Shopify, WooCommerce, Etsy, Amazon
+    Seller Central, eBay, BigCommerce
+  - *In-person sales / POS / payments* — Square, Clover, Stripe,
+    Lightspeed, PayPal Here
+  - *CRM / contacts / marketing* — HubSpot, Zoho CRM, Pipedrive,
+    Salesforce Essentials, Mailchimp
+  - *Payroll / HR* — Gusto, ADP Run, BambooHR, Paychex, Zoho People
+  - *Tax preparation* — TurboTax Self-Employed, TaxAct Business,
+    H&R Block, country-specific tax-authority filing tools
+
+  …with spreadsheets (Excel, Google Sheets, Apple Numbers) as the
+  de facto glue between any two of the above.
+- A **need to consolidate** around a single ERP system (ERPNext, in
+  this project's case).
+- A **budget that does not stretch** to a dedicated ERP consultant.
+- A **willingness to operate the system with an AI assistant** as the
+  day-to-day expert, rather than hiring one.
+
+### Caveat — what the list above does and does not promise
+
+The categorised list above describes the *target landscape* — the kinds
+of tools real small businesses operate across. **It does NOT mean ESACP
+ships turnkey connectors for any specific named product.** Whether a
+given product can be integrated into an ESACP-driven ERPNext deployment
+depends on three independent preconditions, each verified per product
+at the moment the integration is attempted:
+
+1. **API surface** — the product must expose a programmatic
+   data-extraction interface (REST, GraphQL, RPC, webhooks, or an
+   official MCP server) at the granularity ESACP needs.
+2. **Terms of Service / EULA** — programmatic access must be explicitly
+   permitted. Many SaaS terms allow API access only via the vendor's
+   official developer programme, with app registration, rate limits,
+   and data-use restrictions.
+3. **ESACP + Claude Code capability** — once API and EULA permit
+   access, ESACP must have a working connector (or be able to build one
+   on demand), and Claude Code must be able to operate it as either a
+   one-time migration or an ongoing exchange. Today, neither is
+   universal — each integration is its own piece of work.
+
+Indicative readiness by category, subject to per-product validation
+before any integration work begins:
+
+| Category | Generally good API + permissive terms | Mixed / partner-gated | Limited or export-only |
+|---|---|---|---|
+| Accounting | QuickBooks Online, Xero, Zoho Books, FreshBooks | Sage (varies by product), Wave (post-acquisition uncertainty) | — |
+| Online sales | Shopify, WooCommerce, BigCommerce | Amazon Seller Central (SP-API onboarding non-trivial), Etsy (seller-data restrictions) | — |
+| POS / payments | Square, Stripe, Clover, Lightspeed | PayPal Here (data via PayPal merchant APIs) | — |
+| CRM / contacts | HubSpot, Zoho CRM, Pipedrive, Mailchimp | Salesforce Essentials (rich APIs, complex auth) | — |
+| Payroll / HR | Gusto, BambooHR, Zoho People | ADP Run, Paychex (partner-programme gated) | — |
+| Tax | — | — | TurboTax, TaxAct, H&R Block (user-driven PDF/CSV export only); country-specific filing tools vary widely |
+
+This table is general knowledge as of authoring, not a validated
+integration matrix. Treat every cell as a starting point that needs
+re-verification (vendor docs + current EULA + ESACP connector status)
+at the moment of integration.
+
+Two recognisable variants of this audience:
+
+1. **Greenfield consolidation** — a small business not yet on any ERP,
+   with data fragmented across the SaaS/desktop tools above, looking
+   to migrate onto ERPNext as their first ERP.
+2. **Maintainer-dependent customisation** — a small business that has
+   already built a customised ERPNext deployment and cannot afford to
+   lose the developer who built it.
+
+Both variants want the same thing: an ERP they can keep running and
+evolving with AI assistance, without continuous expert contracting.
+
+## What this branch is for
+
+This is the `on_boarding` branch. Its job is to produce the
+**new-operator onboarding material** — the protocols, documentation,
+and code that take a new operator from first encounter with ESACP all
+the way to a fully staged deployment.
+
+You (the fresh Claude reading this) are the **author** of that
+onboarding material. The end-user (a new operator who has never seen
+ESACP before) is the **consumer**.
+
+Both populations have zero prior knowledge of any specific tenant. The
+branch must therefore be self-contained: nothing on this branch may
+assume tenant-specific names, hostnames, secrets, or business logic.
+
+## The end-user journey the onboarding material must cover
+
+The new operator's path runs in four stages:
+
+1. **First encounter with ESACP** — what it is, what it solves, what
+   posture it asks the operator to adopt, what hardware/accounts are
+   needed.
+2. **Preparing a controller machine** — OS choice, prerequisites, repo
+   clone, SSH keys, secrets (SOPS/age), GPG signing, basic toolchain.
+3. **Using the controller to prepare the first local KVM VMs** —
+   hypervisor setup on a target host, WireGuard mesh, observability
+   hub VM, a first ERPNext target VM, validating the fleet through
+   the Cytoscape UI.
+4. **Reaching a staged VPS master + slave** — moving from local KVM to
+   a cloud-VPS deployment, the master/slave pairing, replication and
+   failover posture.
+
+The deliverable is the **material** that walks an operator through
+those four stages, not the stages themselves running. The fresh Claude
+on this branch authors that material; an end-user later follows it.
+
+## Scope
+
+### In scope (S69+ work on this branch)
+
+- Operator-facing documentation for each of the four stages above,
+  pitched at zero-knowledge readers.
+- Screenshots, walkthroughs, and (where useful) recorded sessions.
+- Code or scripts that streamline the operator's path through the
+  four stages — but only where the existing pipeline does not already
+  cover the case and where the addition serves first-time-operator
+  ergonomics, not power-user productivity.
+- A self-check the operator can run after each stage to confirm they
+  are where they think they are.
+
+### Out of scope (do not pull these into the branch)
+
+- Tenant-specific business logic, bespoke apps, customised DocTypes,
+  or migration history.
+- Multi-tenant operations.
+- Production cutover procedures, V13→V14→V15→V16 migration playbooks.
+- Cloud-orchestration backends beyond a single VPS master + slave
+  (no CloudStack, no Kubernetes).
+- Observability stack design beyond first-contact-with-Grafana for
+  the new operator.
+- Anything that requires the operator to already have an opinion
+  about ERPNext internals. Onboarding assumes none.
+
+## What this branch is NOT for
+
+This branch is not a place to develop new platform features, refactor
+the pipeline, change MCP-connector behaviour, touch the Cytoscape
+control plane's data model, or modify any code outside the
+`on_boarding/` tree. If a defect in the platform shows up while
+authoring onboarding material, file an issue on the upstream tracker
+and continue with the onboarding work — do not fix the platform from
+this branch.
+
+## Next steps
+
+Read [`POINTERS.md`](POINTERS.md) for the map into ESACP's existing
+repo-resident technical surface (what files exist, what each is for,
+which are universal vs. tenant-specific).
+
+Then read [`AI_GUARDRAILS.md`](AI_GUARDRAILS.md) for the conduct and
+process rules you are expected to follow while working on this branch.
+
+Then read [`README.md`](README.md) for the kit index and the
+first-session checklist.

--- a/on_boarding/POINTERS.md
+++ b/on_boarding/POINTERS.md
@@ -1,0 +1,118 @@
+# Pointers — where to find ESACP's existing technical surface
+
+This is your map into the repo. It tells you what exists, what each
+file is for, and — crucially — which parts of the repo are **universal**
+(safe to inherit on this zero-knowledge branch) vs. **tenant-specific**
+(institutional history of the current operating tenant; not your
+onboarding-author concern).
+
+You do not need to read everything before starting. You need to know
+where to look.
+
+## Root-level orientation
+
+| File | What it is | Universal or tenant-specific |
+|---|---|---|
+| `CLAUDE.md` (root) | Project context for any Claude Code session on ESACP. Has the Session Protocol, commit conventions, banned patterns, architecture rules, QA verdict contract, and global conduct rules. | **Mixed** — see section table below |
+| `internal_docs/RUNBOOK.md` | Operator runbook for hypervisor + target VM operations. | Mostly universal; some examples use real hostnames |
+| `internal_docs/qa-contract.md` | The QA verdict layer contract (T1–T5 triggers, verdict shape, fail-safe). Required reading for any Claude that commits, merges, pushes, performs destructive ops, or closes issues. | Universal |
+| `.claude/agents/esacp-qa.md` | The QA agent definition that implements the contract. | Universal |
+| `internal_docs/qa-log.md` | Running log of every QA verdict the project has produced. Read as historical context, not as a rulebook. | Tenant-specific (institutional memory) |
+| `internal_docs/DiagramDesign.md`, `FailoverDesign.md` | Architecture references for the Cytoscape control plane and failover posture. | Universal |
+| `hosts_map.yml` | The authoritative host directory for the current fleet. | **Tenant-specific contents, universal format** — the *file's role* is universal; its current entries are tenant-side |
+
+### Root `CLAUDE.md` — section-by-section
+
+| Section | Universal? | Why |
+|---|---|---|
+| Mission (top line) | Universal | Describes the project's purpose in tenant-agnostic terms |
+| Session Protocol | **Universal — required reading** | One objective per session, 1:1:1 discipline, housekeeping bundles, umbrella branches, bug workflow |
+| Three-Bucket Architecture & Bespoke App Repos | Tenant-specific | Institutional history of the current tenant's repo layout; not your concern as an onboarding author |
+| Current State (stage table) | Tenant-specific | Stage progress for the current tenant's fleet |
+| Architecture (controller/hypervisor table) | Tenant-specific | Specific to the current operator's hardware history |
+| Key Files | **Universal — required reading** | The actual file map of the project |
+| Commit Conventions | **Universal — required reading** | Conventional Commits + GPG signing + co-author trailer |
+| Banned Patterns | **Universal — required reading** | No `sed`, no heredocs-as-code, no `python tools/x.py` |
+| Invoke scripts as executables | **Universal — required reading** | `./tools/x.py` not `python tools/x.py` |
+| Function and script size limits | **Universal — required reading** | ≤50 lines preferred, 101+ is a reject |
+| Architecture Rules — Anti-Spiral Enforcement | **Universal — required reading** | Where business logic lives, dispatcher rules, no subprocess in dispatchers, dead-code deletion |
+| QA Verdict Contract | **Universal — required reading** | Refers to `internal_docs/qa-contract.md` |
+| Global Conduct Rules | **Universal — required reading** | Already inlined into `on_boarding/AI_GUARDRAILS.md` so you can read it without leaving the kit |
+
+## Subdirectory `CLAUDE.md` files
+
+Each of these adds domain-specific gotchas. Read the one that matches
+the surface you are touching:
+
+| Path | Domain |
+|---|---|
+| `platforms/kvm/CLAUDE.md` | KVM/libvirt hypervisor, bootstrap, ERPNext differentiation, WireGuard/iptables/SSH |
+| `ansible/CLAUDE.md` | Ansible plays/roles, MCP server configurations, MariaDB/nginx/Grafana gotchas |
+| `docker/observability/CLAUDE.md` | Prometheus/Grafana/Loki/Alertmanager stack ports and gotchas |
+| `prototypes/cytoscape/CLAUDE.md` | Cytoscape.js control plane: zone frames, viewport, selectors, Inspect/Refresh/Destroy |
+| `tools/CLAUDE.md` | `api.py` endpoints, `esacp.py` CLI, `generate_inventory.py` |
+
+All of these contain real hostnames in examples; the *patterns and
+rules* are universal, the *example data* is tenant-side.
+
+## The pipeline — where business logic lives
+
+`tools/pipeline/` is the only place infrastructure operations are
+allowed to live. Specifically:
+
+- `tools/pipeline/stages/sNN_<name>/` — Stage-N unit functions
+  (`(Config, Emit) -> TaskResult`)
+- `tools/pipeline/stages/stage_N_*/__init__.py` — stage orchestrators
+- `tools/pipeline/macro/` — multi-stage macros
+- `tools/pipeline/orchestration/` — non-stage operations (host
+  registration, VM build, destroy)
+
+Dispatchers (`tools/esacp.py`, `tools/api.py`, `tools/job_worker.py`,
+`tools/cli/*.py`) only parse input, call one pipeline primitive, and
+format output. They are NOT allowed to contain business logic.
+
+If your onboarding material needs to invoke an infrastructure
+operation, invoke a primitive. Do not write new logic in a dispatcher.
+If the primitive does not exist, that is an upstream platform gap —
+file an issue, do not patch around it from the branch.
+
+## Tools you will use
+
+| Tool | What it does |
+|---|---|
+| `./tools/esacp.py` | The unified lab CLI. Always invoked as the executable, not via `python`. |
+| `./tools/host_identity.py` | Python constants resolved from `hosts_map.yml`. |
+| `./tools/generate_inventory.py` | Derives Ansible inventory from `hosts_map.yml`. |
+| `./tools/secrets.py` | Build secrets from env or SOPS-encrypted file. |
+| `gh` (GitHub CLI) | Issue filing, PR creation, PR status checks. Auth is operator-side. |
+| `sops` + `age` | Secret encryption. Operator must have an age key. |
+| `gpg` | Required for commit signing (see `CLAUDE.md` Commit Conventions). |
+
+## Things that look like documentation but are not
+
+These exist on the repo and you will encounter them — they are **not**
+orientation for you, and you should not let your onboarding material
+depend on them:
+
+- `internal_docs/SessionLogs/` — agendas + minutes from the current
+  tenant's operating sessions. Historical record. Tenant-specific.
+- `internal_docs/AuditReports/` — audit outputs from the current
+  tenant's operating sessions. Tenant-specific.
+- `memory/` (under `~/.claude/projects/.../memory/` on the current
+  operator's controller) — Claude's private memory dir. Symlinked
+  from a private repo. **NOT** available to you, **NOT** available
+  to end-users, **MUST NOT** be referenced as a dependency by any
+  onboarding material you produce.
+
+## What's available to you, what isn't
+
+| Available | Not available |
+|---|---|
+| Anything checked into the repo on the `on_boarding` branch | The current operator's `memory/` directory |
+| `CLAUDE.md` (universal sections), subdirectory `CLAUDE.md` files | Private tenant repositories (memory, business-logic, validation suites) |
+| `internal_docs/qa-contract.md`, `.claude/agents/esacp-qa.md` | Tenant-specific issue trackers beyond `martinhbramwell/ESACP` |
+| `internal_docs/RUNBOOK.md`, design docs | The current operator's `~/.claude/CLAUDE.md` |
+| `tools/pipeline/`, `tools/cli/`, `tools/api.py` source | Production ERPNext (read-only at most; not for onboarding examples) |
+| Public ERPNext / Frappe documentation | Anything outside this branch on someone else's authority |
+
+When in doubt, ask the operator. Do not invent.

--- a/on_boarding/README.md
+++ b/on_boarding/README.md
@@ -1,0 +1,102 @@
+# `on_boarding/` — starting kit
+
+This directory is the starting kit for developing **new-operator
+onboarding material** for ESACP. The kit was scoped and stocked on
+the parent project's Session 68 (2026-05-20) under issue
+[ESACP#406](https://github.com/martinhbramwell/ESACP/issues/406). It
+is the substrate the next Claude Code session — working from a fresh
+Windows 11 controller with no prior project context — will pick up
+from.
+
+The kit is small on purpose. Four files orient you; the actual
+onboarding material is what you (the fresh Claude) will build from
+here.
+
+## Files in this kit
+
+| File | What it gives you |
+|---|---|
+| [`ORIENTATION.md`](ORIENTATION.md) | What ESACP is, who it's for, what this branch is for, the four-stage end-user journey the onboarding material must cover, scope (in/out) |
+| [`POINTERS.md`](POINTERS.md) | Map into ESACP's existing repo-resident technical surface — which sections of which files are universal, which are tenant-specific |
+| [`AI_GUARDRAILS.md`](AI_GUARDRAILS.md) | Conduct rules, process rules, and repo-resident guard-rail pointers — your behavioural contract on this branch |
+| [`README.md`](README.md) | This file — kit index + first-session checklist |
+
+## First-session checklist (zero-knowledge Claude)
+
+Run this on first checkout of the `on_boarding` branch.
+
+1. **Confirm you're on the right branch and it's clean.**
+   ```bash
+   git branch --show-current   # expect: on_boarding
+   git status                  # expect: clean
+   ```
+
+2. **Read the kit in order.**
+   - [`ORIENTATION.md`](ORIENTATION.md) — what you're building and for whom
+   - [`POINTERS.md`](POINTERS.md) — where the existing material lives
+   - [`AI_GUARDRAILS.md`](AI_GUARDRAILS.md) — how you're expected to behave
+
+3. **Read the universal sections of the root `CLAUDE.md`** —
+   `POINTERS.md` flags which sections to read and which to skip as
+   tenant-specific.
+
+4. **State your objective.** One sentence. One objective per session.
+   See the Session Protocol in the root `CLAUDE.md`.
+
+5. **Ask the operator** the following before producing any onboarding
+   material:
+   - What's the operator's hardware posture (their controller machine,
+     their target hypervisor, their cloud-VPS plan)?
+   - Are they actually new to ESACP, or are they testing the
+     onboarding material with prior knowledge?
+   - Which of the four end-user stages do they want covered first?
+
+6. **File a GitHub issue on `martinhbramwell/ESACP`** for the first
+   piece of onboarding work before you write any of it. Bug workflow
+   discipline applies to feature work too: issue first, then code,
+   then `fixes #N` in the commit message.
+
+## What's NOT in this kit and why
+
+- **No tenant-specific material.** No tenant identifiers, no real
+  hostnames, no bespoke-app references, no fleet data. The branch's
+  audience is zero-knowledge; the kit reflects that.
+- **No memory-dir dependencies.** The parent project keeps Claude's
+  behavioural memory in a separate private repo, symlinked into
+  Claude's runtime memory directory. You don't have it, end-users
+  won't have it, and nothing on this branch may depend on it.
+- **No turnkey onboarding material yet.** S68 (the session that
+  created this kit) was scoping + scaffolding only. The actual
+  onboarding material is your job from here.
+
+## Working agreements with the operator
+
+- **One objective per session.** If a second concern surfaces while
+  you're working on the first, file it as an issue and return to the
+  primary objective.
+- **Conventional Commits, GPG-signed, with the co-author trailer.**
+  See `CLAUDE.md` §"Commit Conventions".
+- **Pull requests merge into the `on_boarding` branch.** This branch
+  merges into `main` only when the operator decides the onboarding
+  material has reached a deliverable state. Do not merge to `main`
+  yourself.
+- **The QA verdict layer applies.** Invoke the `esacp-qa` agent
+  before any commit / merge / push / destructive op / issue close,
+  and act on its verdict.
+
+## Reporting back
+
+When you finish a session's work, leave the operator a short status
+note. What you produced, what's next, what's blocking. Two sentences
+is usually enough. The operator does not need a transcript — they
+can read the diff. They need the outcome and the next handle.
+
+## Pointers to upstream project state
+
+- Issue tracker: `martinhbramwell/ESACP` on GitHub
+- Branch policy: see `CLAUDE.md` §"Session Protocol" (umbrella vs.
+  1:1:1 vs. housekeeping bundle)
+- This branch's originating issue: [ESACP#406](https://github.com/martinhbramwell/ESACP/issues/406)
+- This branch's originating agenda:
+  `internal_docs/SessionLogs/2026-05-20-2034-next-agenda.md`
+  (read as historical context; do not adopt as your own agenda)


### PR DESCRIPTION
## Summary

- Creates the `on_boarding` branch off `main` and stocks it with the
  starting kit a fresh Claude Code session on a separate Windows 11
  controller will need to develop new-user onboarding functionality
  under a **zero-knowledge assumption**.
- S68 deliverable is scoping + scaffolding only; the fresh Win-11
  Claude takes ownership of the actual onboarding material from S69+
  in its own sessions.

## Kit contents (`on_boarding/`)

- **`ORIENTATION.md`** — what ESACP is, target audience (data-scattered
  small businesses across accounting / online sales / POS / CRM /
  payroll / tax with named examples), 4-stage end-user journey,
  caveat + indicative-readiness table for SaaS integrations (API
  surface + EULA + ESACP/Claude-Code capability preconditions).
- **`POINTERS.md`** — map into ESACP's repo-resident technical surface,
  with section-by-section CLAUDE.md universal-vs-tenant-specific
  annotation.
- **`AI_GUARDRAILS.md`** — global conduct rules + project-agnostic
  process rules (inlined from memory so the zero-knowledge fresh
  Claude inherits them) + repo-resident guard-rail pointers + QA
  verdict layer guidance.
- **`README.md`** — kit index + first-session checklist.

## Audience framing (operator-corrected mid-session)

Initial draft inherited the current operating tenant's posture
("heavily customised ERPNext + maintainer-dependent") as the universal
frame. Corrected to: **data-scattered small businesses needing to
consolidate around ERPNext but unable to justify a dedicated ERP
consultant**. The maintainer-dependent case is now one of two named
variants, not the primary framing.

## Tenant-detail scrub

Scrubbed against the agenda's Sub-step 3 pattern list. Clean for all
patterns. The canonical `martinhbramwell/ESACP` repo URL is retained
as institutional coordinate (6 references) — the fresh Claude needs
it to file issues.

## Acceptance

- [x] `on_boarding` branch exists on `origin`
- [x] Starting-kit files committed under `on_boarding/`
- [x] Tenant-detail scrub clean (institutional `martinhbramwell/ESACP`
      retained per operator decision)
- [x] T1+T3 QA verdict: approve (v2.1 §2.1 combined trigger)
- [ ] T2 QA verdict pending
- [ ] PR merged via `fixes #406`
- [ ] `mergedAt` non-null before session close

## Test plan

- [ ] T2 QA verdict (pre-merge): approve
- [ ] Squash-merge or merge-commit per operator preference
- [ ] Verify ESACP#406 auto-closes via `fixes #406` in commit body
- [ ] Confirm `gh pr view` reports `mergedAt` non-null before session
      end (per `feedback_pr_merge_before_session_close.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)