### PR TITLE
fix(nginx): R6 template parity with ce_sri prod

### DIFF
--- a/platforms/kvm/templates/nginx_vhost.conf.j2
+++ b/platforms/kvm/templates/nginx_vhost.conf.j2
@@ -31,16 +31,52 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    client_max_body_size 50m;
+    sendfile on;
+    keepalive_timeout 15;
+    client_body_buffer_size 16K;
+    client_header_buffer_size 1k;
+
     gzip on;
     gzip_vary on;
     gzip_proxied any;
     gzip_comp_level 6;
-    gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
+    gzip_http_version 1.1;
+    gzip_min_length 256;
+    gzip_types
+        application/atom+xml
+        application/font-woff
+        application/javascript
+        application/json
+        application/rss+xml
+        application/vnd.ms-fontobject
+        application/x-font-ttf
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        application/xml+rss
+        font/opentype
+        image/svg+xml
+        image/x-icon
+        text/css
+        text/plain
+        text/x-component
+        text/xml;
 
     root /home/{{ erp_user }}/{{ bench_name_new }}/sites;
 
     location /assets {
         try_files $uri =404;
+    }
+
+    location ~ ^/protected/(.*) {
+        internal;
+        try_files /{{ site_url }}/$1 =404;
+    }
+
+    location ~ ^/files/.*\.(htm|html|svg|xml)$ {
+        add_header Content-Disposition "attachment" always;
+        try_files /{{ site_url }}/public$uri @webserver;
     }
 
     location ~ ^/files/.*$ {
@@ -77,6 +113,8 @@ server {
 
     location / {
         rewrite ^(.+)/$ $1 permanent;
+        rewrite ^(.+)/index\.html$ $1 permanent;
+        rewrite ^(.+)\.html$ $1 permanent;
         try_files /{{ site_url }}/public$uri @webserver;
     }
 }


### PR DESCRIPTION
## Summary

- Closes #483 (R6 — nginx template parity audit vs `ce_sri/development/initialization/makeNGinxConfFile.sh`).
- Single-file change: `platforms/kvm/templates/nginx_vhost.conf.j2`. Adds R6a (`/protected/` internal location), R6b (`Content-Disposition: attachment` for `/files/*.{htm,html,svg,xml}`), R6c (`client_max_body_size 50m` + perf optimizations), R6e.1 (`.html` / `index.html` stripping rewrites), R6e.3 (expanded `gzip_types` + `gzip_min_length 256` + `gzip_http_version 1.1`).
- R6d **dropped** (`proxy_redirect off` — no observable defect under modern Frappe's relative `Location:` headers). R6e.2 **deferred** (502.html template source-policy decision pending).

## Methodology

Neighborhood audit per `feedback_v13_v16_verification_depth.md` sub-rule #1; operator walkthrough with per-item fix/defer/drop dispositions per sub-rule #6 (#483 S80 comment thread). Diff against `PRODUCTION_20260404/apps/ce_sri/development/initialization/makeNGinxConfFile.sh` as the proven source-of-truth.

## Test plan

- [x] **A0** operator walkthrough (S80) — `fix` / `defer` / `drop` signoff captured per-item on #483
- [x] **A1** template diff lands in this PR
- [x] **A2 / A3** R6d-drop / R6e.2-defer rationales captured in #483 comment thread
- [x] **A4** template deployed on dev01 + dev02 via direct pipeline-primitive script (see #492 — `refresh` macro is content-blind on stages 4/5 verify gates; tracked separately)
- [x] **A5** all six probes pass on both VMs:
  - R6a: `GET /protected/<nonexistent>` → `HTTP/2 404`
  - R6b: `GET /files/<probe>.html` → `Content-Disposition: attachment`
  - R6c: `POST 5 MiB → /api/method/ping` → `HTTP/2 200` (no 413)
  - R6e.1 (`.html`): 301 → `/somepage`
  - R6e.1 (`index.html`): 301 → `/somedir`
  - R6e.3: `/assets/css/frappe-web-b4.css` with `Accept-Encoding: gzip` → `Content-Encoding: gzip`
  - Full results posted to #483 (comment 4544904185)
- [ ] **A6** Qualys regression — DEFERRED via #488 (SSL Labs cannot scan RFC1918 lab IPs; SSL grading low-priority while ESACP-built hosts are LAN-only)
- [ ] **A7** LSKB#31 cross-link — still open; explicit non-dependency per #483

## Cross-references

- Parent: #480 (V13→V16 re-migration umbrella)
- Memory: `feedback_v13_v16_verification_depth.md`
- New trackers from this session: #488 (Qualys deferral until public reachability), #492 (pipeline `refresh` is content-blind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)