### PR TITLE
docs(on_boarding): codify closeout-PR backfill workflow (guardrail against Session-6 slip)

### DIFF
--- a/on_boarding/internal_docs/session-discipline.md
+++ b/on_boarding/internal_docs/session-discipline.md
@@ -148,6 +148,45 @@ eventual `on_boarding` → `main` merge.)
 `on_boarding/internal_docs/SESSIONS.md` lives next to this file. Header row only; no
 prose between entries.
 
+### Closeout-PR backfill workflow
+
+Session closeout PRs carry a circular-reference problem: the closeout
+commit's SESSIONS row and qa-log summary row need to cite the closeout
+PR's own number, which doesn't exist until the PR is opened. The
+established workflow handles this in two distinct precedents that
+**must not be conflated**:
+
+**Precedent 1 — T1+T3 skip on the closeout commit itself.** The closeout
+commit (which writes the SESSIONS row + qa-log entries) leaves `PR #TBD`
+placeholders in the cells that would have cited its own PR. T1 and T3 on
+*this commit specifically* are skipped, because the inputs (the PR
+number) don't exist at commit time. T2 on the closeout PR's merge and
+T5 on any issues that PR closes still apply normally. Reference:
+Session-3 `7a66f4d`, Session-5 `c155c62`.
+
+**Precedent 2 — the backfill commit is its own sub-branch + PR.** Once
+the closeout PR has merged and its number is known, a *separate* commit
+substitutes `PR #TBD` → `#NNN` in the two cells. This backfill commit
+goes through the full sub-branch + T1 + commit + T3 + push + PR + T2 +
+merge cycle. It does **not** inherit the T1+T3 skip from precedent 1.
+By backfill time, the PR number is the entire content of the change —
+there is no longer any reason to skip QA gates. Reference: Session-5
+backfill = PR [#471](https://github.com/martinhbramwell/ESACP/pull/471).
+
+The skips are different because precedent 1's skip is structural (inputs
+don't exist) while precedent 2's would be merely procedural-shortcut
+(inputs do exist; we'd just be skipping for convenience). Session 6
+(2026-05-24) introduced commit `87e1043` directly to `on_boarding`,
+mistakenly applying precedent 1's skip to a precedent-2 commit. The
+content was correct but the discipline drifted; this section codifies
+the distinction so future Junior catches the shape before committing.
+
+**Mechanical check before committing**: if the diff touches only
+`PR #TBD → #NNN` substitutions in `SESSIONS.md` and/or `qa-log.md`, and
+you are about to commit directly to `on_boarding` (no sub-branch), STOP.
+Cut a `docs/session-N-pr-backfill` sub-branch first and route the change
+through a PR.
+
 ## QA verdict layer
 
 T1 commits · T2 merges · T3 pushes · T4 destructive ops · T5 issue


### PR DESCRIPTION
Codifies the two-precedents distinction Session 6 conflated. Closes #478 (manual T5 required per `project_on_boarding_trunk_vs_default.md`).

## Summary

- New sub-section in `session-discipline.md` under "Practical mechanics" titled "Closeout-PR backfill workflow".
- Explicitly delineates: (1) T1+T3 skip on the closeout commit itself = structural (PR # doesn't exist yet); (2) the backfill commit after closeout-PR merge = own sub-branch + PR with full QA gates, NOT a skip.
- Mechanical pre-commit check: if diff touches only `PR #TBD → #NNN` substitutions and the working branch is `on_boarding` (not a sub-branch), STOP and cut `docs/session-N-pr-backfill`.
- Memory entry `feedback_closeout_backfill_two_precedents.md` added out-of-tree (operator memory dir) + MEMORY.md index updated, so future Junior reads the rule at session-start.

## The slip this guardrail prevents

Commit `87e1043` on `on_boarding` (Session 6, 2026-05-24) — backfill of `PR #TBD` → `#477` committed directly to `on_boarding` instead of routing through its own sub-branch + PR per Session-5 precedent ([#471](https://github.com/martinhbramwell/ESACP/pull/471)). Content was correct; discipline drifted. Operator authorized leaving the commit and writing this guardrail rather than reverting.

## Test plan

- [x] T1 esacp-qa verdict: approve (single file, +39/-0, format correct, real-name scan clean, content accurately describes the two precedents)
- [x] T3 esacp-qa verdict: approve (commit `28b96ed` GPG-signed, bit-identical to T1, fixes #478 in body)
- [ ] T2 esacp-qa verdict on this PR
- [ ] Merge to `on_boarding`
- [ ] Manual T5 close on #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)