### PR TITLE
feat(substrate): V16 prereqs ansible role — Python 3.14 + Node 24 + pkg-config (#445)

### DIFF
--- a/ansible/inventory/kvm.yml
+++ b/ansible/inventory/kvm.yml
@@ -40,6 +40,7 @@ all:
           wg_role: spoke
           vm_name: dev02
           display_name: dev02
+          target_frappe_major: 16
           ansible_ssh_common_args: -o ProxyJump=hasan@toshiba
     development:
       hosts:

--- a/ansible/roles/frappe_substrate_v16/README.md
+++ b/ansible/roles/frappe_substrate_v16/README.md
@@ -1,0 +1,58 @@
+# frappe_substrate_v16
+
+V16-era frappe substrate prereqs — installs Python 3.14, Node 24, and
+pkg-config on hosts whose `hosts_map.yml` declares `target_frappe_major >= 16`.
+No-op on V13/V14/V15 targets.
+
+## Why this role exists (ESACP#445)
+
+The S74 V14-trial-extension probe established the V16 substrate distance
+(see `internal_docs/SessionLogs/2026-05-22-v14-trial-notes.md` § Extension 3):
+
+| Surface | Packer-baked v13 image | V16 frappe pin |
+|---|---|---|
+| Python | 3.10.12 | **3.14.x** (`requires-python = ">=3.14,<3.15"`) |
+| Node | 18.20.8 | **24.x** (`engines.node = ">=24"`) |
+| `pkg-config` | absent | required by pip install |
+
+The packer template is still v13-era; rebuilding it for the V16 era is a
+separate session per S75 agenda. This role provides a forward-compatible
+overlay so V16-target VMs can be brought to substrate-ready state without
+waiting on the packer template refresh.
+
+## Scope
+
+In:
+- `python3.14` + `python3.14-dev` + `python3.14-venv` (deadsnakes PPA on 22.04)
+- `nodejs` ≥ 24 (NodeSource setup_24.x)
+- `pkg-config`
+- Idempotent: skips Node setup if `node --version` already ≥ 24.
+
+Out (separate issues / sessions):
+- Rebuilding the bench venv on Python 3.14 (substrate migration territory).
+- `returnable`'s pypika URL-dep crash (E9 — bespoke-app pattern fix).
+- `erpnext.patches.v16_0.make_workstation_operating_components` defect
+  (ESACP#444).
+- Packer-template refresh (multi-session work, separate plan).
+
+## Acceptance
+
+Role's final task asserts:
+1. `python3.14 --version` matches `^Python 3.14.`
+2. `node --version` major ≥ 24.
+3. `pkg-config --version` returns non-empty.
+
+To run against a single target:
+
+```
+ansible-playbook -i ansible/inventory/kvm.yml ansible/site-kvm.yml \
+  --limit dev02 --tags frappe_substrate_v16
+```
+
+(Role is wired into Play 4 with `tags: [frappe_substrate_v16]`.)
+
+## Variables
+
+See `defaults/main.yml`. The role keys off `target_frappe_major` —
+declared per-host in `hosts_map.yml` and surfaced as a hostvar by
+`tools/generate_inventory.py`. Defaults to `13` when absent.

--- a/ansible/roles/frappe_substrate_v16/defaults/main.yml
+++ b/ansible/roles/frappe_substrate_v16/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# frappe_substrate_v16 — defaults
+#
+# Pins for the V16-era frappe substrate. See ESACP#445.
+#
+# Python: frappe 16.x pyproject declares requires-python = ">=3.14,<3.15".
+# Node:   frappe 16.x package.json declares engines.node = ">=24".
+
+frappe_substrate_v16_python_pkg: "python3.14"
+frappe_substrate_v16_python_extra_pkgs:
+  - "python3.14-dev"
+  - "python3.14-venv"
+
+# NodeSource setup script — major-version specific URL.
+# 24 is the V16-era pin; bump in lock-step with frappe's engines.node.
+frappe_substrate_v16_node_major: 24
+frappe_substrate_v16_nodesource_setup_url: "https://deb.nodesource.com/setup_{{ frappe_substrate_v16_node_major }}.x"
+
+# deadsnakes PPA name used by ansible.builtin.apt_repository.
+# 22.04 (jammy) does not ship Python 3.14; deadsnakes is the established
+# source. On 24.04+ this may be replaced by the system python3.14 package
+# when one becomes available — re-evaluate in the packer-template session.
+frappe_substrate_v16_deadsnakes_ppa: "ppa:deadsnakes/ppa"

--- a/ansible/roles/frappe_substrate_v16/tasks/main.yml
+++ b/ansible/roles/frappe_substrate_v16/tasks/main.yml
@@ -1,0 +1,92 @@
+---
+# frappe_substrate_v16 — V16-era substrate prereqs (ESACP#445).
+#
+# Conditionally installs Python 3.14, Node 24, and pkg-config on hosts
+# whose hosts_map.yml declares target_frappe_major >= 16. No-op on
+# V13/V14/V15 targets (which keep the packer-baked python3.10 + node18).
+#
+# Validated path: Ubuntu 22.04 + deadsnakes PPA + NodeSource setup_24.x
+# (S74 V14-trial-extension findings E5/E6/E7). Packer-template bake-in
+# is a separate session per S75 agenda.
+
+- name: Determine whether V16 substrate prereqs apply to this host
+  ansible.builtin.set_fact:
+    frappe_substrate_v16_active: "{{ (target_frappe_major | default(13) | int) >= 16 }}"
+
+- name: V16 substrate prereqs — install
+  when: frappe_substrate_v16_active
+  block:
+    - name: Add deadsnakes PPA (Python 3.14 source on jammy)
+      ansible.builtin.apt_repository:
+        repo: "{{ frappe_substrate_v16_deadsnakes_ppa }}"
+        state: present
+        update_cache: yes
+
+    - name: Install Python 3.14 + dev + venv
+      ansible.builtin.apt:
+        name: "{{ [frappe_substrate_v16_python_pkg] + frappe_substrate_v16_python_extra_pkgs }}"
+        state: present
+
+    - name: Install pkg-config (required by frappe v16 pip install)
+      ansible.builtin.apt:
+        name: pkg-config
+        state: present
+
+    - name: Detect installed Node major version
+      ansible.builtin.command: node --version
+      register: frappe_substrate_v16_node_check
+      changed_when: false
+      failed_when: false
+
+    - name: Add NodeSource repo + install Node {{ frappe_substrate_v16_node_major }} (only when current Node is older)
+      when: >
+        frappe_substrate_v16_node_check.rc != 0
+        or (frappe_substrate_v16_node_check.stdout | regex_search('v([0-9]+)', '\\1') | first | int)
+           < frappe_substrate_v16_node_major
+      block:
+        - name: Fetch NodeSource setup script
+          ansible.builtin.get_url:
+            url: "{{ frappe_substrate_v16_nodesource_setup_url }}"
+            dest: /tmp/nodesource_setup.sh
+            mode: '0755'
+
+        - name: Run NodeSource setup script (rewrites apt source to target major)
+          # No creates: guard — packer-baked image may have an older
+          # nodesource.list (e.g., node_18.x). The setup script is
+          # idempotent and rewrites the apt source to the target major.
+          # The outer block's when: ensures this only runs when current
+          # Node is missing or < target major.
+          ansible.builtin.command: bash /tmp/nodesource_setup.sh
+
+        - name: Install Node.js {{ frappe_substrate_v16_node_major }}
+          ansible.builtin.apt:
+            name: nodejs
+            state: latest
+            update_cache: yes
+
+    - name: Capture installed Python 3.14 version
+      ansible.builtin.command: "{{ frappe_substrate_v16_python_pkg }} --version"
+      register: frappe_substrate_v16_python_version
+      changed_when: false
+
+    - name: Capture installed Node version
+      ansible.builtin.command: node --version
+      register: frappe_substrate_v16_node_version_final
+      changed_when: false
+
+    - name: Capture installed pkg-config version
+      ansible.builtin.command: pkg-config --version
+      register: frappe_substrate_v16_pkgconfig_version
+      changed_when: false
+
+    - name: Assert acceptance — Python 3.14 + Node {{ frappe_substrate_v16_node_major }} + pkg-config present
+      ansible.builtin.assert:
+        that:
+          - frappe_substrate_v16_python_version.stdout is regex('^Python 3\\.14\\.')
+          - (frappe_substrate_v16_node_version_final.stdout | regex_search('v([0-9]+)', '\\1') | first | int) >= frappe_substrate_v16_node_major
+          - frappe_substrate_v16_pkgconfig_version.stdout | length > 0
+        success_msg: >-
+          {{ frappe_substrate_v16_python_version.stdout }} /
+          node {{ frappe_substrate_v16_node_version_final.stdout }} /
+          pkg-config {{ frappe_substrate_v16_pkgconfig_version.stdout }}
+        fail_msg: "V16 substrate prereqs assertion failed — inspect the role's three capture tasks."

--- a/ansible/site-kvm.yml
+++ b/ansible/site-kvm.yml
@@ -85,6 +85,10 @@
     - docker
     - mariadb
     - nginx_ui
+    # frappe_substrate_v16 self-gates on target_frappe_major >= 16 so
+    # it is a no-op on V13/V14/V15 targets (ESACP#445).
+    - role: frappe_substrate_v16
+      tags: [frappe_substrate_v16]
 
 # ── Play 5: WireGuard spoke — controller (this host, runs locally) ─────────
 - name: WireGuard spoke — controller

--- a/hosts_map.yml
+++ b/hosts_map.yml
@@ -22,6 +22,13 @@ zone_domains:
 #   KVM:   virbr0 IP (192.168.122.10) — stable, internal to the host.
 #   vbox:  hub's bridged LAN IP — set in ansible/group_vars/vbox.yml since
 #          it varies by LAN. Leave blank here; group_vars overrides.
+#
+# target_frappe_major: optional per-host integer (13 / 14 / 15 / 16 / …).
+#   The frappe major version this host is being prepared for. Absent ⇒ 13
+#   (default, matches packer-baked v13-era image). When ≥ 16, the
+#   `frappe_substrate_v16` ansible role installs Python 3.14, Node 24,
+#   and pkg-config (see ESACP#445). Tracks substrate readiness for
+#   incremental V16 cutover (see [[end-state-v16-lts-current-stack]]).
 
 groups:
 
@@ -107,6 +114,7 @@ groups:
       backend: kvm
       hypervisor: toshiba
       vm_role: dev:unspecified
+      target_frappe_major: 16
       ansible_groups:
         - kvm
         - targets

--- a/tools/generate_inventory.py
+++ b/tools/generate_inventory.py
@@ -64,6 +64,11 @@ def build_inventory(data: dict) -> dict:
             }
             if attrs.get("ansible_connection"):
                 hv["ansible_connection"] = attrs["ansible_connection"]
+            # Surface the per-host target frappe major to ansible so the
+            # frappe_substrate_v16 role can no-op on V13/V14/V15 hosts
+            # (ESACP#445).
+            if "target_frappe_major" in attrs:
+                hv["target_frappe_major"] = attrs["target_frappe_major"]
             # Remote-hosted VMs are on a hypervisor virbr0; controller cannot
             # route there directly — ProxyJump through the hypervisor is required.
             hypervisor = attrs.get("hypervisor")


### PR DESCRIPTION
## Summary

Adds `frappe_substrate_v16` ansible role to overlay V16-era substrate prereqs on the packer-baked v13-era image (the packer template refresh itself is multi-session work, deferred per S75 agenda).

- `hosts_map.yml`: new optional `target_frappe_major: <int>` per VM (default 13 when absent). Set to 16 on `dev02` only.
- `tools/generate_inventory.py`: pass the field through as a hostvar (5-line change).
- `ansible/roles/frappe_substrate_v16/`: new role, self-gates on `target_frappe_major >= 16`. Installs Python 3.14 (deadsnakes PPA), Node 24 (NodeSource setup_24.x with inner `when:` gating on current major), and pkg-config. Final task asserts all three version strings.
- `ansible/site-kvm.yml`: role appended to Play 4 (targets) with the `frappe_substrate_v16` tag.

Closes #445.

## Why

S74 V14-trial-extension to V16 established the substrate distance (see `internal_docs/SessionLogs/2026-05-22-v14-trial-notes.md` § Extension 3):

- frappe v16 `requires-python = ">=3.14,<3.15"`
- frappe v16 `engines.node = ">=24"`
- `pkg-config` required by pip install

None of these were on the packer-baked v13 image (Python 3.10 + Node 18). This role is the forward-compatible overlay so V16-target VMs become substrate-ready without waiting on the packer template refresh.

## Acceptance evidence

Two runs against `dev02`:

1. **First pass** — assert failed on Node (uncovered the packer-baked `nodesource.list` still pointed at node_18.x; the original `creates:` guard meant the setup-24 script never ran). Fixed: removed the `creates:` guard so the NodeSource setup runs idempotently when the block is entered (block's outer `when:` already gates entry to the "Node < 24" case). Re-ran — passed: `Python 3.14.5 / node v24.15.0 / pkg-config 0.29.2`.
2. **Idempotency probe** — re-ran the role; `changed=0`, inner Node tasks `skipped` because Node is now ≥24. Asserts re-pass identically.

`ansible-playbook --syntax-check ansible/site-kvm.yml` clean.
`tools/pre_commit_size_check.py` exit 0.

## QA

`esacp-qa` Trigger 1 (pre-commit): `approve-with-conditions`, hard_block=false.
`esacp-qa` Trigger 3 (pre-push): `approve`, hard_block=true.

T1 conditions discharged before commit:
- Untracked role dir staged ✓
- Pre-existing `hasan@` hardcode in `tools/generate_inventory.py` filed as #451 (not introduced here)
- Pre-existing 140-line `tools/generate_inventory.py` filed as #452 (not introduced here)

## Out of scope (separate sessions / issues)

- Packer template rebuild for the V16 era (multi-session).
- Rebuilding `dev02`'s bench env on python3.14 (substrate migration territory; gated on E9 + #444).
- `returnable`'s pypika URL-dep crash (E9 — bespoke-app pattern fix).
- `erpnext.patches.v16_0.make_workstation_operating_components` defect (#444).

Per `feedback_no_downstream_of_merge_acceptance.md`, this PR's acceptance does not gate on those other issues' resolution.

## Test plan

- [x] `frappe_substrate_v16` role applied to `dev02` — three version strings asserted.
- [x] Re-run idempotency probe — `changed=0`, asserts re-pass.
- [x] `ansible-playbook --syntax-check site-kvm.yml` clean.
- [x] `tools/pre_commit_size_check.py` exit 0.
- [x] `tools/generate_inventory.py` regen — byte-clean diff confined to `target_frappe_major: 16` on dev02 line.
- [ ] Post-merge: confirm `mergedAt` populated, confirm #445 auto-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)