### PR TITLE
docs(on_boarding): seed docs/SESSIONS.md (operationalize the session-log convention)

### DIFF
--- a/on_boarding/README.md
+++ b/on_boarding/README.md
@@ -28,6 +28,7 @@ These are written by Junior (the on_boarding-branch Claude) as work proceeds. Th
 | File | What it gives you |
 |---|---|
 | [`docs/session-discipline.md`](docs/session-discipline.md) | Cadence rules for this branch — 1:1:N issue bundling, sub-branch flow, acceptance test for docs, QA verdict layer, parent-project precedence |
+| [`docs/SESSIONS.md`](docs/SESSIONS.md) | One-line session log — one row per session, append-only. Read to see what prior sessions on this branch produced |
 
 ## First-session checklist (zero-knowledge Claude)
 

--- a/on_boarding/docs/SESSIONS.md
+++ b/on_boarding/docs/SESSIONS.md
@@ -1,0 +1,11 @@
+# `on_boarding` branch session log
+
+One row per session. Newest at the bottom. Append-only.
+
+The convention — what each column means, when to append, what counts as
+a session — is defined in [`session-discipline.md`](session-discipline.md)
+§"One-line session log".
+
+| Date | Objective | Sub-branch → PR | Issues |
+|---|---|---|---|
+| 2026-05-21 | Bootstrap `on_boarding` cadence rules, seed the session log, file the Stage-2 fresh-controller-setup backlog | `docs/session-discipline` → [#414](https://github.com/martinhbramwell/ESACP/pull/414) | refs [#412](https://github.com/martinhbramwell/ESACP/issues/412) (cadence doc; closes on `main` merge) · refs [#415](https://github.com/martinhbramwell/ESACP/issues/415) (Stage-2 backlog) · fixes [#416](https://github.com/martinhbramwell/ESACP/issues/416) (this seed) |


### PR DESCRIPTION
## Summary

Operationalizes the one-line session log convention defined in `on_boarding/docs/session-discipline.md` §"One-line session log". PR #414 (merged) defined the convention but did not seed the file itself — a forward-reference flagged by that PR's T2 verdict.

## Changes

- **New:** `on_boarding/docs/SESSIONS.md` (11 lines) — convention header pointing to `session-discipline.md`, table header, and one row recording Session 1 (the session that wrote the cadence doc and files this seed).
- **Modified:** `on_boarding/README.md` (+1 line) — Working-docs table now indexes `SESSIONS.md`.

## Acceptance for #416

- [x] File exists at `on_boarding/docs/SESSIONS.md`
- [x] Header explains the convention briefly and links to `docs/session-discipline.md`
- [x] Table has at least one row (Session 1)
- [x] README cross-reference exists

## Test plan

- [x] Content review against #416 acceptance criteria
- [x] Commit GPG-signed (\`9C6BCEA8…04E8\`, "Good signature")
- [x] T1 verdict: \`approve\`
- [x] T3 verdict: \`approve\`
- [ ] T2 verdict at merge time

Closes #416 on eventual \`on_boarding\` → \`main\` merge.
Refs #412 (cadence doc, same thematic spine), #415 (Stage-2 backlog rollup, same thematic spine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)