### PR TITLE
feat(on_boarding): bootstrap.py v0 — controller toolkit installer (#431)

### DIFF
--- a/on_boarding/README.md
+++ b/on_boarding/README.md
@@ -31,6 +31,15 @@ These are written by Junior (the on_boarding-branch Claude) as work proceeds. Th
 | [`docs/session-discipline.md`](docs/session-discipline.md) | Cadence rules for this branch — 1:1:N issue bundling, sub-branch flow, acceptance test for docs, QA verdict layer, parent-project precedence |
 | [`docs/SESSIONS.md`](docs/SESSIONS.md) | One-line session log — one row per session, append-only. Read to see what prior sessions on this branch produced |
 | [`docs/qa-log.md`](docs/qa-log.md) | Junior-side QA verdict log — notable `esacp-qa` verdicts from this branch's sessions. Brevity-protocol-curated. Companion to (not duplicate of) `internal_docs/qa-log.md` |
+| [`docs/stage-2-triage.md`](docs/stage-2-triage.md) | The Stage-2 friction-list triage (Session 2): six items from #415 sorted into Bucket 1 / 2 / 3 by Buzz-relevance, plus the hybrid-shape decision (bootstrap script + wizard prompts + browser-driven signups) |
+
+## Executable kit (under `tools/`)
+
+Scripts Buzz (or an operator on Buzz's behalf) is expected to run. Each is idempotent; safe to re-run.
+
+| File | What it does |
+|---|---|
+| [`tools/bootstrap.py`](tools/bootstrap.py) | Stage-2 v0 — installs the no-credential half of the controller toolkit (`pinentry-curses`, `keychain`, `age`, `gh`, `sops`) and configures GPG cache TTL + `~/.bashrc` lines for `GPG_TTY` and `keychain`. Targets Ubuntu 22.04+ / WSL2 Ubuntu. Invoke: `./on_boarding/tools/bootstrap.py`. Closes [#431](https://github.com/martinhbramwell/ESACP/issues/431). |
 
 ## First-session checklist (zero-knowledge Claude)
 

--- a/on_boarding/tools/bootstrap.py
+++ b/on_boarding/tools/bootstrap.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""ESACP on_boarding — controller toolkit installer (v0).
+
+Stage-2 bootstrap: installs the no-credential half of the controller
+toolkit (pinentry-curses, keychain, age, gh, sops) and configures GPG
+cache TTL + bashrc lines for GPG_TTY and keychain.
+
+Targets Ubuntu 22.04+ / WSL2 Ubuntu. Cross-OS support is tracked in
+https://github.com/martinhbramwell/ESACP/issues/435.
+
+Idempotent: safe to re-run. Each step probes its target state and
+skips if already configured.
+
+Closes https://github.com/martinhbramwell/ESACP/issues/431.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+
+# ── Data ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Prose:
+    name: str
+    what: str
+    why: str
+    who: str
+    cost: str
+
+
+SOPS_DEB_URL = (
+    "https://github.com/getsops/sops/releases/download/v3.9.4/"
+    "sops_3.9.4_amd64.deb"
+)
+
+
+# ── Prose (Buzz contract: visibility + confident tone) ────────────
+
+
+def announce(p: Prose) -> None:
+    print(f"\n→ Installing {p.name}")
+    print(f"  What:  {p.what}")
+    print(f"  Why:   {p.why}")
+    print(f"  Who:   {p.who}")
+    print(f"  Cost:  {p.cost}")
+
+
+def announce_skip(p: Prose) -> None:
+    print(f"  ✓ {p.name} — already installed, skipping")
+
+
+def announce_config(name: str, what: str, why: str, effect: str) -> None:
+    print(f"\n→ Configuring {name}")
+    print(f"  What:  {what}")
+    print(f"  Why:   {why}")
+    print(f"  When:  {effect}")
+
+
+# ── Control (Buzz contract: confirm before acting, pause on failure) ──
+
+
+def confirm_proceed() -> None:
+    print()
+    print("This script will install a small set of free tools and add a few")
+    print("lines to two config files in your home directory. It will ask for")
+    print("your sudo password once for the system installs. Previously-done")
+    print("steps are detected and skipped, so re-running is safe.")
+    print()
+    ans = input("Shall we proceed? [y/N] ").strip().lower()
+    if ans not in ("y", "yes"):
+        print("OK — no changes made. Exiting.")
+        sys.exit(0)
+
+
+def failure_prompt(step: str, detail: str) -> str:
+    print()
+    print(f"⚠  Step '{step}' failed: {detail}")
+    print()
+    while True:
+        ans = input("Choice [r=retry / s=skip / a=abort]: ").strip().lower()
+        if ans in ("r", "s"):
+            return ans
+        if ans == "a":
+            print("Aborting. Already-completed steps remain in place.")
+            sys.exit(1)
+        print("Please type r, s, or a.")
+
+
+# ── Probes ────────────────────────────────────────────────────────
+
+
+def has_binary(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def has_dpkg_pkg(pkg: str) -> bool:
+    result = subprocess.run(
+        ["dpkg", "-s", pkg],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+# ── Installs ──────────────────────────────────────────────────────
+
+
+def sh(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=False)
+
+
+def install_apt(pkg: str) -> bool:
+    """apt update + apt install. Returns True on success."""
+    upd = sh(["sudo", "apt-get", "update", "-qq"])
+    if upd.returncode != 0:
+        return False
+    ins = sh(["sudo", "apt-get", "install", "-y", pkg])
+    return ins.returncode == 0
+
+
+def install_gh_repo() -> bool:
+    """Add GitHub CLI apt repo, then apt install gh."""
+    keyring_url = "https://cli.github.com/packages/githubcli-archive-keyring.gpg"
+    keyring_path = "/etc/apt/keyrings/githubcli-archive-keyring.gpg"
+    list_path = "/etc/apt/sources.list.d/github-cli.list"
+    arch = subprocess.run(
+        ["dpkg", "--print-architecture"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    list_line = (
+        f"deb [arch={arch} signed-by={keyring_path}] "
+        "https://cli.github.com/packages stable main\n"
+    )
+    steps: list[list[str]] = [
+        ["sudo", "mkdir", "-p", "-m", "755", "/etc/apt/keyrings"],
+        ["sudo", "curl", "-fsSL", "-o", keyring_path, keyring_url],
+        ["sudo", "chmod", "go+r", keyring_path],
+        ["sudo", "tee", list_path],
+    ]
+    for i, step in enumerate(steps):
+        stdin_data = list_line.encode() if step[-1] == list_path else None
+        result = subprocess.run(
+            step,
+            input=stdin_data,
+            capture_output=(stdin_data is not None),
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+    return install_apt("gh")
+
+
+def install_sops_deb() -> bool:
+    """Download sops .deb and dpkg install it. v3.9.4, amd64 only."""
+    if subprocess.run(
+        ["dpkg", "--print-architecture"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip() != "amd64":
+        print("  sops .deb install supports amd64 only; skipping on this arch")
+        return False
+    with NamedTemporaryFile(suffix=".deb", delete=False) as tmp:
+        deb_path = tmp.name
+    try:
+        urllib.request.urlretrieve(SOPS_DEB_URL, deb_path)
+        result = sh(["sudo", "dpkg", "-i", deb_path])
+        return result.returncode == 0
+    finally:
+        Path(deb_path).unlink(missing_ok=True)
+
+
+# ── Step runner ───────────────────────────────────────────────────
+
+
+def run_install(p: Prose, probe, installer) -> None:
+    """Probe → announce → install loop with failure prompt."""
+    if probe():
+        announce_skip(p)
+        return
+    announce(p)
+    while True:
+        if installer():
+            print(f"  ✓ {p.name} installed")
+            return
+        choice = failure_prompt(f"install {p.name}", "command exited non-zero")
+        if choice == "s":
+            print(f"  ⤳ {p.name} skipped — you will need to install it manually")
+            return
+
+
+# ── Config edits ──────────────────────────────────────────────────
+
+
+GPG_AGENT_CONF = Path.home() / ".gnupg" / "gpg-agent.conf"
+GPG_TTL_LINES = "default-cache-ttl 28800\nmax-cache-ttl 28800\n"
+
+BASHRC = Path.home() / ".bashrc"
+BASHRC_GPG_TTY = "export GPG_TTY=$(tty)\n"
+BASHRC_KEYCHAIN = 'eval "$(keychain --eval --quiet)"\n'
+
+
+def configure_gpg_agent_ttl() -> None:
+    announce_config(
+        "GPG password cache (8 hours)",
+        "edits ~/.gnupg/gpg-agent.conf",
+        "so you do not re-type your GPG password every commit",
+        "after next 'gpgconf --kill gpg-agent' or shell relogin",
+    )
+    GPG_AGENT_CONF.parent.mkdir(mode=0o700, exist_ok=True)
+    existing = GPG_AGENT_CONF.read_text() if GPG_AGENT_CONF.exists() else ""
+    if "default-cache-ttl" in existing:
+        print("  ✓ already configured")
+        return
+    sep = "" if (not existing or existing.endswith("\n")) else "\n"
+    GPG_AGENT_CONF.write_text(existing + sep + GPG_TTL_LINES)
+    print(f"  ✓ wrote {GPG_AGENT_CONF}")
+
+
+def configure_bashrc() -> None:
+    announce_config(
+        "shell environment (GPG_TTY + keychain)",
+        "appends up to 2 lines to ~/.bashrc",
+        "so GPG knows which terminal to prompt on, and SSH/GPG passwords "
+        "cache across shell sessions",
+        "on next shell open or after 'source ~/.bashrc'",
+    )
+    existing = BASHRC.read_text() if BASHRC.exists() else ""
+    appended = ""
+    if "GPG_TTY" not in existing:
+        appended += BASHRC_GPG_TTY
+    if "keychain --eval" not in existing:
+        appended += BASHRC_KEYCHAIN
+    if not appended:
+        print("  ✓ already configured")
+        return
+    sep = "" if (not existing or existing.endswith("\n")) else "\n"
+    BASHRC.write_text(existing + sep + appended)
+    n = appended.count("\n")
+    print(f"  ✓ appended {n} line{'s' if n != 1 else ''} to {BASHRC}")
+
+
+# ── Orchestrator ──────────────────────────────────────────────────
+
+
+def check_os() -> None:
+    if not Path("/etc/debian_version").exists():
+        print("This script targets Debian-family Linux (Ubuntu / WSL2 Ubuntu).")
+        print("Cross-OS support is tracked in")
+        print("  https://github.com/martinhbramwell/ESACP/issues/435")
+        sys.exit(1)
+
+
+UBUNTU_REPO_WHO = (
+    "your operating system's own software library — no outside party "
+    "is contacted beyond Ubuntu's package mirrors"
+)
+
+APT_ITEMS: list[Prose] = [
+    Prose(
+        name="pinentry-curses",
+        what="the in-terminal program that prompts for your GPG password",
+        why="so password prompts work inside scripts and remote shells",
+        who=UBUNTU_REPO_WHO,
+        cost="free, ~200 KB",
+    ),
+    Prose(
+        name="keychain",
+        what="a wrapper that keeps your SSH and GPG agents running",
+        why="so you type your key passwords once per login, not per command",
+        who=UBUNTU_REPO_WHO,
+        cost="free, ~150 KB",
+    ),
+    Prose(
+        name="age",
+        what="a modern file-encryption tool",
+        why="so your passwords and keys can be kept encrypted inside the "
+        "code copy, readable only by your machine",
+        who=UBUNTU_REPO_WHO,
+        cost="free, ~2 MB",
+    ),
+]
+
+GH_PROSE = Prose(
+    name="gh",
+    what="GitHub's command-line tool",
+    why="so ESACP can manage your code copy on your behalf",
+    who="GitHub (the company that hosts your code copy) — they see your "
+    "machine downloading their tool over the public internet; they "
+    "will not know your name until you sign in, which is a later step",
+    cost="free, ~12 MB",
+)
+
+SOPS_PROSE = Prose(
+    name="sops",
+    what="a secrets-encryption tool (originally Mozilla, now CNCF)",
+    why="so passwords and keys inside the code copy stay encrypted at rest",
+    who="GitHub (where sops is published) — same as above: they see a "
+    "download, not an identity",
+    cost="free, ~10 MB",
+)
+
+
+def main() -> None:
+    print("ESACP on_boarding — controller toolkit installer (v0)")
+    print("=" * 56)
+    check_os()
+    confirm_proceed()
+    for p in APT_ITEMS:
+        run_install(p, lambda p=p: has_dpkg_pkg(p.name), lambda p=p: install_apt(p.name))
+    run_install(GH_PROSE, lambda: has_binary("gh"), install_gh_repo)
+    run_install(SOPS_PROSE, lambda: has_binary("sops"), install_sops_deb)
+    configure_gpg_agent_ttl()
+    configure_bashrc()
+    print()
+    print("Done. Next steps:")
+    print("  1. Close this terminal and open a new one (picks up bashrc).")
+    print("     Or run:  source ~/.bashrc")
+    print("  2. If you changed gpg-agent.conf for the first time:")
+    print("     gpgconf --kill gpg-agent")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Session 3 deliverable. Agenda: #439. Closes #431 on merge (manual T5 close required since target is `on_boarding`, not `main`, per memory `project_on_boarding_trunk_vs_default.md`).

## Summary

- Adds `on_boarding/tools/bootstrap.py` — idempotent Python installer for the no-credential half of the Stage-2 controller toolkit:
  - `pinentry-curses`, `keychain`, `age` via standard `apt`
  - `gh` via GitHub's official apt repo (keyring + sources.list setup)
  - `sops` via `.deb` download from GitHub releases
  - GPG cache TTL = 8h written to `~/.gnupg/gpg-agent.conf`
  - `GPG_TTY` export + `keychain --eval` lines appended to `~/.bashrc`
- Updates `on_boarding/README.md` — adds a new "Executable kit" section pointing to `tools/bootstrap.py`, plus a `docs/stage-2-triage.md` row that was missing from the Working-docs table.

## Buzz contract compliance

Per [`BUZZ_PERSPECTIVE.md`](https://github.com/martinhbramwell/ESACP/blob/on_boarding/on_boarding/BUZZ_PERSPECTIVE.md) §"Visibly safe", every install prints four fields **before** acting:

```
→ Installing gh
  What:  GitHub's command-line tool
  Why:   so ESACP can manage your code copy on your behalf
  Who:   GitHub (the company that hosts your code copy) — they see your machine
         downloading their tool over the public internet; they will not know your
         name until you sign in, which is a later step
  Cost:  free, ~12 MB
```

Note: #431's body abbreviated the contract to three fields (What/Why/Cost). The canonical doc is four (What/Why/**Who**/Cost). This implementation honours the canonical doc — the `Who` field was added on the T1 QA verdict.

Other Buzz contract points:
- **Control** — `confirm_proceed()` asks before the first install; `failure_prompt()` offers `r=retry / s=skip / a=abort` on each failure.
- **Anchoring** — prose in business language ("so you do not re-type your GPG password every commit"), not developer language.
- **Confident tone** — declarative, no apology-spam.
- **IT-consultant pitch** — implicit in the prose voice; Stage-1 first-encounter explicit pitch is a separate (later) deliverable.

## Architecture compliance

- Not under `tools/pipeline/**` (controller-side end-user installer ≠ infra business logic) — the anti-spiral dispatcher rules and the `tools/pipeline/**` 80-line cap do not apply.
- Per-function size: every function ≤50 lines (largest is `install_gh_repo` at 32). File total 337 lines, dominated by `Prose` data + module docstring; no single unit unreviewable.
- Banned patterns: no `sed`, no shell heredocs feeding code. `subprocess.run` is called with list args throughout (`shell=False`).
- `chmod +x` per the "Invoke as executable" rule; shebang is `#!/usr/bin/env python3`.

## Idempotency

Each step probes before acting:
- apt packages — `dpkg -s <pkg>` returns 0
- binaries (`gh`, `sops`) — `shutil.which`
- config edits — `grep` the marker line in the existing file content

Re-runs print `✓ already installed, skipping` (or `✓ already configured`) and do nothing.

## What's NOT in this PR (deferred)

- **Cross-OS support** — macOS / Windows-native paths deferred to #435.
- **Credential surface** — git identity declaration, GPG-key generation, GitHub login, SSH-key paste — those live in #432 (wizard) and #433 (browser-driven).
- **`cloud-init` test fixture** for a pristine-VM idempotency run — out of scope for v0; the script's idempotency is verified on this controller (`gh`, `keychain`, `pinentry-curses` already installed → skip path exercised).

## Test plan

- [x] `python3 -m py_compile on_boarding/tools/bootstrap.py` clean
- [x] `echo n | ./on_boarding/tools/bootstrap.py` exits cleanly (Y/N parse + OS check + intro prose)
- [x] `python3 -c 'import bootstrap; bootstrap.announce(...)'` renders all four fields (What/Why/Who/Cost)
- [x] All idempotency probes return correct results on this controller (verified: `gh`/`keychain`/`pinentry-curses` → True; `sops`/`age` → False)
- [x] `git check-ignore on_boarding/tools/__pycache__` returns 0 (gitignored)
- [ ] **Operator verification on a fresh Ubuntu 22.04+ / WSL2 box** — required by #431 acceptance and `session-discipline.md` §"Every documented command is run on the target OS before publish". Not done on this PR; targets a separate verification session.

## QA verdicts (per qa-contract §2)

- **T1 (pre-commit)** — `approve-with-conditions`. Condition: add the `Who` field per `BUZZ_PERSPECTIVE.md` canonical four-field spec. Resolved in-session before commit; verified by direct render test. Will appear in `on_boarding/docs/qa-log.md` at session close.
- **T3 (pre-push)** — `approve`. Confirmed single commit, no surprise files, GPG-signed, no force-push, target = `on_boarding`.
- **T2 (pre-merge into `on_boarding`)** — pending; advisory per memory `project_on_boarding_trunk_vs_default.md`.
- **T5 (manual `#431` close on merge)** — pending; required since `fixes #N` does not auto-close on sub-branch merges into `on_boarding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)