### PR TITLE
feat(pipeline): V13->V16 post-migrate fix R3 — disable IRS 1099 PF (#498)

### DIFF
--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -94,7 +94,7 @@ Job types: `provision`, `provision_generic`, `refresh`, `destroy`, `build_templa
 
 ## esacp.py — Unified Lab CLI
 
-`./tools/esacp.py <subcommand> [options]` — run from project root; `--help` lists all subcommands. 14 subcommands routed through `tools/cli/*.py` per-command dispatchers.
+`./tools/esacp.py <subcommand> [options]` — run from project root; `--help` lists all subcommands. 15 subcommands routed through `tools/cli/*.py` per-command dispatchers.
 
 Non-obvious behaviours:
 - `provisionVM` Ansible output filter: shows PLAY headers, ✓ ok, ★ changed, ❌ fatal, RECAP only (filter lives in `tools/pipeline/stages/common/ansible_output.py`; orchestrator is `tools/pipeline/orchestration/ansible_provision.py`)
@@ -103,6 +103,7 @@ Non-obvious behaviours:
 - `snapShotVM`: KVM-only; dispatcher calls `pipeline/orchestration/snapshot_ops.py` (local virsh). Standalone `platforms/kvm/snapshot.py` still exists for operator use (revert/delete/start/state) per `internal_docs/BuildOutProcedure.md`.
 - `destroyVM` (legacy, local libvirt only): uses `tools/pipeline/orchestration/local_vm_teardown.py` for inspect + teardown; not to be confused with `destroy` which runs the full `macro/destroy.py`
 - `applySubstrateMigration` (#418): bundles `g1_seed_patch_log.py` + `g2_clear_fixture_custom_fields.py` + `bench migrate` over SSH on a lab VM. Use for LSKB#15-style bespoke-app migration tests on already-restored production data — closes the bypass that caused two cascading failures in S54/S55. Dispatcher calls `tools/pipeline/orchestration/substrate_apply.py`. See `tools/vm_scripts/README.md` for the protection catalogue.
+- `applyV16PostMigrateFixups` (#498, #480 child): runs catalogued V13→V16 post-migrate fix-scripts on a lab VM. Today's catalogue: R3 = disable orphan `IRS 1099 Form` Print Format (`tools/vm_scripts/r3_disable_irs_1099_pf.py`). Dispatcher calls `tools/pipeline/orchestration/v16_post_migrate_fixups.py`. Extensible — R1 (#486) and R6e.2 (#496) will plug in here.
 
 ## diagnose.py — Remote VM Process Diagnostics
 

--- a/tools/cli/apply_v16_post_migrate_fixups.py
+++ b/tools/cli/apply_v16_post_migrate_fixups.py
@@ -1,0 +1,44 @@
+"""CLI: apply V13->V16 post-migrate fixups on a lab VM (#498, #480 child).
+
+Thin dispatcher: build Config from hosts_map, call the primitive,
+format the result. Catalogue currently covers R3 (IRS 1099 Print Format
+disable). R1 and R6e.2 will plug into the same primitive when filed.
+"""
+
+from __future__ import annotations
+
+from tools.cli._common import banner, console, kvm_hosts, PROJECT_ROOT
+from tools.pipeline.orchestration.v16_post_migrate_fixups import (
+    apply_v16_post_migrate_fixups,
+)
+from tools.pipeline.stages.common.config import build_config
+
+
+def add_subparser(sub) -> None:
+    p = sub.add_parser(
+        "applyV16PostMigrateFixups",
+        help="Run V13->V16 post-migrate fix-scripts (R3 today; extensible)",
+    )
+    p.add_argument("vm", help="Target VM (e.g. dev02)")
+
+
+def run(args, config: dict) -> int:
+    vm = args.vm
+    host_cfg = kvm_hosts(config).get(vm) or {}
+    if not host_cfg.get("wg_ip"):
+        console.print(
+            f"[red]No wg_ip for {vm} in hosts_map.yml — "
+            "VM must be provisioned first.[/red]"
+        )
+        return 1
+
+    banner(f"Apply V16 post-migrate fixups: {vm}")
+    cfg = build_config(vm, host_cfg, str(PROJECT_ROOT), use_wg=True)
+    result = apply_v16_post_migrate_fixups(cfg, console.print)
+
+    if result.success:
+        marker = "(changed)" if result.changed else "(no-op)"
+        console.print(f"[green]OK  {result.message} {marker}[/green]")
+        return 0
+    console.print(f"[red]FAIL  {result.message}[/red]")
+    return 1

--- a/tools/esacp.py
+++ b/tools/esacp.py
@@ -13,10 +13,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from tools.cli import (
-    add_host, apply_substrate_migration, build_vm, clear_known_hosts,
-    confirm_prerequisites, destroy, destroy_vm, display_configuration,
-    provision, provision_generic, provision_vm, snapshot_vm, validate_keys,
-    validate_observability, verify_vpn,
+    add_host, apply_substrate_migration, apply_v16_post_migrate_fixups,
+    build_vm, clear_known_hosts, confirm_prerequisites, destroy, destroy_vm,
+    display_configuration, provision, provision_generic, provision_vm,
+    snapshot_vm, validate_keys, validate_observability, verify_vpn,
 )
 from tools.cli._common import console, load_config, kvm_hosts
 
@@ -37,9 +37,10 @@ DISPATCH = {
     "snapShotVM":            snapshot_vm.run,
     "displayConfiguration":  display_configuration.run,
     "applySubstrateMigration": apply_substrate_migration.run,
+    "applyV16PostMigrateFixups": apply_v16_post_migrate_fixups.run,
 }
 
-VM_COMMANDS = {"destroyVM", "buildVM", "provisionVM", "provision", "provisionGeneric", "destroy", "snapShotVM", "applySubstrateMigration"}
+VM_COMMANDS = {"destroyVM", "buildVM", "provisionVM", "provision", "provisionGeneric", "destroy", "snapShotVM", "applySubstrateMigration", "applyV16PostMigrateFixups"}
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -53,9 +54,8 @@ def _build_parser() -> argparse.ArgumentParser:
     sub.add_parser("validateKeys",         help="Verify SOPS/age keys and WireGuard key structure")
     sub.add_parser("clearKnownHosts",      help="Remove stale SSH known_hosts entries for ESACP VMs")
 
-    add_host.add_subparser(sub)
-    provision_generic.add_subparser(sub)
-    apply_substrate_migration.add_subparser(sub)
+    for mod in (add_host, provision_generic, apply_substrate_migration, apply_v16_post_migrate_fixups):
+        mod.add_subparser(sub)
 
     for name, help_text in (
         ("destroyVM",   "Destroy a KVM VM and all its storage"),

--- a/tools/pipeline/orchestration/test_v16_post_migrate_fixups.py
+++ b/tools/pipeline/orchestration/test_v16_post_migrate_fixups.py
@@ -1,0 +1,76 @@
+"""Colocated test for v16_post_migrate_fixups primitive (#498)."""
+
+from __future__ import annotations
+
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from tools.pipeline.orchestration.v16_post_migrate_fixups import (
+    apply_v16_post_migrate_fixups,
+)
+from tools.pipeline.stages.common.types import Config
+
+MOD = "tools.pipeline.orchestration.v16_post_migrate_fixups"
+EMIT = lambda _m: None  # noqa: E731
+
+
+def _config() -> Config:
+    return Config(
+        hostname="dev02", nickname="D2IRBL", zone="development", backend="kvm",
+        target_ip="10.10.0.17", wg_ip="10.10.0.17", virbr0_ip="192.168.122.17",
+        site_url="dev02.iridium.blue", domain="iridium.blue",
+        erp_user="erpadm", erp_user_pwd="x", db_root_pwd="x",
+        bench_dir="/home/erpadm/frappe-bench-D2IRBL",
+        bench_dir_orig="/home/erpadm/frappe-bench",
+        provision_mode="restored", hypervisor="toshiba",
+        ssh_key="/dev/null", ssh_opts=[], project_root="/tmp/proj",
+    )
+
+
+def _cp(rc=0, stdout="", stderr=""):
+    return CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+def _run(rsync=_cp(), ssh=_cp()):
+    with patch(f"{MOD}.rsync_to_vm", return_value=rsync), \
+         patch(f"{MOD}.ssh_run", return_value=ssh) as s:
+        return apply_v16_post_migrate_fixups(_config(), EMIT), s
+
+
+def test_first_apply_sets_changed_true():
+    out = "  [OK] disabled (was 0, now 1)\n  [PROBE] disabled=1\n"
+    result, s = _run(ssh=_cp(stdout=out))
+    assert result.success and result.changed and "disabled=1" in result.message
+    cmd = s.call_args.args[1]
+    assert "r3_disable_irs_1099_pf.py" in cmd
+    assert "--bench-dir /home/erpadm/frappe-bench-D2IRBL" in cmd
+    assert "--site dev02.iridium.blue" in cmd
+
+
+def test_already_disabled_is_no_op():
+    out = "  [OK] already disabled\n  [PROBE] disabled=1\n"
+    result, _ = _run(ssh=_cp(stdout=out))
+    assert result.success and not result.changed
+
+
+def test_record_absent_is_no_op():
+    out = "  [SKIP] not present\n  [PROBE] disabled=absent\n"
+    result, _ = _run(ssh=_cp(stdout=out))
+    assert result.success and not result.changed
+    assert "disabled=absent" in result.message
+
+
+def test_rsync_failure_aborts_before_ssh():
+    result, s = _run(rsync=_cp(rc=1, stderr="boom"))
+    assert not result.success and "rsync" in result.message and s.call_count == 0
+
+
+def test_r3_ssh_failure_returns_fail():
+    result, _ = _run(ssh=_cp(rc=1, stderr="mysql exploded"))
+    assert not result.success and "R3" in result.message
+
+
+def test_unexpected_probe_returns_fail():
+    out = "  [PROBE] disabled=garbage\n"
+    result, _ = _run(ssh=_cp(stdout=out))
+    assert not result.success and "probe unexpected" in result.message

--- a/tools/pipeline/orchestration/v16_post_migrate_fixups.py
+++ b/tools/pipeline/orchestration/v16_post_migrate_fixups.py
@@ -1,0 +1,69 @@
+"""V13->V16 post-migrate fixups primitive (ESACP#498, #480 child).
+
+Rsyncs `tools/vm_scripts/` and runs each catalogued fix-script over SSH.
+Catalogue today: R3 disable IRS 1099 PF. Caller runs this AFTER bench
+migrate to V16; running against a V13 substrate is benign.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.pipeline.stages.common.ssh import rsync_to_vm, ssh_run
+from tools.pipeline.stages.common.types import Config, Emit, TaskResult
+
+R3_SCRIPT = "/tmp/vm_scripts/r3_disable_irs_1099_pf.py"
+R3_PROBE_PREFIX = "  [PROBE] "
+R3_EXPECTED_PROBES = {"disabled=1", "disabled=absent"}
+
+
+def _rsync_scripts(config: Config, emit: Emit) -> TaskResult:
+    project = Path(config.project_root)
+    local = str(project / "tools" / "vm_scripts") + "/"
+    emit(f"  rsync vm_scripts -> {config.hostname}:/tmp/vm_scripts/")
+    r = rsync_to_vm(config, local, "/tmp/vm_scripts/", timeout=60)
+    if r.returncode != 0:
+        return TaskResult(False, False, f"rsync vm_scripts: {r.stderr.strip()}")
+    return TaskResult(True, False, "vm_scripts rsynced")
+
+
+def _run_r3(config: Config, emit: Emit) -> TaskResult:
+    cmd = (f"python3 {R3_SCRIPT} "
+           f"--bench-dir {config.bench_dir} --site {config.site_url}")
+    r = ssh_run(config, cmd, timeout=60)
+    if r.returncode != 0:
+        emit(f"  [FAIL] R3: rc={r.returncode}")
+        if r.stdout.strip():
+            emit(f"    stdout: {r.stdout.strip()[-500:]}")
+        if r.stderr.strip():
+            emit(f"    stderr: {r.stderr.strip()[-500:]}")
+        return TaskResult(False, False, "R3 disable IRS 1099 PF failed")
+
+    probe = None
+    changed = False
+    for line in r.stdout.splitlines():
+        emit(line)
+        if line.startswith(R3_PROBE_PREFIX):
+            probe = line[len(R3_PROBE_PREFIX):].strip()
+        if "(was 0, now 1)" in line:
+            changed = True
+
+    if probe not in R3_EXPECTED_PROBES:
+        return TaskResult(False, False, f"R3 probe unexpected: {probe!r}")
+
+    return TaskResult(True, changed, f"R3 probe={probe}")
+
+
+def apply_v16_post_migrate_fixups(config: Config, emit: Emit) -> TaskResult:
+    """Apply all V13->V16 post-migrate fixups to the target VM."""
+    sync = _rsync_scripts(config, emit)
+    if not sync.success:
+        return sync
+
+    r3 = _run_r3(config, emit)
+    if not r3.success:
+        return r3
+
+    any_changed = r3.changed
+    return TaskResult(True, any_changed,
+                      f"V16 post-migrate fixups applied: {r3.message}")

--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -30,6 +30,7 @@
   "tools/cli/_common.py": 73,
   "tools/cli/add_host.py": 66,
   "tools/cli/apply_substrate_migration.py": 38,
+  "tools/cli/apply_v16_post_migrate_fixups.py": 44,
   "tools/cli/build_vm.py": 26,
   "tools/cli/clear_known_hosts.py": 27,
   "tools/cli/confirm_prerequisites.py": 67,
@@ -103,6 +104,8 @@
   "tools/pipeline/orchestration/test_hosts_map_remove.py": 57,
   "tools/pipeline/orchestration/test_hub_seed_iso.py": 57,
   "tools/pipeline/orchestration/test_substrate_apply.py": 80,
+  "tools/pipeline/orchestration/test_v16_post_migrate_fixups.py": 76,
+  "tools/pipeline/orchestration/v16_post_migrate_fixups.py": 69,
   "tools/pipeline/orchestration/verify_build_vm.py": 80,
   "tools/pipeline/orchestration/verify_vpn.py": 77,
   "tools/pipeline/orchestration/virsh.py": 15,
@@ -210,5 +213,6 @@
   "tools/pipeline/upgrade_v14/verify.py": 42,
   "tools/vm_scripts/g1_seed_patch_log.py": 77,
   "tools/vm_scripts/install_specific/__init__.py": 14,
+  "tools/vm_scripts/r3_disable_irs_1099_pf.py": 72,
   "tools/vm_scripts/u6_dedup_smoke_test.py": 70
 }

--- a/tools/vm_scripts/README.md
+++ b/tools/vm_scripts/README.md
@@ -26,6 +26,7 @@ invoke these scripts in the right order; raw bench commands bypass them.
 | `h4e_patch_parms.py` | `ce_sri_parms.json` carrying stale `erpnext_api.erpnext_api_key` after H4a regenerates keys — must be patched before `.env` rendering | `stages/stage_8_app_config/post_restart_config.sh:14` |
 | `poll_gunicorn.py` | Race condition between supervisor restart and the next stage's HTTP call — polls `/api/method/ping` until 200 | `stages/stage_8_app_config/{pre,post,generic}_restart_config.sh` |
 | `u6_dedup_smoke_test.py` | Read-only post-migrate assertion that `(dt, fieldname)` pairs in `tabDocField` ∪ `tabCustom Field` are deduplicated (ESACP#335) | operator-invoked smoke test |
+| `r3_disable_irs_1099_pf.py` | Orphan `IRS 1099 Form` Print Format (Jinja template upstream-deleted) remaining invokable after V13→V16 migrate — sets `disabled=1` (ESACP#498, #480 child) | `pipeline/orchestration/v16_post_migrate_fixups.py` |
 | `install_specific/` | Site differentiation (ce_sri config, naming series, test data) — see `tools/CLAUDE.md` § install_specific | `stages/stage_8_app_config/{pre,post}_restart_config.sh` |
 
 ## When you're designing a new lab workflow

--- a/tools/vm_scripts/r3_disable_irs_1099_pf.py
+++ b/tools/vm_scripts/r3_disable_irs_1099_pf.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""r3_disable_irs_1099_pf.py — Disable orphan IRS 1099 Form Print Format.
+
+V13->V16 post-migrate fix R3 (ESACP#498, #480 child). Jinja template
+upstream-deleted long before V16; row persists on restored production
+DBs. Sets disabled=1 (reversible). Idempotent; safe if record absent.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+PRINT_FORMAT_NAME = "IRS 1099 Form"
+
+
+def get_db_credentials(bench_dir, site):
+    cfg_path = os.path.join(bench_dir, "sites", site, "site_config.json")
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+    return cfg["db_name"], cfg.get("db_password", "")
+
+
+def run_sql(db_name, db_password, sql):
+    result = subprocess.run(
+        ["mysql", "-AD", db_name, f"-u{db_name}", f"-p{db_password}",
+         "-N", "-B", "-e", sql],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"  ERROR: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bench-dir", required=True)
+    parser.add_argument("--site", required=True)
+    args = parser.parse_args()
+
+    db_name, db_password = get_db_credentials(args.bench_dir, args.site)
+
+    current = run_sql(
+        db_name, db_password,
+        f"SELECT disabled FROM `tabPrint Format` "
+        f"WHERE name='{PRINT_FORMAT_NAME}';",
+    )
+
+    if current == "":
+        print(f"  [SKIP] Print Format '{PRINT_FORMAT_NAME}' not present")
+        print("  [PROBE] disabled=absent")
+        return
+
+    if current == "1":
+        print(f"  [OK] Print Format '{PRINT_FORMAT_NAME}' already disabled")
+        print("  [PROBE] disabled=1")
+        return
+
+    run_sql(
+        db_name, db_password,
+        f"UPDATE `tabPrint Format` SET disabled=1, "
+        f"modified=NOW(), modified_by='Administrator' "
+        f"WHERE name='{PRINT_FORMAT_NAME}';",
+    )
+    print(f"  [OK] Print Format '{PRINT_FORMAT_NAME}' disabled "
+          f"(was {current}, now 1)")
+    print("  [PROBE] disabled=1")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `applyV16PostMigrateFixups` CLI subcommand + supporting primitive that runs catalogued V13→V16 post-migrate fix-scripts on a lab VM.
- Today's catalogue: **R3** — disable the orphan `IRS 1099 Form` Print Format (Jinja template upstream-deleted long before V16; row persists on restored production DBs as an always-broken artifact).
- Extensible — R1 (#486) and R6e.2 (#496) will plug into the same primitive when picked up.

Child of #480 (V13→V16 re-migration umbrella). Split from #486 (R1+R3 bundle) at implementation time per the operator decision recorded in #486's discipline note. #486 retitled to R1-only with a comment explaining the split.

## Architecture

Per `tools/CLAUDE.md` anti-spiral rules:

- **VM-side script**: `tools/vm_scripts/r3_disable_irs_1099_pf.py` (72 lines, +x) — standalone Python; reads `site_config.json` and runs mysql `UPDATE tabPrint Format SET disabled=1 WHERE name='IRS 1099 Form'` if exists. Idempotent; safe if record absent. Emits `[PROBE] disabled=…` for the orchestration to parse.
- **Pipeline primitive**: `tools/pipeline/orchestration/v16_post_migrate_fixups.py` (69 lines) — `(Config, Emit) -> TaskResult` IoC signature. Rsyncs `vm_scripts/`, runs R3 over SSH, parses probe.
- **Colocated test**: `test_v16_post_migrate_fixups.py` (76 lines) — 6 cases covering first-apply / already-disabled / record-absent / rsync-fail / ssh-fail / unexpected-probe.
- **CLI dispatcher**: `tools/cli/apply_v16_post_migrate_fixups.py` (44 lines) — thin shell.
- **esacp.py wiring**: subcommand registered; `add_subparser` block refactored to a for-loop to keep within the 106-line baseline.
- **README + tools/CLAUDE.md**: updated catalogue + subcommand description.

## Test plan

- [x] 6/6 colocated unit tests pass
- [x] First-apply on dev01 V13: `(was 0, now 1)` → probe `disabled=1` → `changed=True`
- [x] Already-disabled on dev02 V16 (S79 lab-applied): `already disabled` → probe `disabled=1` → `changed=False`
- [x] Idempotence on dev01: 2nd run = `(no-op)`
- [x] `python3 tools/pre_commit_size_check.py` → exit 0
- [x] esacp-qa T1+T3 verdict: `approve-with-conditions`, hard_block: false

## Closes

`fixes #498` (in commit body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)