### PR TITLE
chore(cld-sh): gate cf-mcp-refresh behind .needs-cf-mcp sentinel (one-shot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,10 @@ internal_docs/diagrams/*.png
 local_settings.yml
 override.yml
 
+# Per-controller signal — operator-touched to trigger Cloudflare MCP token
+# refresh on next Cld.sh launch. One-shot: consumed by Cld.sh on success.
+.needs-cf-mcp
+
 # Backup files
 *.bak
 *.backup

--- a/Cld.sh
+++ b/Cld.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-cf-mcp-refresh
+if [[ -f .needs-cf-mcp ]]; then
+  cf-mcp-refresh && rm -f .needs-cf-mcp
+fi
 
 claude --chrome


### PR DESCRIPTION
## Summary

Gate `cf-mcp-refresh` in `Cld.sh` behind a per-controller `.needs-cf-mcp` sentinel file. **One-shot semantics**: a successful refresh consumes the sentinel, so the refresh fires exactly once per `touch .needs-cf-mcp`.

- Controllers without the sentinel: launch skips `cf-mcp-refresh` and proceeds directly to `claude --chrome` (acceptance criterion 2 from #425).
- Controllers with the sentinel: `cf-mcp-refresh && rm -f .needs-cf-mcp` — success consumes; failure preserves the sentinel for retry, and `set -e` still exits before `claude --chrome` (current exit-on-failure behaviour preserved).
- `.needs-cf-mcp` added to `.gitignore` — per-controller signal, not repo state (operator-ratified Option 1 from session-start discussion).

## Origin

Filed by Junior (Claude on the `on_boarding` branch / WSL+Win-11 controller) per chain-of-command — broader-project territory implemented on `main`. Operator chose **one-shot** over **persistent** interpretation in session-start triage.

## Acceptance

Verified against the criteria in #425:

- [x] `Cld.sh` on `main` carries the gated form.
- [x] No behaviour change on controllers without `.needs-cf-mcp` beyond skipping `cf-mcp-refresh`.
- [x] Implementer follows broader-project discipline (Conventional Commits, GPG-signed commit, Co-Author trailer, `fixes #425` in commit body).
- [x] `bash -n Cld.sh` → syntax OK.

## Test plan

- [x] Static: bash syntax check on `Cld.sh`.
- [x] Static: diff inspection — exactly two files touched, both in scope.
- [ ] Empirical (operator, post-merge): on this controller, observe that next `./Cld.sh` launch (no sentinel present) skips `cf-mcp-refresh` and proceeds to `claude --chrome` cleanly.
- [ ] Empirical (operator, post-merge): `touch .needs-cf-mcp && ./Cld.sh` → refresh fires, sentinel is removed, claude launches.
- [ ] Empirical (Junior, post-pull on `on_boarding`): working-tree `M Cld.sh` resolves cleanly against the merged version.

## Notes

- Closes #425.
- `.gitignore` addition lives next to the `local_settings.yml` / `override.yml` block (same per-controller semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)