### PR TITLE
fix(substrate): skip v16 make_workstation_operating_components patch (#444)

### DIFF
--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -208,6 +208,7 @@
   "tools/pipeline/upgrade_v14/test_switch_to_v14_cmd.py": 44,
   "tools/pipeline/upgrade_v14/test_verify.py": 35,
   "tools/pipeline/upgrade_v14/verify.py": 42,
+  "tools/vm_scripts/g1_seed_patch_log.py": 77,
   "tools/vm_scripts/install_specific/__init__.py": 14,
   "tools/vm_scripts/u6_dedup_smoke_test.py": 70
 }

--- a/tools/vm_scripts/g1_seed_patch_log.py
+++ b/tools/vm_scripts/g1_seed_patch_log.py
@@ -23,6 +23,10 @@ PATCHES_TO_SKIP = [
         "frappe.patches.v12_0.delete_duplicate_indexes  # 2022-12-15",
         "queries session_status table which doesn't exist in production backup",
     ),
+    (
+        "erpnext.patches.v16_0.make_workstation_operating_components #1",
+        "ESACP#444: upstream doc.save() on submitted Workstation halts V15→V16",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `erpnext.patches.v16_0.make_workstation_operating_components #1` to `PATCHES_TO_SKIP` in `tools/vm_scripts/g1_seed_patch_log.py`, unblocking V15→V16 migration on tenants with submitted `Workstation` rows.

Closes #444.

## Why

Upstream erpnext v16 patch calls `doc.save()` on submitted `Workstation` docs to backfill the new `Operating Components Cost` field (introduced for the new `Workstation Operation` child doctype). Frappe's `_validate_update_after_submit` blocks the write because the field is not marked `allow_on_submit`, raising:

```
frappe.exceptions.UpdateAfterSubmitError:
  Not allowed to change Operating Components Cost after submission from 0 to 3
```

Per global conduct rule (no modification of third-party code), the local remediation is to pre-seed the `Patch Log` row via `g1_seed_patch_log.py` — substrate-apply primitive (#418) re-rsyncs `vm_scripts/` and runs `g1` before `bench migrate`, so the patch is marked already-executed and bench skips it.

The `#1` suffix matters: `frappe.modules.patch_handler.executed()` queries `tabPatch Log` for the verbatim patches.txt line, which includes the trailing `#1` comment. Without the suffix the pre-seed row doesn't match and bench re-runs the patch.

## Acceptance evidence (dev02, S75)

- `bench migrate` exit 0 (was failing with `UpdateAfterSubmitError`).
- `bench --site dev02.iridium.blue version`: **frappe 16.18.3 / erpnext 16.19.1** (was 15.108.0 / 15.108.3).
- Row counts preserved across all 3 key doctypes:
  - `tabSales Invoice`: 22,433 (unchanged)
  - `tabCustomer`: 1,803 (unchanged)
  - `tabItem`: 312 (unchanged)
- `/login` HTTP 200 ✓ · `/api/method/ping` returns `{"message":"pong"}` ✓ · `/desk/*` fully functional (operator confirmed live exploration of Sales Invoice list, user management, logout/login cycle).
- **Reboot-clean supervisor startup** — operator rebooted dev02 and confirmed the v16 stack comes up clean automatically (not just via in-session restart).

## Out of scope (new defects surfaced — filed as separate issues)

These would have surfaced for any successful V15→V16 migration on this site; not regressions from this PR.

- **#456** — `bug(v16-upgrade): website root / returns 404 — Web Page record missing for configured home_page`. ERP backend fully functional via /desk; only the public-website portal landing is broken.
- **#457** — `chore(v16-upgrade): currentsite.txt deprecation warning at every gunicorn boot — switch to bench use`. Cosmetic for now; v16 deprecated `currentsite.txt` in favour of `bench use <site>`.

## Tenant business impact of the skip

The skip leaves `Operating Components Cost` at its default (0) on existing `Workstation` docs (2 rows on dev02 / production data). Populating this field is a deferred tenant business decision outside ESACP automated scope — a new issue can be filed if/when automation is required.

## QA

`esacp-qa` Trigger 1 (pre-commit) — `approve-with-conditions`, hard_block=false.

Conditions discharged before commit:
- Comment wording on the `PATCHES_TO_SKIP` entry reworded (and then shrunk further to satisfy the 80-line size ratchet); final form is a single-line `ESACP#444` pointer with no ambiguity about ESACP scope.
- Verbatim commit command stated (GPG-signed, Conventional Commits format, `fixes #444`, Co-Authored-By trailer).

Per verdict layer v2.1 §2.1 (T1+T3 combined for single-commit branches) and §2.2 (T2 carve-out for same), no further QA invocations required pre-merge.

## Test plan

- [x] `bench migrate` exit 0 on dev02 with the skip applied.
- [x] Version strings confirmed frappe 16.x / erpnext 16.x.
- [x] Row counts preserved across SI / Customer / Item.
- [x] /login + /api + /desk functional.
- [x] Reboot-clean supervisor startup.
- [x] Pre-commit size check pass (file: 77 lines).
- [ ] Post-merge: confirm `mergedAt` populated, confirm #444 auto-closed by `fixes` keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)