### PR TITLE
fix(nginx): add Origin + X-Frappe-Site-Name to socketio vhost block

### DIFF
--- a/platforms/kvm/templates/nginx_vhost.conf.j2
+++ b/platforms/kvm/templates/nginx_vhost.conf.j2
@@ -55,6 +55,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Required by frappe realtime authenticate middleware.
+        # Without these, upstream node-socketio sees no Origin / X-Frappe-Site-Name
+        # and rejects with "Invalid origin" (apps/frappe/realtime/middlewares/authenticate.js).
+        proxy_set_header X-Frappe-Site-Name $host;
+        proxy_set_header Origin $scheme://$http_host;
         proxy_pass http://frappe-socketio-{{ bench_name_new }};
     }
 


### PR DESCRIPTION
## Summary

Adds two missing `proxy_set_header` directives in `/socket.io` location of
`platforms/kvm/templates/nginx_vhost.conf.j2`. Without them, upstream node-socketio
sees no Origin header → frappe realtime middleware rejects with "Invalid origin".

Always-broken on both V13 and V16 dev VMs. Manual patch + reload on dev01 + dev02
verified: socket.io connects.

## Closes

- #481 (R5 socketio defect)
- Part of #480 (V13→V16 re-migration umbrella)

## Test plan

- [x] Manual patch applied to dev02 `/etc/nginx/sites-available/dev02.iridium.blue` + `nginx -s reload` — V16 socket.io connects (`connected: true` + valid id)
- [x] Manual patch applied to dev01 `/etc/nginx/sites-available/dev01.iridium.blue` + `nginx -s reload` — V13 socket.io connects (`connected: true` + valid id)
- [x] `nginx -t` passes on both VMs after patch
- [ ] Ansible re-run on dev01 + dev02 to validate template is the source-of-truth (deferred — current substrate already patched manually)
- [ ] Apply to production cutover script (deferred — covered by #480 umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)