### PR TITLE
feat(on_boarding): Jekyll scaffold + static chat-bubble index.md (Sub-branch 2 of #455)

### DIFF
--- a/on_boarding/docs/.gitignore
+++ b/on_boarding/docs/.gitignore
@@ -1,0 +1,7 @@
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+.bundle/
+vendor/
+Gemfile.lock

--- a/on_boarding/docs/Gemfile
+++ b/on_boarding/docs/Gemfile
@@ -1,0 +1,18 @@
+source "https://rubygems.org"
+
+# Jekyll — local-serve only for now.
+# Pinned to a recent 4.x to match what the controller's Ruby (3.3.x) builds
+# cleanly against. Bump deliberately, not opportunistically.
+gem "jekyll", "~> 4.4"
+
+# Minimal plugins. The page is hand-written HTML inside Markdown; no
+# theme, no SEO plugin, no feed plugin — those land when the page is
+# actually published (out of scope for #467).
+group :jekyll_plugins do
+end
+
+# Windows / JRuby compatibility shims — left commented; uncomment only
+# if a future operator hits the underlying error on their platform.
+# gem "tzinfo", ">= 1", "< 3"
+# gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+# gem "wdm", "~> 0.1.1", platforms: %i[mingw mswin x64_mingw]

--- a/on_boarding/docs/_config.yml
+++ b/on_boarding/docs/_config.yml
@@ -1,0 +1,37 @@
+title: "ESACP — onboarding"
+description: >-
+  Chat-bubble mock of a Buzz_000 walkthrough — the static-UX preview
+  that seeds the future PWA + Cloudflare-Worker chatbot described in
+  on_boarding/internal_docs/entry-architecture-notes.md.
+
+# No remote theme. The page is hand-written HTML; the layout in
+# _layouts/default.html is intentionally minimal — chat-bubble surface
+# only, no nav/footer/sidebar.
+theme:
+
+# Local-serve only. base_url stays empty so localhost links work.
+url: ""
+baseurl: ""
+
+# Quiet the build a little.
+quiet: false
+incremental: false
+
+# Markdown engine — kramdown is jekyll's default; explicit for clarity.
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+
+# Sass / SCSS. style: compressed for the CSS asset; sourcemaps off.
+sass:
+  style: compressed
+  sourcemap: never
+
+# Exclude generator / vendor noise from the build.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+  - .bundle/
+  - README.md

--- a/on_boarding/docs/_layouts/default.html
+++ b/on_boarding/docs/_layouts/default.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page.title | default: site.title }}</title>
+  <meta name="description" content="{{ site.description }}">
+  <link rel="stylesheet" href="{{ '/assets/css/chat.css' | relative_url }}">
+</head>
+<body>
+  <main class="page">
+    <header class="page-header">
+      <h1>{{ page.title | default: site.title }}</h1>
+      {% if page.subtitle %}<p class="subtitle">{{ page.subtitle }}</p>{% endif %}
+    </header>
+    <section class="chat">
+      {{ content }}
+    </section>
+    <footer class="page-footer">
+      <p>Static mock — no chatbot wired up yet. See
+        <code>on_boarding/internal_docs/entry-architecture-notes.md</code>
+        for the live-chat architecture this page seeds.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/on_boarding/docs/assets/css/chat.scss
+++ b/on_boarding/docs/assets/css/chat.scss
@@ -1,0 +1,163 @@
+---
+---
+
+/* Chat-bubble mock — static, no JS. Two speakers (Buzz, Essex)
+   alternating turns. Bubble layout is asymmetric so the speaker is
+   visually unambiguous even before reading. */
+
+:root {
+  --bg: #fafaf7;
+  --ink: #1d1d1f;
+  --ink-muted: #5b5b62;
+  --rule: #e4e4e0;
+
+  --buzz-bg: #ffffff;
+  --buzz-border: #d8d8d0;
+  --buzz-speaker: #6b5e3a;   /* warm brown — heirloom, wood, antique */
+
+  --essex-bg: #eef3ff;
+  --essex-border: #b9caee;
+  --essex-speaker: #2a4480;  /* steady blue — tool, instrument, calm */
+
+  --radius: 12px;
+  --gap: 0.9rem;
+  --bubble-max: 38rem;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.page {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+}
+
+.page-header {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+
+  h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .subtitle {
+    margin: 0;
+    color: var(--ink-muted);
+    font-size: 0.95rem;
+  }
+}
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+
+.turn {
+  display: flex;
+  flex-direction: column;
+  max-width: var(--bubble-max);
+
+  .speaker {
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.2rem;
+  }
+
+  .bubble {
+    border-radius: var(--radius);
+    padding: 0.75rem 1rem;
+    border: 1px solid;
+
+    p:first-child { margin-top: 0; }
+    p:last-child  { margin-bottom: 0; }
+
+    code {
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 0.88em;
+      background: rgba(0, 0, 0, 0.05);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+    }
+
+    pre {
+      background: #0f0f12;
+      color: #e8e8e8;
+      padding: 0.85rem 1rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      font-size: 0.85rem;
+      line-height: 1.45;
+
+      code {
+        background: transparent;
+        padding: 0;
+        color: inherit;
+        font-size: inherit;
+      }
+    }
+
+    ul, ol { padding-left: 1.25rem; }
+    li + li { margin-top: 0.2rem; }
+  }
+}
+
+.turn.buzz {
+  align-self: flex-start;
+
+  .speaker { color: var(--buzz-speaker); }
+  .bubble {
+    background: var(--buzz-bg);
+    border-color: var(--buzz-border);
+    border-bottom-left-radius: 4px;
+  }
+}
+
+.turn.essex {
+  align-self: flex-end;
+  align-items: flex-end;
+
+  .speaker { color: var(--essex-speaker); }
+  .bubble {
+    background: var(--essex-bg);
+    border-color: var(--essex-border);
+    border-bottom-right-radius: 4px;
+  }
+}
+
+.page-footer {
+  margin-top: 3rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+
+  code {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    background: rgba(0, 0, 0, 0.05);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+  }
+}
+
+@media (max-width: 28rem) {
+  .turn { max-width: 100%; }
+  .page { padding: 1.25rem 0.85rem 3rem; }
+}

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -1,0 +1,206 @@
+---
+layout: default
+title: "Setting up ESACP on a Windows 11 machine"
+subtitle: "A first conversation between Buzz_000 and Essex. Static mock — no chatbot wired up yet."
+---
+
+<!--
+  Static chat-bubble mock. Each turn is a div with class "turn buzz" or
+  "turn essex". The inner div uses `markdown="1"` so kramdown still
+  processes the bubble content. No JS, no chatbot.
+
+  Walkthrough beats (see #467 acceptance):
+    1. Why a parallel Ubuntu-24.04 WSL distro
+    2. The one PowerShell line that imports it
+    3. Visual branding so Buzz can tell ESACP's window apart
+    4. Snapshot / revert posture (Minecraft "shelter")
+    5. The first prompt in the new shell + what Essex does next
+-->
+
+> **Audience:** Variant 1 greenfield (small business not yet on any ERP) ·
+> **Archetype:** Win-11 controller, never opened a terminal, mobile-first ·
+> **Stage:** 1 — first encounter.
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Hi. A friend told me ESACP could help me get my business onto one piece of software instead of the seven I'm using now. I've got a Windows 11 laptop. Where do I start?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Welcome, Buzz. The first thing we'll do is give your laptop a small, separate Linux room to work in — without touching anything you already have on Windows. The piece of Windows that lets us do this is called **WSL** (Windows Subsystem for Linux); it's free, it's made by Microsoft, and it ships with your laptop already.
+
+Think of it like adding a clean workbench to your garage. Your existing tools stay where they are; we just put the ESACP work on its own surface so nothing gets mixed up.
+
+When you're ready, I'll walk you through the first command.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Hold on — I already had someone install Ubuntu on this thing last year for a different project. Won't yours wreck that one?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Good catch, and the answer is *no, by design*. WSL lets you run several Linux installations side by side, each with its own name and its own files. We're going to create a brand-new one called **ESACP** and leave your existing Ubuntu completely alone.
+
+Here's the plan, and I'll narrate every step before we run it:
+
+- **What** — install a fresh Ubuntu 24.04, then re-import it under the name `ESACP`.
+- **Why** — a separate name means a separate filesystem. If anything ever goes wrong with the ESACP side, your other Ubuntu is untouched.
+- **Who** — only Microsoft (the WSL feature) and Canonical (the people who make Ubuntu). Nobody else is involved at this step.
+- **Cost** — zero. The disk space comes out of your laptop's drive (around 1.5 GB to start).
+
+Open **PowerShell** — the blue terminal, not the black one — and we'll do it together.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Got it open. Now what?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Two commands. The first one downloads Ubuntu 24.04 from Microsoft's catalogue:
+
+```powershell
+wsl --install -d Ubuntu-24.04 --no-launch
+```
+
+The `--no-launch` is intentional — we don't want it to start asking *you* for a username yet. It'll just sit there, ready.
+
+When that finishes (a minute or two), tell me and we'll do the second one.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Done. It said "Ubuntu-24.04 has been installed."
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Perfect. Now we'll make the ESACP-branded copy. Three lines:
+
+```powershell
+mkdir C:\WSL\ESACP
+wsl --export Ubuntu-24.04 C:\WSL\ESACP\seed.tar
+wsl --import ESACP C:\WSL\ESACP C:\WSL\ESACP\seed.tar --version 2
+```
+
+In plain English: we made a folder, took a snapshot of the fresh Ubuntu you just installed, and registered that snapshot back under the name **ESACP**. You now have a Linux distribution called `ESACP` that is yours.
+
+Type `wsl -l -v` and you should see both `Ubuntu-24.04` and `ESACP` in the list.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+There they are. So now I just open the ESACP one?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Almost. One more thing first — let's make the ESACP window *look* different from the other one, so you never have to guess which is which. This is a one-time setup in **Windows Terminal** (the app with the multicoloured icon in your Start menu).
+
+Open Windows Terminal, click the **down-arrow** next to the `+` tab, choose **Settings**, then **Open JSON file**. We'll add a profile for ESACP. I'll give you the exact block to paste:
+
+```json
+{
+  "name": "ESACP",
+  "commandline": "wsl.exe -d ESACP",
+  "icon": "🛠️",
+  "tabTitle": "ESACP",
+  "colorScheme": "Tango Dark",
+  "background": "#0f2a1d",
+  "startingDirectory": "//wsl$/ESACP/root"
+}
+```
+
+Save the file. Open a new tab — you'll see **ESACP** in the dropdown, in a deep-green window that's unmistakable.
+
+- **What** — a named, coloured terminal profile for ESACP.
+- **Why** — when you have three windows open and you're tired, the green one is always ESACP. Mistakes get cheaper.
+- **Who** — nobody outside Microsoft. The setting lives in a file on your laptop.
+- **Cost** — free.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+That's cute. Green window, ESACP. Got it. What if I mess everything up?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+That's the best question you've asked yet, and we have a clean answer.
+
+Before we change anything inside the ESACP room, we'll take a **snapshot** — a complete copy of the room as it is right now. If anything goes sideways later, you run one command and you're back to this exact state. Nothing else on your laptop is affected.
+
+Snapshot (run from PowerShell, not from inside ESACP):
+
+```powershell
+wsl --export ESACP C:\WSL\ESACP\snapshots\day-0.tar
+```
+
+Revert, if you ever need to:
+
+```powershell
+wsl --unregister ESACP
+wsl --import ESACP C:\WSL\ESACP C:\WSL\ESACP\snapshots\day-0.tar --version 2
+```
+
+I think of it as the **shelter** in a Minecraft survival world — a safe place you can always return to. An IT consultant would charge you several hundred dollars to set up a backup-and-restore system this clean. We just did it in two lines, and you own it.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+OK. Snapshot taken. Now do I go in?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Now you go in. Open the green **ESACP** tab in Windows Terminal. You'll see a prompt that looks something like this:
+
+```text
+root@ESACP:~#
+```
+
+You're inside the ESACP room. From here I'll start the actual setup — installing the small set of tools the platform needs (a key manager, a signing utility, GitHub's command-line client, and a couple of others). Every install will get the same *What / Why / Who / Cost* explanation you've seen so far, and you'll click "yes" to each one.
+
+An IT consultant would take weeks to wire up everything we're about to set up, and would charge you accordingly. ESACP has all of it in its training. We'll go through it together at your pace.
+
+When you're ready, type `whoami` and press Enter. We'll start there.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+*[end of static mock — the next turns will come from the real chatbot when the backend lands. See `on_boarding/internal_docs/entry-architecture-notes.md`.]*
+  </div>
+</div>


### PR DESCRIPTION
Sub-branch 2 of agenda issue [#455](https://github.com/martinhbramwell/ESACP/issues/455); tracked as sub-issue [#467](https://github.com/martinhbramwell/ESACP/issues/467).

## What lands

A self-contained, local-serve-only Jekyll site at `on_boarding/docs/`:

| File | Purpose |
|---|---|
| `Gemfile` | `gem "jekyll", "~> 4.4"`; no plugins, no theme dependency. |
| `_config.yml` | Custom layout, kramdown GFM, rouge highlighter, compressed sass. |
| `_layouts/default.html` | Minimal HTML scaffold linking the chat stylesheet. |
| `assets/css/chat.scss` | Two-speaker chat bubbles (`.turn.buzz` left-aligned warm, `.turn.essex` right-aligned cool). |
| `index.md` | The Buzz_000 walkthrough — 11 alternating turns covering the parallel Ubuntu-24.04 WSL distro install, the `wsl --export`/`--import` rename to `ESACP`, the Windows Terminal profile for visual branding, the `wsl --export`/`--unregister`/`--import` snapshot/revert posture framed as the Minecraft \"shelter\", and the handoff into the new shell. |
| `.gitignore` | `_site/`, `.jekyll-cache/`, `.bundle/`, `vendor/`, `Gemfile.lock`. |

No JavaScript on the page. No chatbot backend. This is the static UX seed for the future PWA + Cloudflare-Worker architecture described in `on_boarding/internal_docs/entry-architecture-notes.md`.

## Verification

- `bundle exec jekyll build` — clean (0.4s, no warnings).
- `bundle exec jekyll serve` on `127.0.0.1:4000` — operator-verified rendered output (\"the mockup works, it progresses the way I want and the conversational tone is also good\").
- QA verdict log: T1 `approve-with-conditions` → persona-declaration blockquote added → T3 `approve`.

## Buzz_000 walkthrough — content beats

1. WSL framing as a clean separate workbench, not a replacement for any existing tool.
2. Why a parallel distro (the operator's existing Ubuntu stays untouched by design).
3. `wsl --install -d Ubuntu-24.04 --no-launch` + `wsl --export` + `wsl --import` as the ESACP-branded distro.
4. Windows Terminal JSON profile — deep-green background, ESACP tab title, so the right window is unambiguous at a glance.
5. Snapshot / revert as the Minecraft shelter — two-line backup, three-line restore, operator owns it.
6. Entry into the new shell + the IT-consultant pitch landing at the natural moment (first tangible capability).

Each Essex turn lands the BUZZ_PERSPECTIVE five-point contract (control / visibility / anchoring / confident tone / IT-consultant pitch where applicable).

## Discipline notes

- `fixes #467` is in the commit body (not only this PR description) per the cross-branch `fixes` rule.
- Per `project_on_boarding_trunk_vs_default.md`, sub-branch → on_boarding merges do **not** auto-close cross-branch `fixes`. #467 will need manual T5 close at session-closeout.
- Persona declaration block in `index.md` body satisfies `session-discipline.md` §\"Persona declaration\" (caught at T1, addressed before commit).

## Out of scope (deferred to future sessions)

- Chatbot interactivity (Path B local dev proxy, Path C Cloudflare Worker per `entry-architecture-notes.md`).
- Publishing this page via GitHub Pages — Pages-classic publishes one source per repo, currently the root `docs/`. Enabling `on_boarding/docs/` needs a Pages-Actions workflow this PR deliberately doesn't introduce.
- Real Buzz_NNN archetype iteration cycles (Buzz_001 onwards).
- `BUZZ_PERSPECTIVE.md` multi-archetype refactor + `ESSEX_PERSPECTIVE.md` creation — flagged in #448 for future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)