### PR TITLE
feat(on_boarding): landing-page sketch — three pain-points + chain-on-girder + Path-A getting-started (Session-8 Sub-branch 2)

### DIFF
--- a/on_boarding/docs/_layouts/landing.html
+++ b/on_boarding/docs/_layouts/landing.html
@@ -26,13 +26,16 @@
         <span class="brand-sub">onboarding</span>
       </a>
       <nav class="tabs" aria-label="Section tabs">
-        <button class="tab" data-tab="problem">The Problem</button>
-        <button class="tab" data-tab="why">Why ESACP?</button>
-        <button class="tab" data-tab="how">How it Works</button>
-        <button class="tab" data-tab="start">Getting Started</button>
-        <button class="tab" data-tab="catch">What&rsquo;s the Catch?</button>
+        <button class="tab" data-tab="problem" type="button">The Problem</button>
+        <button class="tab" data-tab="why" type="button">Why ESACP?</button>
+        <button class="tab" data-tab="how" type="button">How it Works</button>
+        <button class="tab" data-tab="start" type="button">Getting Started</button>
+        <button class="tab" data-tab="catch" type="button">What&rsquo;s the Catch?</button>
       </nav>
       <div class="controls">
+        <button class="hamburger" type="button" aria-label="Show all sections" aria-expanded="false" aria-controls="tabs-menu">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+        </button>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
           <svg class="icon-sun"  width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
           <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
@@ -43,6 +46,7 @@
         </div>
       </div>
     </div>
+    <div class="tabs-menu" id="tabs-menu" role="menu" hidden></div>
   </header>
 
   <main class="page">
@@ -52,27 +56,64 @@
       <button class="nav-arrow nav-prev" type="button" aria-label="Previous section" title="Previous">&lsaquo;</button>
       <button class="nav-arrow nav-next" type="button" aria-label="Next section" title="Next">&rsaquo;</button>
     </div>
+
+    <nav class="bottom-tabs" aria-label="Section tabs (bottom)"></nav>
+
+    <div class="bottom-meta">
+      <p>
+        The architecture this page seeds is documented in
+        <a href="https://github.com/martinhbramwell/ESACP/blob/on_boarding/on_boarding/internal_docs/entry-architecture-notes.md"><code>internal_docs/entry-architecture-notes.md</code></a>.
+      </p>
+      <p>
+        Source: <a href="https://github.com/martinhbramwell/ESACP">martinhbramwell/ESACP</a> on GitHub.
+      </p>
+    </div>
   </main>
 
   <script>
     (function () {
       var TABS = ['problem', 'why', 'how', 'start', 'catch'];
 
+      var $tabs        = document.querySelector('.tabs');
+      var $hamburger   = document.querySelector('.hamburger');
+      var $menu        = document.getElementById('tabs-menu');
+      var $bottomTabs  = document.querySelector('.bottom-tabs');
+      var $themeToggle = document.querySelector('.theme-toggle');
+
+      // Populate dropdown menu + bottom-tabs from the top tabs (single source of truth).
+      Array.prototype.forEach.call(document.querySelectorAll('.topbar .tab'), function (t) {
+        var label = (t.textContent || '').replace(/\s+/g, ' ').trim();
+
+        var menuItem = document.createElement('button');
+        menuItem.className = 'tab-menu-item';
+        menuItem.dataset.tab = t.dataset.tab;
+        menuItem.textContent = label;
+        menuItem.setAttribute('role', 'menuitem');
+        menuItem.setAttribute('type', 'button');
+        $menu.appendChild(menuItem);
+
+        var bottomBtn = document.createElement('button');
+        bottomBtn.className = 'tab tab-bottom';
+        bottomBtn.dataset.tab = t.dataset.tab;
+        bottomBtn.textContent = label;
+        bottomBtn.setAttribute('type', 'button');
+        $bottomTabs.appendChild(bottomBtn);
+      });
+
       function activate(id, opts) {
         opts = opts || {};
         if (TABS.indexOf(id) === -1) id = TABS[0];
 
-        document.querySelectorAll('.tab').forEach(function (btn) {
-          btn.classList.toggle('is-active', btn.dataset.tab === id);
-          btn.setAttribute('aria-selected', btn.dataset.tab === id ? 'true' : 'false');
+        Array.prototype.forEach.call(document.querySelectorAll('.tab, .tab-menu-item'), function (b) {
+          b.classList.toggle('is-active', b.dataset.tab === id);
         });
-        document.querySelectorAll('[data-panel]').forEach(function (panel) {
-          panel.classList.toggle('is-active', panel.dataset.panel === id);
+        Array.prototype.forEach.call(document.querySelectorAll('[data-panel]'), function (p) {
+          p.classList.toggle('is-active', p.dataset.panel === id);
         });
 
         var idx = TABS.indexOf(id);
-        document.querySelectorAll('.nav-prev').forEach(function (b) { b.disabled = idx <= 0; });
-        document.querySelectorAll('.nav-next').forEach(function (b) { b.disabled = idx >= TABS.length - 1; });
+        Array.prototype.forEach.call(document.querySelectorAll('.nav-prev'), function (b) { b.disabled = idx <= 0; });
+        Array.prototype.forEach.call(document.querySelectorAll('.nav-next'), function (b) { b.disabled = idx >= TABS.length - 1; });
 
         if (!opts.silent) {
           try { history.replaceState(null, '', '#' + id); } catch (e) {}
@@ -90,23 +131,40 @@
         activate(TABS[next], { scroll: true });
       }
 
-      // Wire tabs.
-      document.querySelectorAll('.tab').forEach(function (btn) {
-        btn.addEventListener('click', function () { activate(btn.dataset.tab, { scroll: true }); });
+      function setMenuOpen(open) {
+        $menu.hidden = !open;
+        if ($hamburger) $hamburger.setAttribute('aria-expanded', open ? 'true' : 'false');
+      }
+
+      // Click delegation — tabs (top/bottom/menu) and in-page hash anchors.
+      document.addEventListener('click', function (e) {
+        var btn = e.target.closest && e.target.closest('.tab, .tab-menu-item');
+        if (btn && btn.dataset.tab) {
+          activate(btn.dataset.tab, { scroll: true });
+          if (btn.classList.contains('tab-menu-item')) setMenuOpen(false);
+          return;
+        }
+        var a = e.target.closest && e.target.closest('a[href^="#"]');
+        if (a) {
+          var id = a.getAttribute('href').slice(1);
+          if (TABS.indexOf(id) !== -1) {
+            e.preventDefault();
+            activate(id, { scroll: true });
+          }
+        }
       });
 
-      // Wire arrows (both top and bottom).
-      document.querySelectorAll('.nav-prev').forEach(function (b) {
+      // Arrows.
+      Array.prototype.forEach.call(document.querySelectorAll('.nav-prev'), function (b) {
         b.addEventListener('click', function () { step(-1); });
       });
-      document.querySelectorAll('.nav-next').forEach(function (b) {
+      Array.prototype.forEach.call(document.querySelectorAll('.nav-next'), function (b) {
         b.addEventListener('click', function () { step(1); });
       });
 
       // Theme toggle.
-      var toggle = document.querySelector('.theme-toggle');
-      if (toggle) {
-        toggle.addEventListener('click', function () {
+      if ($themeToggle) {
+        $themeToggle.addEventListener('click', function () {
           var current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
           var next = current === 'dark' ? 'light' : 'dark';
           document.documentElement.setAttribute('data-theme', next);
@@ -114,14 +172,54 @@
         });
       }
 
-      // Keyboard nav: left/right when not focused in an input.
+      // Hamburger toggle + outside-click + Esc.
+      if ($hamburger) {
+        $hamburger.addEventListener('click', function (e) {
+          e.stopPropagation();
+          setMenuOpen($menu.hidden);
+        });
+      }
+      document.addEventListener('click', function (e) {
+        if (!$menu.hidden && !$menu.contains(e.target) && e.target !== $hamburger) {
+          setMenuOpen(false);
+        }
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && !$menu.hidden) setMenuOpen(false);
+      });
+
+      // Keyboard arrow nav (skip when focused in an input).
       document.addEventListener('keydown', function (e) {
         if (e.target && /input|textarea|select/i.test(e.target.tagName)) return;
         if (e.key === 'ArrowLeft')  step(-1);
         if (e.key === 'ArrowRight') step(1);
       });
 
-      // Initial tab: hash > localStorage > first.
+      // Direct URL-hash edits (back/forward in some browsers also fire this).
+      window.addEventListener('hashchange', function () {
+        var id = location.hash.replace('#', '');
+        if (TABS.indexOf(id) !== -1) activate(id, { silent: true });
+      });
+
+      // Overflow detection — toggles body.tabs-overflow when the rightmost
+      // tab can't fit. Stable: hamburger reserves space always, so the
+      // measurement doesn't flip-flop on the transition.
+      function checkOverflow() {
+        if (!$tabs) return;
+        var overflow = ($tabs.scrollWidth - $tabs.clientWidth) > 2;
+        document.body.classList.toggle('tabs-overflow', overflow);
+      }
+      var rafId = 0;
+      window.addEventListener('resize', function () {
+        if (rafId) cancelAnimationFrame(rafId);
+        rafId = requestAnimationFrame(checkOverflow);
+      });
+      if (document.fonts && document.fonts.ready && document.fonts.ready.then) {
+        document.fonts.ready.then(checkOverflow);
+      }
+      checkOverflow();
+
+      // Initial activate.
       var initial = (location.hash || '').replace('#', '');
       if (TABS.indexOf(initial) === -1) {
         try { initial = localStorage.getItem('esacp-tab') || TABS[0]; } catch (e) { initial = TABS[0]; }

--- a/on_boarding/docs/_layouts/landing.html
+++ b/on_boarding/docs/_layouts/landing.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page.title | default: site.title }}</title>
+  <meta name="description" content="{{ page.description | default: site.description }}">
+  <link rel="stylesheet" href="{{ '/assets/css/landing.css' | relative_url }}">
+</head>
+<body>
+  <main class="page">
+    {{ content }}
+  </main>
+</body>
+</html>

--- a/on_boarding/docs/_layouts/landing.html
+++ b/on_boarding/docs/_layouts/landing.html
@@ -2,14 +2,132 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
   <title>{{ page.title | default: site.title }}</title>
   <meta name="description" content="{{ page.description | default: site.description }}">
   <link rel="stylesheet" href="{{ '/assets/css/landing.css' | relative_url }}">
+  <script>
+    // Apply theme before paint to avoid flash. Runs sync, blocking.
+    (function () {
+      try {
+        var saved = localStorage.getItem('esacp-theme');
+        var theme = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) { /* localStorage blocked — fall through to CSS default */ }
+    })();
+  </script>
 </head>
 <body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="#problem">
+        <span class="brand-mark">ESACP</span>
+        <span class="brand-sub">onboarding</span>
+      </a>
+      <nav class="tabs" aria-label="Section tabs">
+        <button class="tab" data-tab="problem">The Problem</button>
+        <button class="tab" data-tab="why">Why ESACP?</button>
+        <button class="tab" data-tab="how">How it Works</button>
+        <button class="tab" data-tab="start">Getting Started</button>
+        <button class="tab" data-tab="catch">What&rsquo;s the Catch?</button>
+      </nav>
+      <div class="controls">
+        <button class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
+          <svg class="icon-sun"  width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+        <div class="nav-arrows nav-arrows-top">
+          <button class="nav-arrow nav-prev" type="button" aria-label="Previous section" title="Previous">&lsaquo;</button>
+          <button class="nav-arrow nav-next" type="button" aria-label="Next section" title="Next">&rsaquo;</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
   <main class="page">
     {{ content }}
+
+    <div class="nav-arrows nav-arrows-bottom" aria-hidden="true">
+      <button class="nav-arrow nav-prev" type="button" aria-label="Previous section" title="Previous">&lsaquo;</button>
+      <button class="nav-arrow nav-next" type="button" aria-label="Next section" title="Next">&rsaquo;</button>
+    </div>
   </main>
+
+  <script>
+    (function () {
+      var TABS = ['problem', 'why', 'how', 'start', 'catch'];
+
+      function activate(id, opts) {
+        opts = opts || {};
+        if (TABS.indexOf(id) === -1) id = TABS[0];
+
+        document.querySelectorAll('.tab').forEach(function (btn) {
+          btn.classList.toggle('is-active', btn.dataset.tab === id);
+          btn.setAttribute('aria-selected', btn.dataset.tab === id ? 'true' : 'false');
+        });
+        document.querySelectorAll('[data-panel]').forEach(function (panel) {
+          panel.classList.toggle('is-active', panel.dataset.panel === id);
+        });
+
+        var idx = TABS.indexOf(id);
+        document.querySelectorAll('.nav-prev').forEach(function (b) { b.disabled = idx <= 0; });
+        document.querySelectorAll('.nav-next').forEach(function (b) { b.disabled = idx >= TABS.length - 1; });
+
+        if (!opts.silent) {
+          try { history.replaceState(null, '', '#' + id); } catch (e) {}
+          try { localStorage.setItem('esacp-tab', id); } catch (e) {}
+        }
+        if (opts.scroll) window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+
+      function step(delta) {
+        var current = (location.hash || '').replace('#', '');
+        var idx = TABS.indexOf(current);
+        if (idx === -1) idx = 0;
+        var next = idx + delta;
+        if (next < 0 || next >= TABS.length) return;
+        activate(TABS[next], { scroll: true });
+      }
+
+      // Wire tabs.
+      document.querySelectorAll('.tab').forEach(function (btn) {
+        btn.addEventListener('click', function () { activate(btn.dataset.tab, { scroll: true }); });
+      });
+
+      // Wire arrows (both top and bottom).
+      document.querySelectorAll('.nav-prev').forEach(function (b) {
+        b.addEventListener('click', function () { step(-1); });
+      });
+      document.querySelectorAll('.nav-next').forEach(function (b) {
+        b.addEventListener('click', function () { step(1); });
+      });
+
+      // Theme toggle.
+      var toggle = document.querySelector('.theme-toggle');
+      if (toggle) {
+        toggle.addEventListener('click', function () {
+          var current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+          var next = current === 'dark' ? 'light' : 'dark';
+          document.documentElement.setAttribute('data-theme', next);
+          try { localStorage.setItem('esacp-theme', next); } catch (e) {}
+        });
+      }
+
+      // Keyboard nav: left/right when not focused in an input.
+      document.addEventListener('keydown', function (e) {
+        if (e.target && /input|textarea|select/i.test(e.target.tagName)) return;
+        if (e.key === 'ArrowLeft')  step(-1);
+        if (e.key === 'ArrowRight') step(1);
+      });
+
+      // Initial tab: hash > localStorage > first.
+      var initial = (location.hash || '').replace('#', '');
+      if (TABS.indexOf(initial) === -1) {
+        try { initial = localStorage.getItem('esacp-tab') || TABS[0]; } catch (e) { initial = TABS[0]; }
+      }
+      activate(initial, { silent: true });
+    })();
+  </script>
 </body>
 </html>

--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -188,6 +188,14 @@ html, body {
 body.tabs-overflow .tabs       { visibility: hidden; pointer-events: none; }
 body.tabs-overflow .hamburger  { visibility: visible; pointer-events: auto; }
 
+/* Hard rule: below 1024px always use the hamburger, even if the
+   five tab labels would technically fit. Keeps the topbar layout
+   predictable on tablets and small laptops. */
+@media (max-width: 1023px) {
+  .tabs      { visibility: hidden; pointer-events: none; }
+  .hamburger { visibility: visible; pointer-events: auto; }
+}
+
 /* theme toggle */
 
 .theme-toggle {

--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -52,7 +52,7 @@
   --accent-ink: #c8e2cf;
 
   --pain-tag: #d18f8f;
-  --gain-tag: #7fc89a;
+  --gain-tag: #d18f8f;
   --caveat-tag: #d6b27a;
 
   --code-bg: rgba(255, 255, 255, 0.08);
@@ -420,6 +420,10 @@ body.tabs-overflow .hamburger  { visibility: visible; pointer-events: auto; }
 .tag.pain-tag   { color: var(--pain-tag); }
 .tag.gain-tag   { color: var(--gain-tag); }
 .tag.caveat-tag { color: var(--caveat-tag); }
+
+  .comment {
+    font-style: italic;
+  }
 
 /* intro */
 

--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -1,11 +1,13 @@
 ---
 ---
 
-/* Landing page — sparse, succinct, styled. Sans body / serif headings,
-   ESACP terminal-green accent, white cards on warm off-white. */
+/* Landing page — five tabs, dark/light, mobile-first responsive.
+   Sparse styling: sans body, serif headings, ESACP terminal-green
+   accent. Theme switches via data-theme="light|dark" on <html>. */
 
 :root {
   --bg: #fafaf7;
+  --bg-elev: #ffffff;
   --card: #ffffff;
   --ink: #1d1d1f;
   --ink-muted: #5b5b62;
@@ -13,11 +15,15 @@
   --rule-soft: #ececea;
 
   --accent: #0f2a1d;          /* ESACP terminal green */
-  --accent-tint: #e9ede7;     /* highlight panel */
-  --accent-ink: #102a1d;      /* accent text */
+  --accent-strong: #0f2a1d;
+  --accent-tint: #e9ede7;
+  --accent-ink: #102a1d;
 
-  --pain-tag: #7b3a3a;        /* warm rust — "the problem" */
-  --gain-tag: #2f6b3a;        /* forest green — "the win"  */
+  --pain-tag: #7b3a3a;
+  --gain-tag: #2f6b3a;
+  --caveat-tag: #8a5a1f;
+
+  --code-bg: rgba(0, 0, 0, 0.05);
 
   --radius: 12px;
   --radius-sm: 8px;
@@ -27,6 +33,29 @@
   --sans:  -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
            "Helvetica Neue", Arial, sans-serif;
   --mono:  ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --topbar-h: 3.5rem;
+}
+
+:root[data-theme="dark"] {
+  --bg: #0f1411;
+  --bg-elev: #161d19;
+  --card: #181f1b;
+  --ink: #e8ebe6;
+  --ink-muted: #9aa29c;
+  --rule: #2a322d;
+  --rule-soft: #1f2622;
+
+  --accent: #6fb285;          /* lighter green for contrast on dark */
+  --accent-strong: #8fcb9f;
+  --accent-tint: #1a2820;
+  --accent-ink: #c8e2cf;
+
+  --pain-tag: #d18f8f;
+  --gain-tag: #7fc89a;
+  --caveat-tag: #d6b27a;
+
+  --code-bg: rgba(255, 255, 255, 0.08);
 }
 
 * { box-sizing: border-box; }
@@ -39,25 +68,205 @@ html, body {
   font-family: var(--sans);
   line-height: 1.55;
   -webkit-font-smoothing: antialiased;
+  scroll-behavior: smooth;
 }
+
+/* ───────────────── top bar ───────────────── */
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--rule);
+  backdrop-filter: saturate(180%) blur(8px);
+}
+
+.topbar-inner {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 0.55rem 0.9rem;
+  min-height: var(--topbar-h);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: var(--accent);
+  line-height: 1;
+}
+
+.brand-mark {
+  font-family: var(--serif);
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.brand-sub {
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-top: 0.15rem;
+}
+
+/* tabs */
+
+.tabs {
+  display: flex;
+  gap: 0.15rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  justify-self: center;
+}
+
+.tabs::-webkit-scrollbar { display: none; }
+
+.tab {
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--ink-muted);
+  background: transparent;
+  border: 0;
+  padding: 0.55rem 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  scroll-snap-align: start;
+}
+
+.tab:hover { color: var(--ink); }
+
+.tab.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* controls (theme + arrows) */
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--ink);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.theme-toggle:hover { background: var(--accent-tint); border-color: var(--accent); }
+
+.theme-toggle svg { display: block; }
+
+:root[data-theme="light"] .theme-toggle .icon-moon { display: none; }
+:root[data-theme="dark"]  .theme-toggle .icon-sun  { display: none; }
+
+/* arrow buttons (top + bottom variants share styles) */
+
+.nav-arrows {
+  display: inline-flex;
+  gap: 0.3rem;
+}
+
+.nav-arrows-bottom {
+  display: flex;
+  justify-content: flex-end;
+  margin: 2.5rem 0 0;
+}
+
+.nav-arrow {
+  font: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  background: transparent;
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.nav-arrow:hover:not(:disabled) {
+  background: var(--accent-tint);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.nav-arrow:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.nav-arrows-bottom .nav-arrow {
+  width: 2.4rem;
+  height: 2.4rem;
+  font-size: 1.25rem;
+}
+
+/* ───────────────── page + panels ───────────────── */
 
 .page {
   max-width: 54rem;
   margin: 0 auto;
-  padding: 3rem 1.25rem 5rem;
+  padding: 2.5rem 1.25rem 5rem;
 }
 
-/* hero */
+[data-panel] {
+  display: none;
+  animation: panel-in 0.18s ease-out;
+}
+
+[data-panel].is-active {
+  display: block;
+}
+
+@keyframes panel-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* hero (only inside problem panel) */
 
 .hero {
   text-align: center;
-  padding: 1rem 0 2.25rem;
-  margin-bottom: 2.5rem;
+  padding: 0.5rem 0 2rem;
+  margin-bottom: 2.25rem;
   border-bottom: 1px solid var(--rule);
 
   h1 {
     font-family: var(--serif);
-    font-size: clamp(2.4rem, 6vw, 3.2rem);
+    font-size: clamp(2.2rem, 6vw, 3.2rem);
     font-weight: 600;
     margin: 0;
     letter-spacing: -0.02em;
@@ -68,31 +277,27 @@ html, body {
   .tagline {
     margin: 0.7rem 0 0;
     color: var(--ink-muted);
-    font-size: clamp(1rem, 2.4vw, 1.15rem);
+    font-size: clamp(0.95rem, 2.4vw, 1.15rem);
     line-height: 1.4;
   }
 }
 
-/* section common */
+/* section/panel headings */
 
-section {
-  margin-bottom: 3rem;
-}
-
-section > h2 {
+[data-panel] > h2 {
   font-family: var(--serif);
-  font-size: clamp(1.4rem, 3.5vw, 1.7rem);
+  font-size: clamp(1.35rem, 3.5vw, 1.7rem);
   font-weight: 600;
   letter-spacing: -0.01em;
   margin: 0 0 1.25rem;
   color: var(--ink);
 }
 
-section > p {
+[data-panel] > p {
   margin: 0.75rem 0;
 }
 
-/* pain points — grid of 3 */
+/* pains grid (used for both problem and gain) */
 
 .pains {
   display: grid;
@@ -124,13 +329,9 @@ section > p {
     margin: 0;
     font-size: 0.95rem;
   }
-
-  .gain {
-    border-top: 1px dashed var(--rule);
-    padding-top: 0.7rem;
-    margin-top: 1rem;
-  }
 }
+
+.pains-gain .pain h3 { color: var(--accent); }
 
 .tag {
   display: inline-block;
@@ -141,8 +342,9 @@ section > p {
   color: var(--ink-muted);
 }
 
-.tag.pain-tag { color: var(--pain-tag); }
-.tag.gain-tag { color: var(--gain-tag); margin-bottom: 0.35rem; }
+.tag.pain-tag   { color: var(--pain-tag); }
+.tag.gain-tag   { color: var(--gain-tag); }
+.tag.caveat-tag { color: var(--caveat-tag); }
 
 /* intro */
 
@@ -159,11 +361,11 @@ section > p {
   padding: 1.1rem 1.3rem;
   font-size: 1.02rem;
   line-height: 1.6;
-  margin: 1.25rem 0 2rem;
+  margin: 0 0 2rem;
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   color: var(--accent-ink);
 
-  strong { color: var(--accent); }
+  strong { color: var(--accent-strong); }
 }
 
 /* stages */
@@ -253,16 +455,60 @@ section > p {
   code {
     font-family: var(--mono);
     font-size: 0.85em;
-    background: rgba(0, 0, 0, 0.05);
+    background: var(--code-bg);
     padding: 0.1em 0.4em;
     border-radius: 4px;
   }
 }
 
+/* caveats (What's the Catch?) */
+
+.caveats {
+  display: grid;
+  gap: 1rem;
+}
+
+.caveat {
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 1.05rem 1.2rem 1.2rem;
+
+  h3 {
+    font-family: var(--serif);
+    font-size: 1.08rem;
+    font-weight: 600;
+    margin: 0.3rem 0 0.45rem;
+    line-height: 1.3;
+    color: var(--ink);
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+}
+
+/* panel-end nudge link */
+
+.panel-cue {
+  margin: 2.25rem 0 0;
+  font-size: 0.92rem;
+  color: var(--ink-muted);
+}
+
+.panel-cue-link {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.panel-cue-link:hover { border-bottom-color: var(--accent); }
+
 /* footer */
 
 .page-footer {
-  margin-top: 4rem;
+  margin-top: 3.5rem;
   padding-top: 1.4rem;
   border-top: 1px solid var(--rule);
   color: var(--ink-muted);
@@ -281,26 +527,95 @@ section > p {
 
   code {
     font-family: var(--mono);
-    background: rgba(0, 0, 0, 0.05);
+    background: var(--code-bg);
     padding: 0.1em 0.4em;
     border-radius: 4px;
   }
 }
 
-/* inline links in body copy */
+/* inline links inside panels */
 
-section a {
+[data-panel] a {
   color: var(--accent);
   text-decoration: none;
   border-bottom: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
   transition: border-color 0.15s ease;
 }
-section a:hover { border-bottom-color: var(--accent); }
+[data-panel] a:hover { border-bottom-color: var(--accent); }
 
-/* tighten on narrow screens */
+/* ───────────────── responsive ─────────────────
+   Mobile-first defaults above. Breakpoints below progressively
+   tighten or relax to keep the page usable from ~320px (older
+   phones in portrait) up through desktop. */
 
-@media (max-width: 30rem) {
-  .page { padding: 1.75rem 0.9rem 3rem; }
-  .step { grid-template-columns: 2rem 1fr; gap: 0.8rem; }
-  .step::before { font-size: 1.6rem; }
+@media (max-width: 40rem) {
+  /* phone-friendly topbar — brand-sub hidden, tabs scroll horizontally,
+     arrows still right-anchored */
+  .topbar-inner {
+    grid-template-columns: auto 1fr auto;
+    padding: 0.45rem 0.75rem;
+    gap: 0.6rem;
+  }
+
+  .brand-sub { display: none; }
+  .brand-mark { font-size: 1.05rem; }
+
+  .tabs {
+    justify-self: stretch;
+    padding: 0 0.1rem;
+  }
+
+  .tab {
+    padding: 0.5rem 0.55rem;
+    font-size: 0.82rem;
+  }
+
+  /* fade indicator that tabs scroll horizontally */
+  .tabs {
+    mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
+  }
+
+  .controls {
+    gap: 0.35rem;
+  }
+
+  .nav-arrow {
+    width: 1.85rem;
+    height: 1.85rem;
+    font-size: 1rem;
+  }
+
+  .page { padding: 1.5rem 0.85rem 3.5rem; }
+  .hero { padding: 0.25rem 0 1.4rem; margin-bottom: 1.5rem; }
+  .step { grid-template-columns: 1.8rem 1fr; gap: 0.7rem; }
+  .step::before { font-size: 1.5rem; }
+
+  .chain-narrative { padding: 0.95rem 1.05rem; font-size: 0.98rem; }
+  .stage, .pain, .caveat { padding: 0.95rem 1rem 1.1rem; }
+
+  .nav-arrows-bottom { margin-top: 1.75rem; }
+  .nav-arrows-bottom .nav-arrow { width: 2.1rem; height: 2.1rem; font-size: 1.1rem; }
+}
+
+@media (max-width: 22rem) {
+  /* very small (older smartphones, ~320px and below): reduce
+     horizontal padding further; allow brand to shrink */
+  .topbar-inner { padding: 0.4rem 0.5rem; gap: 0.4rem; }
+  .brand-mark { font-size: 0.95rem; }
+  .tab { padding: 0.5rem 0.45rem; font-size: 0.78rem; }
+  .page { padding: 1.25rem 0.65rem 3rem; }
+  .theme-toggle { width: 1.85rem; height: 1.85rem; }
+}
+
+@media (min-width: 64rem) {
+  /* roomy desktop — slightly larger type and breathing room */
+  .topbar-inner { padding: 0.65rem 1.25rem; }
+  .page { padding: 3rem 1.5rem 5.5rem; }
+}
+
+/* high-contrast / reduced-motion friendliness */
+
+@media (prefers-reduced-motion: reduce) {
+  [data-panel] { animation: none; }
+  html { scroll-behavior: auto; }
 }

--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -34,7 +34,7 @@
            "Helvetica Neue", Arial, sans-serif;
   --mono:  ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
-  --topbar-h: 3.5rem;
+  --topbar-h: 4.25rem;
 }
 
 :root[data-theme="dark"] {
@@ -46,7 +46,7 @@
   --rule: #2a322d;
   --rule-soft: #1f2622;
 
-  --accent: #6fb285;          /* lighter green for contrast on dark */
+  --accent: #6fb285;
   --accent-strong: #8fcb9f;
   --accent-tint: #1a2820;
   --accent-ink: #c8e2cf;
@@ -83,9 +83,10 @@ html, body {
 }
 
 .topbar-inner {
+  position: relative;
   max-width: 64rem;
   margin: 0 auto;
-  padding: 0.55rem 0.9rem;
+  padding: 0.6rem 0.9rem;
   min-height: var(--topbar-h);
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -116,19 +117,15 @@ html, body {
   margin-top: 0.15rem;
 }
 
-/* tabs */
+/* tabs (top strip) */
 
 .tabs {
   display: flex;
   gap: 0.15rem;
-  overflow-x: auto;
-  scrollbar-width: none;
-  scroll-snap-type: x mandatory;
-  -webkit-overflow-scrolling: touch;
+  overflow: hidden;
   justify-self: center;
+  min-width: 0;
 }
-
-.tabs::-webkit-scrollbar { display: none; }
 
 .tab {
   font: inherit;
@@ -141,8 +138,7 @@ html, body {
   cursor: pointer;
   white-space: nowrap;
   border-bottom: 2px solid transparent;
-  transition: color 0.15s ease, border-color 0.15s ease;
-  scroll-snap-align: start;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
 }
 
 .tab:hover { color: var(--ink); }
@@ -158,13 +154,41 @@ html, body {
   border-radius: 4px;
 }
 
-/* controls (theme + arrows) */
+/* controls (hamburger + theme + arrows) */
 
 .controls {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
+
+/* hamburger — always reserves space; revealed by body.tabs-overflow */
+
+.hamburger {
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  width: 2.4rem;
+  height: 2.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--ink);
+  visibility: hidden;
+  pointer-events: none;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.hamburger:hover { background: var(--accent-tint); border-color: var(--accent); }
+.hamburger svg { display: block; }
+
+/* overflow swap: top tabs ↔ hamburger */
+
+body.tabs-overflow .tabs       { visibility: hidden; pointer-events: none; }
+body.tabs-overflow .hamburger  { visibility: visible; pointer-events: auto; }
+
+/* theme toggle */
 
 .theme-toggle {
   background: transparent;
@@ -181,40 +205,39 @@ html, body {
 }
 
 .theme-toggle:hover { background: var(--accent-tint); border-color: var(--accent); }
-
 .theme-toggle svg { display: block; }
 
 :root[data-theme="light"] .theme-toggle .icon-moon { display: none; }
 :root[data-theme="dark"]  .theme-toggle .icon-sun  { display: none; }
 
-/* arrow buttons (top + bottom variants share styles) */
+/* arrow buttons (top + bottom share styles, +50% from prior version) */
 
 .nav-arrows {
   display: inline-flex;
-  gap: 0.3rem;
+  gap: 0.35rem;
 }
 
 .nav-arrows-bottom {
   display: flex;
   justify-content: flex-end;
-  margin: 2.5rem 0 0;
+  margin: 2.75rem 0 0;
 }
 
 .nav-arrow {
   font: inherit;
-  font-size: 1.1rem;
+  font-size: 1.65rem;
   line-height: 1;
   background: transparent;
   border: 1px solid var(--rule);
   color: var(--ink);
-  width: 2rem;
-  height: 2rem;
+  width: 3rem;
+  height: 3rem;
   border-radius: 999px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease, color 0.15s ease;
 }
 
 .nav-arrow:hover:not(:disabled) {
@@ -229,9 +252,53 @@ html, body {
 }
 
 .nav-arrows-bottom .nav-arrow {
-  width: 2.4rem;
-  height: 2.4rem;
-  font-size: 1.25rem;
+  width: 3.6rem;
+  height: 3.6rem;
+  font-size: 1.875rem;
+}
+
+/* hamburger dropdown menu */
+
+.tabs-menu {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  right: 0.9rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  padding: 0.4rem;
+  min-width: 14rem;
+  max-width: calc(100vw - 1.5rem);
+  z-index: 60;
+}
+
+.tabs-menu[hidden] { display: none; }
+
+.tab-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  font-size: 0.98rem;
+  color: var(--ink);
+  background: transparent;
+  border: 0;
+  padding: 0.65rem 0.9rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.tab-menu-item:hover  { background: var(--accent-tint); color: var(--accent); }
+.tab-menu-item.is-active {
+  background: var(--accent-tint);
+  color: var(--accent);
+  font-weight: 600;
+}
+.tab-menu-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 /* ───────────────── page + panels ───────────────── */
@@ -239,7 +306,7 @@ html, body {
 .page {
   max-width: 54rem;
   margin: 0 auto;
-  padding: 2.5rem 1.25rem 5rem;
+  padding: 2.5rem 1.25rem 4.5rem;
 }
 
 [data-panel] {
@@ -489,11 +556,25 @@ html, body {
   }
 }
 
-/* panel-end nudge link */
+/* essex-demo note — appears only inside the catch panel */
+
+.essex-demo-note {
+  margin: 2rem 0 0;
+  padding: 1.05rem 1.2rem;
+  background: var(--accent-tint);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--accent-ink);
+}
+
+/* panel-end nudge link — +50% from prior */
 
 .panel-cue {
-  margin: 2.25rem 0 0;
-  font-size: 0.92rem;
+  margin: 2.75rem 0 0;
+  font-size: 1.38rem;
+  line-height: 1.45;
   color: var(--ink-muted);
 }
 
@@ -501,21 +582,55 @@ html, body {
   color: var(--accent);
   text-decoration: none;
   border-bottom: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  font-weight: 500;
 }
 
 .panel-cue-link:hover { border-bottom-color: var(--accent); }
 
-/* footer */
+/* bottom tab nav (mirrors top, populated by JS) */
 
-.page-footer {
-  margin-top: 3.5rem;
-  padding-top: 1.4rem;
+.bottom-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.45rem;
+  margin: 2.5rem 0 1.5rem;
+  padding: 1.6rem 0 0;
   border-top: 1px solid var(--rule);
-  color: var(--ink-muted);
-  font-size: 0.88rem;
-  line-height: 1.6;
+}
 
-  p { margin: 0.45rem 0; }
+.bottom-tabs .tab {
+  font-size: 0.92rem;
+  padding: 0.55rem 1rem;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink-muted);
+}
+
+.bottom-tabs .tab:hover {
+  background: var(--accent-tint);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.bottom-tabs .tab.is-active {
+  background: var(--accent-tint);
+  color: var(--accent);
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+/* bottom meta (architecture + source) */
+
+.bottom-meta {
+  text-align: center;
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+  line-height: 1.55;
+  margin: 0 auto 1rem;
+
+  p { margin: 0.4rem 0; }
 
   a {
     color: var(--accent);
@@ -543,49 +658,45 @@ html, body {
 }
 [data-panel] a:hover { border-bottom-color: var(--accent); }
 
-/* ───────────────── responsive ─────────────────
-   Mobile-first defaults above. Breakpoints below progressively
-   tighten or relax to keep the page usable from ~320px (older
-   phones in portrait) up through desktop. */
+/* ───────────────── responsive ───────────────── */
 
 @media (max-width: 40rem) {
-  /* phone-friendly topbar — brand-sub hidden, tabs scroll horizontally,
-     arrows still right-anchored */
   .topbar-inner {
-    grid-template-columns: auto 1fr auto;
-    padding: 0.45rem 0.75rem;
-    gap: 0.6rem;
+    padding: 0.5rem 0.75rem;
+    gap: 0.55rem;
   }
 
-  .brand-sub { display: none; }
+  .brand-sub  { display: none; }
   .brand-mark { font-size: 1.05rem; }
-
-  .tabs {
-    justify-self: stretch;
-    padding: 0 0.1rem;
-  }
 
   .tab {
     padding: 0.5rem 0.55rem;
     font-size: 0.82rem;
   }
 
-  /* fade indicator that tabs scroll horizontally */
-  .tabs {
-    mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
-  }
-
-  .controls {
-    gap: 0.35rem;
-  }
+  .controls { gap: 0.4rem; }
 
   .nav-arrow {
-    width: 1.85rem;
-    height: 1.85rem;
-    font-size: 1rem;
+    width: 2.775rem;
+    height: 2.775rem;
+    font-size: 1.5rem;
+  }
+  .nav-arrows-bottom .nav-arrow {
+    width: 3.15rem;
+    height: 3.15rem;
+    font-size: 1.65rem;
   }
 
-  .page { padding: 1.5rem 0.85rem 3.5rem; }
+  .hamburger {
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+  .theme-toggle {
+    width: 1.9rem;
+    height: 1.9rem;
+  }
+
+  .page { padding: 1.5rem 0.85rem 3rem; }
   .hero { padding: 0.25rem 0 1.4rem; margin-bottom: 1.5rem; }
   .step { grid-template-columns: 1.8rem 1fr; gap: 0.7rem; }
   .step::before { font-size: 1.5rem; }
@@ -593,27 +704,54 @@ html, body {
   .chain-narrative { padding: 0.95rem 1.05rem; font-size: 0.98rem; }
   .stage, .pain, .caveat { padding: 0.95rem 1rem 1.1rem; }
 
-  .nav-arrows-bottom { margin-top: 1.75rem; }
-  .nav-arrows-bottom .nav-arrow { width: 2.1rem; height: 2.1rem; font-size: 1.1rem; }
+  .nav-arrows-bottom { margin-top: 2rem; }
+
+  .panel-cue { font-size: 1.18rem; }
+
+  .bottom-tabs {
+    margin: 2rem 0 1rem;
+    padding-top: 1.25rem;
+    gap: 0.35rem;
+  }
+  .bottom-tabs .tab {
+    font-size: 0.85rem;
+    padding: 0.5rem 0.85rem;
+  }
+
+  .tabs-menu { right: 0.55rem; min-width: 12.5rem; }
 }
 
 @media (max-width: 22rem) {
-  /* very small (older smartphones, ~320px and below): reduce
-     horizontal padding further; allow brand to shrink */
+  /* very small (older smartphones, ~320px and below) */
   .topbar-inner { padding: 0.4rem 0.5rem; gap: 0.4rem; }
-  .brand-mark { font-size: 0.95rem; }
-  .tab { padding: 0.5rem 0.45rem; font-size: 0.78rem; }
-  .page { padding: 1.25rem 0.65rem 3rem; }
-  .theme-toggle { width: 1.85rem; height: 1.85rem; }
+  .brand-mark   { font-size: 0.95rem; }
+  .page         { padding: 1.25rem 0.65rem 2.75rem; }
+
+  .hamburger    { width: 2rem; height: 2rem; }
+  .theme-toggle { width: 1.8rem; height: 1.8rem; }
+  .nav-arrow {
+    width: 2.4rem;
+    height: 2.4rem;
+    font-size: 1.3rem;
+  }
+  .nav-arrows-bottom .nav-arrow {
+    width: 2.7rem;
+    height: 2.7rem;
+    font-size: 1.45rem;
+  }
+
+  .panel-cue { font-size: 1.08rem; }
+  .bottom-tabs .tab {
+    font-size: 0.8rem;
+    padding: 0.45rem 0.7rem;
+  }
+  .tabs-menu { right: 0.4rem; min-width: 11rem; }
 }
 
 @media (min-width: 64rem) {
-  /* roomy desktop — slightly larger type and breathing room */
-  .topbar-inner { padding: 0.65rem 1.25rem; }
-  .page { padding: 3rem 1.5rem 5.5rem; }
+  .topbar-inner { padding: 0.7rem 1.25rem; }
+  .page         { padding: 3rem 1.5rem 5rem; }
 }
-
-/* high-contrast / reduced-motion friendliness */
 
 @media (prefers-reduced-motion: reduce) {
   [data-panel] { animation: none; }

--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -1,0 +1,306 @@
+---
+---
+
+/* Landing page — sparse, succinct, styled. Sans body / serif headings,
+   ESACP terminal-green accent, white cards on warm off-white. */
+
+:root {
+  --bg: #fafaf7;
+  --card: #ffffff;
+  --ink: #1d1d1f;
+  --ink-muted: #5b5b62;
+  --rule: #e4e4e0;
+  --rule-soft: #ececea;
+
+  --accent: #0f2a1d;          /* ESACP terminal green */
+  --accent-tint: #e9ede7;     /* highlight panel */
+  --accent-ink: #102a1d;      /* accent text */
+
+  --pain-tag: #7b3a3a;        /* warm rust — "the problem" */
+  --gain-tag: #2f6b3a;        /* forest green — "the win"  */
+
+  --radius: 12px;
+  --radius-sm: 8px;
+
+  --serif: ui-serif, "Iowan Old Style", "Apple Garamond", Baskerville,
+           Georgia, "Times New Roman", serif;
+  --sans:  -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+           "Helvetica Neue", Arial, sans-serif;
+  --mono:  ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+.page {
+  max-width: 54rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem 5rem;
+}
+
+/* hero */
+
+.hero {
+  text-align: center;
+  padding: 1rem 0 2.25rem;
+  margin-bottom: 2.5rem;
+  border-bottom: 1px solid var(--rule);
+
+  h1 {
+    font-family: var(--serif);
+    font-size: clamp(2.4rem, 6vw, 3.2rem);
+    font-weight: 600;
+    margin: 0;
+    letter-spacing: -0.02em;
+    color: var(--accent);
+    line-height: 1.05;
+  }
+
+  .tagline {
+    margin: 0.7rem 0 0;
+    color: var(--ink-muted);
+    font-size: clamp(1rem, 2.4vw, 1.15rem);
+    line-height: 1.4;
+  }
+}
+
+/* section common */
+
+section {
+  margin-bottom: 3rem;
+}
+
+section > h2 {
+  font-family: var(--serif);
+  font-size: clamp(1.4rem, 3.5vw, 1.7rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 1.25rem;
+  color: var(--ink);
+}
+
+section > p {
+  margin: 0.75rem 0;
+}
+
+/* pain points — grid of 3 */
+
+.pains {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 44rem) {
+  .pains { grid-template-columns: repeat(3, 1fr); }
+}
+
+.pain {
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 1.1rem 1.15rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+
+  h3 {
+    font-family: var(--serif);
+    font-size: 1.08rem;
+    font-weight: 600;
+    margin: 0.3rem 0 0.5rem;
+    line-height: 1.3;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+
+  .gain {
+    border-top: 1px dashed var(--rule);
+    padding-top: 0.7rem;
+    margin-top: 1rem;
+  }
+}
+
+.tag {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.tag.pain-tag { color: var(--pain-tag); }
+.tag.gain-tag { color: var(--gain-tag); margin-bottom: 0.35rem; }
+
+/* intro */
+
+.intro {
+  font-size: 1.05rem;
+  line-height: 1.62;
+}
+
+/* chain narrative */
+
+.chain-narrative {
+  background: var(--accent-tint);
+  border-left: 4px solid var(--accent);
+  padding: 1.1rem 1.3rem;
+  font-size: 1.02rem;
+  line-height: 1.6;
+  margin: 1.25rem 0 2rem;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--accent-ink);
+
+  strong { color: var(--accent); }
+}
+
+/* stages */
+
+.stages {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.stage {
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 1.1rem 1.25rem 1.3rem;
+
+  .role {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    margin: 0 0 0.4rem;
+  }
+
+  h3 {
+    font-family: var(--serif);
+    font-size: 1.18rem;
+    font-weight: 600;
+    margin: 0 0 0.7rem;
+    color: var(--accent);
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+
+  p {
+    margin: 0.55rem 0 0;
+    font-size: 0.97rem;
+  }
+}
+
+/* get-started steps */
+
+.steps {
+  display: grid;
+  gap: 1.4rem;
+  counter-reset: stepnum;
+}
+
+.step {
+  display: grid;
+  grid-template-columns: 2.4rem 1fr;
+  gap: 1rem;
+  align-items: start;
+
+  &::before {
+    counter-increment: stepnum;
+    content: counter(stepnum);
+    font-family: var(--serif);
+    font-size: 1.9rem;
+    font-weight: 600;
+    color: var(--accent);
+    line-height: 1;
+    padding-top: 0.1rem;
+    text-align: right;
+  }
+
+  h3 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin: 0 0 0.35rem;
+    line-height: 1.3;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.96rem;
+  }
+
+  .why {
+    margin-top: 0.55rem;
+    color: var(--ink-muted);
+    font-size: 0.88rem;
+    font-style: italic;
+    line-height: 1.5;
+  }
+
+  code {
+    font-family: var(--mono);
+    font-size: 0.85em;
+    background: rgba(0, 0, 0, 0.05);
+    padding: 0.1em 0.4em;
+    border-radius: 4px;
+  }
+}
+
+/* footer */
+
+.page-footer {
+  margin-top: 4rem;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--rule);
+  color: var(--ink-muted);
+  font-size: 0.88rem;
+  line-height: 1.6;
+
+  p { margin: 0.45rem 0; }
+
+  a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid var(--rule-soft);
+    transition: border-color 0.15s ease;
+  }
+  a:hover { border-bottom-color: var(--accent); }
+
+  code {
+    font-family: var(--mono);
+    background: rgba(0, 0, 0, 0.05);
+    padding: 0.1em 0.4em;
+    border-radius: 4px;
+  }
+}
+
+/* inline links in body copy */
+
+section a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+  transition: border-color 0.15s ease;
+}
+section a:hover { border-bottom-color: var(--accent); }
+
+/* tighten on narrow screens */
+
+@media (max-width: 30rem) {
+  .page { padding: 1.75rem 0.9rem 3rem; }
+  .step { grid-template-columns: 2rem 1fr; gap: 0.8rem; }
+  .step::before { font-size: 1.6rem; }
+}

--- a/on_boarding/docs/essex-demo.md
+++ b/on_boarding/docs/essex-demo.md
@@ -1,0 +1,206 @@
+---
+layout: default
+title: "Setting up ESACP on a Windows 11 machine"
+subtitle: "A first conversation between Buzz_000 and Essex. Static mock — no chatbot wired up yet."
+---
+
+<!--
+  Static chat-bubble mock. Each turn is a div with class "turn buzz" or
+  "turn essex". The inner div uses `markdown="1"` so kramdown still
+  processes the bubble content. No JS, no chatbot.
+
+  Walkthrough beats (see #467 acceptance):
+    1. Why a parallel Ubuntu-24.04 WSL distro
+    2. The one PowerShell line that imports it
+    3. Visual branding so Buzz can tell ESACP's window apart
+    4. Snapshot / revert posture (Minecraft "shelter")
+    5. The first prompt in the new shell + what Essex does next
+-->
+
+> **Audience:** Variant 1 greenfield (small business not yet on any ERP) ·
+> **Archetype:** Win-11 controller, never opened a terminal, mobile-first ·
+> **Stage:** 1 — first encounter.
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Hi. A friend told me ESACP could help me get my business onto one piece of software instead of the seven I'm using now. I've got a Windows 11 laptop. Where do I start?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Welcome, Buzz. The first thing we'll do is give your laptop a small, separate Linux room to work in — without touching anything you already have on Windows. The piece of Windows that lets us do this is called **WSL** (Windows Subsystem for Linux); it's free, it's made by Microsoft, and it ships with your laptop already.
+
+Think of it like adding a clean workbench to your garage. Your existing tools stay where they are; we just put the ESACP work on its own surface so nothing gets mixed up.
+
+When you're ready, I'll walk you through the first command.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Hold on — I already had someone install Ubuntu on this thing last year for a different project. Won't yours wreck that one?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Good catch, and the answer is *no, by design*. WSL lets you run several Linux installations side by side, each with its own name and its own files. We're going to create a brand-new one called **ESACP** and leave your existing Ubuntu completely alone.
+
+Here's the plan, and I'll narrate every step before we run it:
+
+- **What** — install a fresh Ubuntu 24.04, then re-import it under the name `ESACP`.
+- **Why** — a separate name means a separate filesystem. If anything ever goes wrong with the ESACP side, your other Ubuntu is untouched.
+- **Who** — only Microsoft (the WSL feature) and Canonical (the people who make Ubuntu). Nobody else is involved at this step.
+- **Cost** — zero. The disk space comes out of your laptop's drive (around 1.5 GB to start).
+
+Open **PowerShell** — the blue terminal, not the black one — and we'll do it together.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Got it open. Now what?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Two commands. The first one downloads Ubuntu 24.04 from Microsoft's catalogue:
+
+```powershell
+wsl --install -d Ubuntu-24.04 --no-launch
+```
+
+The `--no-launch` is intentional — we don't want it to start asking *you* for a username yet. It'll just sit there, ready.
+
+When that finishes (a minute or two), tell me and we'll do the second one.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+Done. It said "Ubuntu-24.04 has been installed."
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Perfect. Now we'll make the ESACP-branded copy. Three lines:
+
+```powershell
+mkdir C:\WSL\ESACP
+wsl --export Ubuntu-24.04 C:\WSL\ESACP\seed.tar
+wsl --import ESACP C:\WSL\ESACP C:\WSL\ESACP\seed.tar --version 2
+```
+
+In plain English: we made a folder, took a snapshot of the fresh Ubuntu you just installed, and registered that snapshot back under the name **ESACP**. You now have a Linux distribution called `ESACP` that is yours.
+
+Type `wsl -l -v` and you should see both `Ubuntu-24.04` and `ESACP` in the list.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+There they are. So now I just open the ESACP one?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Almost. One more thing first — let's make the ESACP window *look* different from the other one, so you never have to guess which is which. This is a one-time setup in **Windows Terminal** (the app with the multicoloured icon in your Start menu).
+
+Open Windows Terminal, click the **down-arrow** next to the `+` tab, choose **Settings**, then **Open JSON file**. We'll add a profile for ESACP. I'll give you the exact block to paste:
+
+```json
+{
+  "name": "ESACP",
+  "commandline": "wsl.exe -d ESACP",
+  "icon": "🛠️",
+  "tabTitle": "ESACP",
+  "colorScheme": "Tango Dark",
+  "background": "#0f2a1d",
+  "startingDirectory": "//wsl$/ESACP/root"
+}
+```
+
+Save the file. Open a new tab — you'll see **ESACP** in the dropdown, in a deep-green window that's unmistakable.
+
+- **What** — a named, coloured terminal profile for ESACP.
+- **Why** — when you have three windows open and you're tired, the green one is always ESACP. Mistakes get cheaper.
+- **Who** — nobody outside Microsoft. The setting lives in a file on your laptop.
+- **Cost** — free.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+That's cute. Green window, ESACP. Got it. What if I mess everything up?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+That's the best question you've asked yet, and we have a clean answer.
+
+Before we change anything inside the ESACP room, we'll take a **snapshot** — a complete copy of the room as it is right now. If anything goes sideways later, you run one command and you're back to this exact state. Nothing else on your laptop is affected.
+
+Snapshot (run from PowerShell, not from inside ESACP):
+
+```powershell
+wsl --export ESACP C:\WSL\ESACP\snapshots\day-0.tar
+```
+
+Revert, if you ever need to:
+
+```powershell
+wsl --unregister ESACP
+wsl --import ESACP C:\WSL\ESACP C:\WSL\ESACP\snapshots\day-0.tar --version 2
+```
+
+I think of it as the **shelter** in a Minecraft survival world — a safe place you can always return to. An IT consultant would charge you several hundred dollars to set up a backup-and-restore system this clean. We just did it in two lines, and you own it.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+OK. Snapshot taken. Now do I go in?
+  </div>
+</div>
+
+<div class="turn essex">
+  <div class="speaker">Essex</div>
+  <div class="bubble" markdown="1">
+Now you go in. Open the green **ESACP** tab in Windows Terminal. You'll see a prompt that looks something like this:
+
+```text
+root@ESACP:~#
+```
+
+You're inside the ESACP room. From here I'll start the actual setup — installing the small set of tools the platform needs (a key manager, a signing utility, GitHub's command-line client, and a couple of others). Every install will get the same *What / Why / Who / Cost* explanation you've seen so far, and you'll click "yes" to each one.
+
+An IT consultant would take weeks to wire up everything we're about to set up, and would charge you accordingly. ESACP has all of it in its training. We'll go through it together at your pace.
+
+When you're ready, type `whoami` and press Enter. We'll start there.
+  </div>
+</div>
+
+<div class="turn buzz">
+  <div class="speaker">Buzz</div>
+  <div class="bubble" markdown="1">
+*[end of static mock — the next turns will come from the real chatbot when the backend lands. See `on_boarding/internal_docs/entry-architecture-notes.md`.]*
+  </div>
+</div>

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -22,8 +22,8 @@ description: >-
 <div class="pains pains-problem">
 
   <div class="pain">
-    <span class="tag pain-tag">The problem</span>
-    <h3>Your information lives in seven places.</h3>
+    <span class="tag pain-tag">A problem!</span>
+    <h3>Your information lives in a half dozen places.</h3>
     <p>
       Spreadsheets, the accounting app, marketplace dashboards, email
       threads, the binder by the printer, a notebook in your pocket.
@@ -33,7 +33,7 @@ description: >-
   </div>
 
   <div class="pain">
-    <span class="tag pain-tag">The problem</span>
+    <span class="tag pain-tag">Another problem!!</span>
     <h3>Half of every month is the same boring assembly job.</h3>
     <p>
       Invoices, monthly reports, AGM packets, quarterly compliance,
@@ -43,12 +43,12 @@ description: >-
   </div>
 
   <div class="pain">
-    <span class="tag pain-tag">The problem</span>
-    <h3>When someone leaves, half your business goes with them.</h3>
+    <span class="tag pain-tag">Yet another problem!!!</span>
+    <h3>When someone leaves, business knowledge goes with them.</h3>
     <p>
-      Years of how-we-do-things lives in one person's head. When they
+      Years of "how-we-do-things" lives in one person's head. When they
       walk out, the institutional memory walks out with them. The next
-      hire takes months to ramp because nothing is written down.
+      hire takes months to ramp up because nothing is written down.
     </p>
   </div>
 
@@ -63,7 +63,7 @@ description: >-
 <h2>What ESACP changes</h2>
 
 <p class="intro">
-  ESACP is a guided setup for ERPNext, the open-source business system
+  ESACP is a guided set up for ERPNext, the open-source business system
   that larger competitors have run since the 1990s. We give you the
   same backbone, on your terms, with an AI that helps you move in.
 </p>
@@ -104,14 +104,15 @@ description: >-
 
 </div>
 
-<p class="panel-cue"><a href="#how" class="panel-cue-link">&lsaquo; Curious how it actually gets installed?</a></p>
+<p class="panel-cue"><a href="#how" class="panel-cue-link">Curious how it actually gets installed?  &rsaquo;</a></p>
 
 </section>
 
 <section data-panel="how" id="how">
 
-<h2>How we get there &mdash; the chain on the girder</h2>
+<h2>How we get there &mdash; the age-old "chain on the girder" problem</h2>
 
+    <p>Analogy: </p>
 <blockquote class="chain-narrative">
   To attach a heavy chain to a beam that's far too high, you don't try
   to throw the chain. It's too heavy and it falls. You throw a
@@ -130,12 +131,12 @@ description: >-
     <h3>You talk to claude.ai about your business.</h3>
     <p>
       You tell it in general terms what your existing setup looks like
-      &mdash; what tools you use, what's painful, what you'd like to be
+      &mdash; what tools you use, what's painful, what you wish was
       different. It listens, asks short questions, and at the end gives
       you a written summary of where you stand. The summary is yours;
       it's also the starting point for stage 2.
     </p>
-    <p>
+    <p class="comment">
       Light, throwable, no commitment. No software on your machine. No
       money spent. About ten minutes. At the end you'll know whether
       ESACP is worth your time.
@@ -152,7 +153,7 @@ description: >-
       reads your stage-1 summary and walks you through every step
       toward stage 3.
     </p>
-    <p>
+    <p class="comment">
       Heavier than stage 1, but still recoverable. If anything goes
       sideways you back out and try again, without affecting anything
       else on your computer.
@@ -169,7 +170,7 @@ description: >-
       assistance &mdash; all in one place, with the system watching
       itself.
     </p>
-    <p>
+    <p class="comment">
       The heavy, valuable, finished thing. What stages 1 and 2 built up
       to.
     </p>
@@ -224,36 +225,39 @@ description: >-
 
   <div class="step">
     <div>
-      <h3>Paste in the Essex instructions.</h3>
+      <h3>Invite "Essex" into the chat.</h3>
       <p>
-        Click <strong>Set custom instructions</strong> on your new
-        project. In another browser tab, open
-        <a href="https://raw.githubusercontent.com/martinhbramwell/ESACP/on_boarding/on_boarding/internal_docs/mode_a_persona_v0.md">the
-        Essex instructions document</a>, press <code>Ctrl</code> + <code>A</code>
-        to select everything, then <code>Ctrl</code> + <code>C</code>
-        to copy. Back in the Project, paste into the instructions box.
-        Save.
+        Inside your new project, click <strong>New chat</strong>. In
+        the message box, paste this one line and press <strong>Send</strong>:
       </p>
+      <blockquote class="chain-narrative">
+        Claude, please read from this link
+        <code>https://bit.ly/A1B2c3</code> and take on the
+        &ldquo;Essex&rdquo; role as it explains.
+      </blockquote>
       <p class="why">
-        Why these instructions: they turn Claude into Essex &mdash; a
-        guide who knows exactly which questions to ask, in which order,
-        in business language. Without them you'd get general-purpose
-        Claude who doesn't know your context.
+        Who is Essex? Essex is a version of Claude who's been trained
+        on ESACP &mdash; an ESACP Expert. The link points to a public
+        page that tells Claude who Essex is and which questions Essex
+        should ask. Without it you'd get general-purpose Claude, who
+        doesn't know your context.
       </p>
     </div>
   </div>
 
   <div class="step">
     <div>
-      <h3>Start the conversation.</h3>
+      <h3>Answer Essex in plain language.</h3>
       <p>
-        Inside your project, click <strong>New chat</strong>. Type
-        <code>Hi.</code> and send. Essex will take it from there.
+        Within a few seconds, Essex will reply in character and ask
+        a first question or two about your business. Type your
+        answer normally and send.
       </p>
       <p class="why">
         What to expect: about ten minutes. Essex will ask five to ten
         short questions about how your business runs today &mdash; no
-        technical questions, no jargon. You answer in plain language.
+        technical questions, no jargon. Use whatever words you'd use
+        with a colleague.
       </p>
     </div>
   </div>
@@ -275,6 +279,26 @@ description: >-
     </div>
   </div>
 
+</div>
+
+<div class="essex-demo-note">
+  <p>
+    <strong>Stage 1 done.</strong> Your summary in hand is the
+    deliverable.
+  </p>
+  <p>
+    Stage 2 &mdash; installing ESACP on your own computer with
+    Claude Code as your guide &mdash; is under active construction.
+    The self-serve walkthrough will land on this page when it's
+    ready.
+  </p>
+  <p>
+    If you'd like to start Stage 2 sooner, email your summary to
+    <a href="mailto:CHANGE-THIS@example.com">CHANGE-THIS@example.com</a>
+    and we'll walk you through it personally. Or
+    <a href="https://github.com/martinhbramwell/ESACP">watch the
+    GitHub repo</a> to track progress.
+  </p>
 </div>
 
 <p class="panel-cue"><a href="#catch" class="panel-cue-link">Before you start &mdash; what's the catch? &rsaquo;</a></p>
@@ -307,15 +331,19 @@ description: >-
 
   <div class="caveat">
     <span class="tag caveat-tag">Cost</span>
-    <h3>Stages 1 and 2 are free. Stage 3 is not.</h3>
+    <h3>Stage 1 is free. Stages 2 and 3 cost something.</h3>
     <p>
       Stage 1 uses the free claude.ai tier &mdash; you'll bump into its
       message limits eventually, but a discovery conversation fits
-      comfortably inside them. Stage 2 runs on your own computer, so
-      again no money out. Stage 3 means real servers on the public
-      internet, and someone has to pay for them. Today that's you, at
-      the going rate for a small VPS &mdash; roughly the cost of a
-      streaming subscription.
+      comfortably inside them. Stage 2 needs Claude Code (Anthropic's
+      developer tool), which is metered: either an Anthropic Pro
+      subscription (about $20 a month) or pay-as-you-go API credits.
+      The work happens on your own computer; what you pay for is the
+      AI that guides you through it. Stage 3 adds a small "virtual private
+	  server" (VPS) on the public internet for the production system &mdash;
+	  about the cost of another streaming subscription. Both bills are
+	  monthly, both cancellable, and the amounts only run while you're
+	  actually using the thing.
     </p>
   </div>
 

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -356,22 +356,15 @@ description: >-
 
 </div>
 
-<p class="panel-cue"><a href="#start" class="panel-cue-link">&lsaquo; Still interested? Back to Getting Started</a></p>
-
-</section>
-
-<footer class="page-footer">
+<div class="essex-demo-note">
   <p>
     Curious what Essex sounds like once you're past discovery?
     <a href="essex-demo.html">See a worked example of a stage-2 conversation</a>
     &mdash; a static walkthrough where Essex helps a small-business
     owner set up the sandbox on a Windows 11 machine.
   </p>
-  <p>
-    The architecture this page seeds is documented in
-    <a href="https://github.com/martinhbramwell/ESACP/blob/on_boarding/on_boarding/internal_docs/entry-architecture-notes.md"><code>internal_docs/entry-architecture-notes.md</code></a>.
-  </p>
-  <p>
-    Source: <a href="https://github.com/martinhbramwell/ESACP">martinhbramwell/ESACP</a> on GitHub.
-  </p>
-</footer>
+</div>
+
+<p class="panel-cue"><a href="#start" class="panel-cue-link">&lsaquo; Still interested? Back to Getting Started</a></p>
+
+</section>

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -8,6 +8,8 @@ description: >-
   to start.
 ---
 
+<section data-panel="problem" id="problem">
+
 <header class="hero">
   <h1>ESACP</h1>
   <p class="tagline">
@@ -15,251 +17,347 @@ description: >-
   </p>
 </header>
 
-<section>
-  <h2>Where small business loses ground</h2>
+<h2>Where small business loses ground</h2>
 
-  <div class="pains">
+<div class="pains pains-problem">
 
-    <div class="pain">
-      <span class="tag pain-tag">The problem</span>
-      <h3>Your information lives in seven places.</h3>
-      <p>
-        Spreadsheets, the accounting app, marketplace dashboards, email
-        threads, the binder by the printer, a notebook in your pocket.
-        Answering one customer question takes ten minutes because nothing
-        is in one place.
-      </p>
-      <div class="gain">
-        <span class="tag gain-tag">What ESACP changes</span>
-        <p>
-          <strong>One place. Ask in plain English.</strong>
-          ESACP gives you a single source of truth and an AI that reads it
-          for you. The answer comes back in seconds, in business language.
-          Larger competitors have had this since 1995. Now you can too.
-        </p>
-      </div>
-    </div>
-
-    <div class="pain">
-      <span class="tag pain-tag">The problem</span>
-      <h3>Half of every month is the same boring assembly job.</h3>
-      <p>
-        Invoices, monthly reports, AGM packets, quarterly compliance,
-        reminders to chase vendors. The same rituals every period &mdash;
-        they don't add value, but you can't skip them.
-      </p>
-      <div class="gain">
-        <span class="tag gain-tag">What ESACP changes</span>
-        <p>
-          <strong>The boring half runs itself.</strong>
-          Recurring patterns become workflows the system handles. You
-          approve; you don't assemble. The hours come back to the parts
-          of the job you actually do well.
-        </p>
-      </div>
-    </div>
-
-    <div class="pain">
-      <span class="tag pain-tag">The problem</span>
-      <h3>When someone leaves, half your business goes with them.</h3>
-      <p>
-        Years of how-we-do-things lives in one person's head. When they
-        walk out, the institutional memory walks out with them. The next
-        hire takes months to ramp because nothing is written down.
-      </p>
-      <div class="gain">
-        <span class="tag gain-tag">What ESACP changes</span>
-        <p>
-          <strong>What your team knows stays in the system.</strong>
-          Decisions, workflows, vendor preferences &mdash; captured as you
-          work, queryable later. The next hire learns from the system,
-          not from someone's memory.
-        </p>
-      </div>
-    </div>
-
+  <div class="pain">
+    <span class="tag pain-tag">The problem</span>
+    <h3>Your information lives in seven places.</h3>
+    <p>
+      Spreadsheets, the accounting app, marketplace dashboards, email
+      threads, the binder by the printer, a notebook in your pocket.
+      Answering one customer question takes ten minutes because nothing
+      is in one place.
+    </p>
   </div>
+
+  <div class="pain">
+    <span class="tag pain-tag">The problem</span>
+    <h3>Half of every month is the same boring assembly job.</h3>
+    <p>
+      Invoices, monthly reports, AGM packets, quarterly compliance,
+      reminders to chase vendors. The same rituals every period &mdash;
+      they don't add value, but you can't skip them.
+    </p>
+  </div>
+
+  <div class="pain">
+    <span class="tag pain-tag">The problem</span>
+    <h3>When someone leaves, half your business goes with them.</h3>
+    <p>
+      Years of how-we-do-things lives in one person's head. When they
+      walk out, the institutional memory walks out with them. The next
+      hire takes months to ramp because nothing is written down.
+    </p>
+  </div>
+
+</div>
+
+<p class="panel-cue">Recognize any of these? <a href="#why" class="panel-cue-link">See what ESACP changes &rsaquo;</a></p>
+
 </section>
 
-<section>
-  <h2>What ESACP does</h2>
+<section data-panel="why" id="why">
 
-  <p class="intro">
-    ESACP will guide you through the entire process of getting started
-    with ERPNext, on the internet, properly secured and ready to start
-    collecting all your data into a single source of truth.
-  </p>
+<h2>What ESACP changes</h2>
 
-  <p class="intro">
-    It's a three-stage process. We don't try to do it all at once
-    &mdash; instead we use a technique anyone who has ever needed to
-    attach a chain to a high beam knows by heart.
-  </p>
+<p class="intro">
+  ESACP is a guided setup for ERPNext, the open-source business system
+  that larger competitors have run since the 1990s. We give you the
+  same backbone, on your terms, with an AI that helps you move in.
+</p>
+
+<div class="pains pains-gain">
+
+  <div class="pain">
+    <span class="tag gain-tag">One place. Ask in plain English.</span>
+    <h3>Your information lives in one place.</h3>
+    <p>
+      A single source of truth, with an AI that reads it for you. The
+      answer to &ldquo;what did we ship to Acme last month?&rdquo; comes
+      back in seconds, in business language. No more cross-referencing
+      seven dashboards.
+    </p>
+  </div>
+
+  <div class="pain">
+    <span class="tag gain-tag">The boring half runs itself.</span>
+    <h3>Recurring rituals become workflows.</h3>
+    <p>
+      Invoicing, reminders, monthly packets, compliance &mdash; the
+      patterns the system can recognize, the system handles. You
+      approve; you don't assemble. The hours come back to the parts of
+      the job you actually do well.
+    </p>
+  </div>
+
+  <div class="pain">
+    <span class="tag gain-tag">What your team knows stays in the system.</span>
+    <h3>Institutional memory survives turnover.</h3>
+    <p>
+      Decisions, workflows, vendor preferences &mdash; captured as you
+      work, queryable later. The next hire learns from the system, not
+      from someone's memory.
+    </p>
+  </div>
+
+</div>
+
+<p class="panel-cue"><a href="#how" class="panel-cue-link">&lsaquo; Curious how it actually gets installed?</a></p>
+
 </section>
 
-<section>
-  <h2>How we get there &mdash; the chain on the girder</h2>
+<section data-panel="how" id="how">
 
-  <blockquote class="chain-narrative">
-    To attach a heavy chain to a beam that's far too high, you don't try
-    to throw the chain. It's too heavy and it falls. You throw a
-    <strong>shoe with a string attached</strong>. The string is light,
-    the shoe is easy to throw. Once the shoe is over the beam, you tie
-    the string to a <strong>rope</strong>, and the string pulls the rope
-    up. Then you tie the rope to the <strong>chain</strong>, and the
-    rope pulls the chain up. Each step is easy on its own. Skip any one
-    of them and you fail.
-  </blockquote>
+<h2>How we get there &mdash; the chain on the girder</h2>
 
-  <div class="stages">
+<blockquote class="chain-narrative">
+  To attach a heavy chain to a beam that's far too high, you don't try
+  to throw the chain. It's too heavy and it falls. You throw a
+  <strong>shoe with a string attached</strong>. The string is light,
+  the shoe is easy to throw. Once the shoe is over the beam, you tie
+  the string to a <strong>rope</strong>, and the string pulls the rope
+  up. Then you tie the rope to the <strong>chain</strong>, and the
+  rope pulls the chain up. Each step is easy on its own. Skip any one
+  of them and you fail.
+</blockquote>
 
-    <div class="stage">
-      <p class="role">Stage 1 &mdash; the shoe on a string</p>
-      <h3>You talk to claude.ai about your business.</h3>
-      <p>
-        You tell it in general terms what your existing setup looks
-        like &mdash; what tools you use, what's painful, what you'd
-        like to be different. It listens, asks short questions, and at
-        the end gives you a written summary of where you stand. The
-        summary is yours; it's also the starting point for stage 2.
-      </p>
-      <p>
-        Light, throwable, no commitment. No software on your machine.
-        No money spent. About ten minutes. At the end you'll know
-        whether ESACP is worth your time.
-      </p>
-    </div>
+<div class="stages">
 
-    <div class="stage">
-      <p class="role">Stage 2 &mdash; the rope</p>
-      <h3>You install ESACP in a safe sandbox on your computer, with Claude Code to guide you.</h3>
-      <p>
-        You bring the ESACP setup down into a controlled space on your
-        own machine &mdash; separate from everything else, fully
-        reversible. Claude Code (Anthropic's developer-focused product)
-        reads your stage-1 summary and walks you through every step
-        toward stage 3.
-      </p>
-      <p>
-        Heavier than stage 1, but still recoverable. If anything goes
-        sideways you back out and try again, without affecting anything
-        else on your computer.
-      </p>
-    </div>
-
-    <div class="stage">
-      <p class="role">Stage 3 &mdash; the chain</p>
-      <h3>Your ERP network controller comes alive.</h3>
-      <p>
-        Your ERPNext system, running on a small set of monitored
-        servers, with ESACP continuously watching the health and
-        productivity of every piece. The data, the workflows, the AI
-        assistance &mdash; all in one place, with the system watching
-        itself.
-      </p>
-      <p>
-        The heavy, valuable, finished thing. What stages 1 and 2 built
-        up to.
-      </p>
-    </div>
-
+  <div class="stage">
+    <p class="role">Stage 1 &mdash; the shoe on a string</p>
+    <h3>You talk to claude.ai about your business.</h3>
+    <p>
+      You tell it in general terms what your existing setup looks like
+      &mdash; what tools you use, what's painful, what you'd like to be
+      different. It listens, asks short questions, and at the end gives
+      you a written summary of where you stand. The summary is yours;
+      it's also the starting point for stage 2.
+    </p>
+    <p>
+      Light, throwable, no commitment. No software on your machine. No
+      money spent. About ten minutes. At the end you'll know whether
+      ESACP is worth your time.
+    </p>
   </div>
+
+  <div class="stage">
+    <p class="role">Stage 2 &mdash; the rope</p>
+    <h3>You install ESACP in a safe sandbox on your computer, with Claude Code to guide you.</h3>
+    <p>
+      You bring the ESACP setup down into a controlled space on your
+      own machine &mdash; separate from everything else, fully
+      reversible. Claude Code (Anthropic's developer-focused product)
+      reads your stage-1 summary and walks you through every step
+      toward stage 3.
+    </p>
+    <p>
+      Heavier than stage 1, but still recoverable. If anything goes
+      sideways you back out and try again, without affecting anything
+      else on your computer.
+    </p>
+  </div>
+
+  <div class="stage">
+    <p class="role">Stage 3 &mdash; the chain</p>
+    <h3>Your ERP network controller comes alive.</h3>
+    <p>
+      Your ERPNext system, running on a small set of monitored
+      servers, with ESACP continuously watching the health and
+      productivity of every piece. The data, the workflows, the AI
+      assistance &mdash; all in one place, with the system watching
+      itself.
+    </p>
+    <p>
+      The heavy, valuable, finished thing. What stages 1 and 2 built up
+      to.
+    </p>
+  </div>
+
+</div>
+
+<p class="panel-cue"><a href="#start" class="panel-cue-link">Ready to throw the shoe? &rsaquo;</a></p>
+
 </section>
 
-<section>
-  <h2>Get started &mdash; your first conversation</h2>
+<section data-panel="start" id="start">
 
-  <p>
-    Stage 1 takes about ten minutes. Five steps:
-  </p>
+<h2>Get started &mdash; your first conversation</h2>
 
-  <div class="steps">
+<p>
+  Stage 1 takes about ten minutes. Five steps:
+</p>
 
-    <div class="step">
-      <div>
-        <h3>Create a free Claude account.</h3>
-        <p>
-          Go to <a href="https://claude.ai">claude.ai</a> and sign up.
-          Takes 30 seconds. Free.
-        </p>
-        <p class="why">
-          Why claude.ai: it's Anthropic's consumer-facing site. The
-          conversation lives on their servers, not yours. Nothing about
-          ESACP touches your machine until stage 2. If you decide ESACP
-          isn't for you, there's nothing to uninstall.
-        </p>
-      </div>
+<div class="steps">
+
+  <div class="step">
+    <div>
+      <h3>Create a free Claude account.</h3>
+      <p>
+        Go to <a href="https://claude.ai">claude.ai</a> and sign up.
+        Takes 30 seconds. Free.
+      </p>
+      <p class="why">
+        Why claude.ai: it's Anthropic's consumer-facing site. The
+        conversation lives on their servers, not yours. Nothing about
+        ESACP touches your machine until stage 2. If you decide ESACP
+        isn't for you, there's nothing to uninstall.
+      </p>
     </div>
-
-    <div class="step">
-      <div>
-        <h3>Create a new Project. Call it &ldquo;ESACP Onboarding&rdquo;.</h3>
-        <p>
-          In claude.ai's left sidebar, click <strong>Projects</strong>,
-          then <strong>+ New project</strong>.
-        </p>
-        <p class="why">
-          Why a Project: it lets you give Claude permanent instructions
-          that apply to every chat inside it. We use this to tell Claude
-          what kind of conversation to have with you.
-        </p>
-      </div>
-    </div>
-
-    <div class="step">
-      <div>
-        <h3>Paste in the Essex instructions.</h3>
-        <p>
-          Click <strong>Set custom instructions</strong> on your new
-          project. In another browser tab, open
-          <a href="https://raw.githubusercontent.com/martinhbramwell/ESACP/on_boarding/on_boarding/internal_docs/mode_a_persona_v0.md">the
-          Essex instructions document</a>, press <code>Ctrl</code> + <code>A</code>
-          to select everything, then <code>Ctrl</code> + <code>C</code>
-          to copy. Back in the Project, paste into the instructions box.
-          Save.
-        </p>
-        <p class="why">
-          Why these instructions: they turn Claude into Essex &mdash; a
-          guide who knows exactly which questions to ask, in which order,
-          in business language. Without them you'd get general-purpose
-          Claude who doesn't know your context.
-        </p>
-      </div>
-    </div>
-
-    <div class="step">
-      <div>
-        <h3>Start the conversation.</h3>
-        <p>
-          Inside your project, click <strong>New chat</strong>. Type
-          <code>Hi.</code> and send. Essex will take it from there.
-        </p>
-        <p class="why">
-          What to expect: about ten minutes. Essex will ask five to ten
-          short questions about how your business runs today &mdash; no
-          technical questions, no jargon. You answer in plain language.
-        </p>
-      </div>
-    </div>
-
-    <div class="step">
-      <div>
-        <h3>Keep the summary.</h3>
-        <p>
-          When Essex feels you've covered enough ground, you'll get a
-          short summary back, written in business language, with names
-          and numbers anonymized. Save it somewhere you'll find it.
-        </p>
-        <p class="why">
-          What it's for: the summary is yours, and it's also the
-          starting input for stage 2. Claude Code reads it before it
-          starts advising you, so you don't have to tell your story
-          twice.
-        </p>
-      </div>
-    </div>
-
   </div>
+
+  <div class="step">
+    <div>
+      <h3>Create a new Project. Call it &ldquo;ESACP Onboarding&rdquo;.</h3>
+      <p>
+        In claude.ai's left sidebar, click <strong>Projects</strong>,
+        then <strong>+ New project</strong>.
+      </p>
+      <p class="why">
+        Why a Project: it lets you give Claude permanent instructions
+        that apply to every chat inside it. We use this to tell Claude
+        what kind of conversation to have with you.
+      </p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div>
+      <h3>Paste in the Essex instructions.</h3>
+      <p>
+        Click <strong>Set custom instructions</strong> on your new
+        project. In another browser tab, open
+        <a href="https://raw.githubusercontent.com/martinhbramwell/ESACP/on_boarding/on_boarding/internal_docs/mode_a_persona_v0.md">the
+        Essex instructions document</a>, press <code>Ctrl</code> + <code>A</code>
+        to select everything, then <code>Ctrl</code> + <code>C</code>
+        to copy. Back in the Project, paste into the instructions box.
+        Save.
+      </p>
+      <p class="why">
+        Why these instructions: they turn Claude into Essex &mdash; a
+        guide who knows exactly which questions to ask, in which order,
+        in business language. Without them you'd get general-purpose
+        Claude who doesn't know your context.
+      </p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div>
+      <h3>Start the conversation.</h3>
+      <p>
+        Inside your project, click <strong>New chat</strong>. Type
+        <code>Hi.</code> and send. Essex will take it from there.
+      </p>
+      <p class="why">
+        What to expect: about ten minutes. Essex will ask five to ten
+        short questions about how your business runs today &mdash; no
+        technical questions, no jargon. You answer in plain language.
+      </p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div>
+      <h3>Keep the summary.</h3>
+      <p>
+        When Essex feels you've covered enough ground, you'll get a
+        short summary back, written in business language, with names
+        and numbers anonymized. Save it somewhere you'll find it.
+      </p>
+      <p class="why">
+        What it's for: the summary is yours, and it's also the
+        starting input for stage 2. Claude Code reads it before it
+        starts advising you, so you don't have to tell your story
+        twice.
+      </p>
+    </div>
+  </div>
+
+</div>
+
+<p class="panel-cue"><a href="#catch" class="panel-cue-link">Before you start &mdash; what's the catch? &rsaquo;</a></p>
+
+</section>
+
+<section data-panel="catch" id="catch">
+
+<h2>What&rsquo;s the catch?</h2>
+
+<p class="intro">
+  Honest version, up front. No marketing tricks &mdash; if any of these
+  are dealbreakers for you, better to know now than three weeks in.
+</p>
+
+<div class="caveats">
+
+  <div class="caveat">
+    <span class="tag caveat-tag">Heads up</span>
+    <h3>This is a working prototype.</h3>
+    <p>
+      Stage 1 (the claude.ai conversation) is something you can
+      genuinely try today. Stages 2 and 3 are under active construction
+      &mdash; the architecture is decided, the parts are being built,
+      and the design is documented openly. You're early. That's the
+      deal: in exchange for being a guinea pig, you get a direct line
+      to the people building it.
+    </p>
+  </div>
+
+  <div class="caveat">
+    <span class="tag caveat-tag">Cost</span>
+    <h3>Stages 1 and 2 are free. Stage 3 is not.</h3>
+    <p>
+      Stage 1 uses the free claude.ai tier &mdash; you'll bump into its
+      message limits eventually, but a discovery conversation fits
+      comfortably inside them. Stage 2 runs on your own computer, so
+      again no money out. Stage 3 means real servers on the public
+      internet, and someone has to pay for them. Today that's you, at
+      the going rate for a small VPS &mdash; roughly the cost of a
+      streaming subscription.
+    </p>
+  </div>
+
+  <div class="caveat">
+    <span class="tag caveat-tag">Privacy</span>
+    <h3>We&rsquo;d like to learn from your conversation. You decide.</h3>
+    <p>
+      When Essex hands you the stage-1 summary, you can voluntarily
+      share the transcript with us to help improve the next version.
+      It's anonymized before it leaves your screen. Saying no is fine;
+      nothing in stage 2 or 3 depends on it.
+    </p>
+  </div>
+
+  <div class="caveat">
+    <span class="tag caveat-tag">Lock-in</span>
+    <h3>You can leave with everything.</h3>
+    <p>
+      ERPNext is open-source. ESACP is open-source. The data is yours,
+      the configuration is yours, the AI conversation transcripts are
+      yours. If at any stage you decide to walk away, you take
+      everything with you. There is no proprietary format and no
+      hostage data.
+    </p>
+  </div>
+
+  <div class="caveat">
+    <span class="tag caveat-tag">AI honesty</span>
+    <h3>AI is the guide, not the operator.</h3>
+    <p>
+      Claude is good at asking the right questions and walking you
+      through a sequence. It's not magic. Decisions about your business
+      are yours; the AI helps you think, not think for you. If the
+      system ever feels like it's pushing you toward something you
+      don't want, push back &mdash; that's how it's designed.
+    </p>
+  </div>
+
+</div>
+
+<p class="panel-cue"><a href="#start" class="panel-cue-link">&lsaquo; Still interested? Back to Getting Started</a></p>
+
 </section>
 
 <footer class="page-footer">
@@ -270,9 +368,7 @@ description: >-
     owner set up the sandbox on a Windows 11 machine.
   </p>
   <p>
-    This is a working prototype. Stage 1 is a proof-of-concept you can
-    try today; stages 2 and 3 are under active construction. The
-    architecture this page seeds is documented in
+    The architecture this page seeds is documented in
     <a href="https://github.com/martinhbramwell/ESACP/blob/on_boarding/on_boarding/internal_docs/entry-architecture-notes.md"><code>internal_docs/entry-architecture-notes.md</code></a>.
   </p>
   <p>

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -1,206 +1,281 @@
 ---
-layout: default
-title: "Setting up ESACP on a Windows 11 machine"
-subtitle: "A first conversation between Buzz_000 and Essex. Static mock — no chatbot wired up yet."
+layout: landing
+title: "ESACP — bring your business onto one system, with AI"
+description: >-
+  ESACP guides small businesses through setting up ERPNext on the
+  internet, properly secured, ready to bring every data source into
+  one place. Three stages, every step explained, no terminal required
+  to start.
 ---
 
-<!--
-  Static chat-bubble mock. Each turn is a div with class "turn buzz" or
-  "turn essex". The inner div uses `markdown="1"` so kramdown still
-  processes the bubble content. No JS, no chatbot.
+<header class="hero">
+  <h1>ESACP</h1>
+  <p class="tagline">
+    ERPNext for small business &mdash; set up, secured, and kept healthy by AI.
+  </p>
+</header>
 
-  Walkthrough beats (see #467 acceptance):
-    1. Why a parallel Ubuntu-24.04 WSL distro
-    2. The one PowerShell line that imports it
-    3. Visual branding so Buzz can tell ESACP's window apart
-    4. Snapshot / revert posture (Minecraft "shelter")
-    5. The first prompt in the new shell + what Essex does next
--->
+<section>
+  <h2>Where small business loses ground</h2>
 
-> **Audience:** Variant 1 greenfield (small business not yet on any ERP) ·
-> **Archetype:** Win-11 controller, never opened a terminal, mobile-first ·
-> **Stage:** 1 — first encounter.
+  <div class="pains">
 
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-Hi. A friend told me ESACP could help me get my business onto one piece of software instead of the seven I'm using now. I've got a Windows 11 laptop. Where do I start?
+    <div class="pain">
+      <span class="tag pain-tag">The problem</span>
+      <h3>Your information lives in seven places.</h3>
+      <p>
+        Spreadsheets, the accounting app, marketplace dashboards, email
+        threads, the binder by the printer, a notebook in your pocket.
+        Answering one customer question takes ten minutes because nothing
+        is in one place.
+      </p>
+      <div class="gain">
+        <span class="tag gain-tag">What ESACP changes</span>
+        <p>
+          <strong>One place. Ask in plain English.</strong>
+          ESACP gives you a single source of truth and an AI that reads it
+          for you. The answer comes back in seconds, in business language.
+          Larger competitors have had this since 1995. Now you can too.
+        </p>
+      </div>
+    </div>
+
+    <div class="pain">
+      <span class="tag pain-tag">The problem</span>
+      <h3>Half of every month is the same boring assembly job.</h3>
+      <p>
+        Invoices, monthly reports, AGM packets, quarterly compliance,
+        reminders to chase vendors. The same rituals every period &mdash;
+        they don't add value, but you can't skip them.
+      </p>
+      <div class="gain">
+        <span class="tag gain-tag">What ESACP changes</span>
+        <p>
+          <strong>The boring half runs itself.</strong>
+          Recurring patterns become workflows the system handles. You
+          approve; you don't assemble. The hours come back to the parts
+          of the job you actually do well.
+        </p>
+      </div>
+    </div>
+
+    <div class="pain">
+      <span class="tag pain-tag">The problem</span>
+      <h3>When someone leaves, half your business goes with them.</h3>
+      <p>
+        Years of how-we-do-things lives in one person's head. When they
+        walk out, the institutional memory walks out with them. The next
+        hire takes months to ramp because nothing is written down.
+      </p>
+      <div class="gain">
+        <span class="tag gain-tag">What ESACP changes</span>
+        <p>
+          <strong>What your team knows stays in the system.</strong>
+          Decisions, workflows, vendor preferences &mdash; captured as you
+          work, queryable later. The next hire learns from the system,
+          not from someone's memory.
+        </p>
+      </div>
+    </div>
+
   </div>
-</div>
+</section>
 
-<div class="turn essex">
-  <div class="speaker">Essex</div>
-  <div class="bubble" markdown="1">
-Welcome, Buzz. The first thing we'll do is give your laptop a small, separate Linux room to work in — without touching anything you already have on Windows. The piece of Windows that lets us do this is called **WSL** (Windows Subsystem for Linux); it's free, it's made by Microsoft, and it ships with your laptop already.
+<section>
+  <h2>What ESACP does</h2>
 
-Think of it like adding a clean workbench to your garage. Your existing tools stay where they are; we just put the ESACP work on its own surface so nothing gets mixed up.
+  <p class="intro">
+    ESACP will guide you through the entire process of getting started
+    with ERPNext, on the internet, properly secured and ready to start
+    collecting all your data into a single source of truth.
+  </p>
 
-When you're ready, I'll walk you through the first command.
+  <p class="intro">
+    It's a three-stage process. We don't try to do it all at once
+    &mdash; instead we use a technique anyone who has ever needed to
+    attach a chain to a high beam knows by heart.
+  </p>
+</section>
+
+<section>
+  <h2>How we get there &mdash; the chain on the girder</h2>
+
+  <blockquote class="chain-narrative">
+    To attach a heavy chain to a beam that's far too high, you don't try
+    to throw the chain. It's too heavy and it falls. You throw a
+    <strong>shoe with a string attached</strong>. The string is light,
+    the shoe is easy to throw. Once the shoe is over the beam, you tie
+    the string to a <strong>rope</strong>, and the string pulls the rope
+    up. Then you tie the rope to the <strong>chain</strong>, and the
+    rope pulls the chain up. Each step is easy on its own. Skip any one
+    of them and you fail.
+  </blockquote>
+
+  <div class="stages">
+
+    <div class="stage">
+      <p class="role">Stage 1 &mdash; the shoe on a string</p>
+      <h3>You talk to claude.ai about your business.</h3>
+      <p>
+        You tell it in general terms what your existing setup looks
+        like &mdash; what tools you use, what's painful, what you'd
+        like to be different. It listens, asks short questions, and at
+        the end gives you a written summary of where you stand. The
+        summary is yours; it's also the starting point for stage 2.
+      </p>
+      <p>
+        Light, throwable, no commitment. No software on your machine.
+        No money spent. About ten minutes. At the end you'll know
+        whether ESACP is worth your time.
+      </p>
+    </div>
+
+    <div class="stage">
+      <p class="role">Stage 2 &mdash; the rope</p>
+      <h3>You install ESACP in a safe sandbox on your computer, with Claude Code to guide you.</h3>
+      <p>
+        You bring the ESACP setup down into a controlled space on your
+        own machine &mdash; separate from everything else, fully
+        reversible. Claude Code (Anthropic's developer-focused product)
+        reads your stage-1 summary and walks you through every step
+        toward stage 3.
+      </p>
+      <p>
+        Heavier than stage 1, but still recoverable. If anything goes
+        sideways you back out and try again, without affecting anything
+        else on your computer.
+      </p>
+    </div>
+
+    <div class="stage">
+      <p class="role">Stage 3 &mdash; the chain</p>
+      <h3>Your ERP network controller comes alive.</h3>
+      <p>
+        Your ERPNext system, running on a small set of monitored
+        servers, with ESACP continuously watching the health and
+        productivity of every piece. The data, the workflows, the AI
+        assistance &mdash; all in one place, with the system watching
+        itself.
+      </p>
+      <p>
+        The heavy, valuable, finished thing. What stages 1 and 2 built
+        up to.
+      </p>
+    </div>
+
   </div>
-</div>
+</section>
 
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-Hold on — I already had someone install Ubuntu on this thing last year for a different project. Won't yours wreck that one?
+<section>
+  <h2>Get started &mdash; your first conversation</h2>
+
+  <p>
+    Stage 1 takes about ten minutes. Five steps:
+  </p>
+
+  <div class="steps">
+
+    <div class="step">
+      <div>
+        <h3>Create a free Claude account.</h3>
+        <p>
+          Go to <a href="https://claude.ai">claude.ai</a> and sign up.
+          Takes 30 seconds. Free.
+        </p>
+        <p class="why">
+          Why claude.ai: it's Anthropic's consumer-facing site. The
+          conversation lives on their servers, not yours. Nothing about
+          ESACP touches your machine until stage 2. If you decide ESACP
+          isn't for you, there's nothing to uninstall.
+        </p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div>
+        <h3>Create a new Project. Call it &ldquo;ESACP Onboarding&rdquo;.</h3>
+        <p>
+          In claude.ai's left sidebar, click <strong>Projects</strong>,
+          then <strong>+ New project</strong>.
+        </p>
+        <p class="why">
+          Why a Project: it lets you give Claude permanent instructions
+          that apply to every chat inside it. We use this to tell Claude
+          what kind of conversation to have with you.
+        </p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div>
+        <h3>Paste in the Essex instructions.</h3>
+        <p>
+          Click <strong>Set custom instructions</strong> on your new
+          project. In another browser tab, open
+          <a href="https://raw.githubusercontent.com/martinhbramwell/ESACP/on_boarding/on_boarding/internal_docs/mode_a_persona_v0.md">the
+          Essex instructions document</a>, press <code>Ctrl</code> + <code>A</code>
+          to select everything, then <code>Ctrl</code> + <code>C</code>
+          to copy. Back in the Project, paste into the instructions box.
+          Save.
+        </p>
+        <p class="why">
+          Why these instructions: they turn Claude into Essex &mdash; a
+          guide who knows exactly which questions to ask, in which order,
+          in business language. Without them you'd get general-purpose
+          Claude who doesn't know your context.
+        </p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div>
+        <h3>Start the conversation.</h3>
+        <p>
+          Inside your project, click <strong>New chat</strong>. Type
+          <code>Hi.</code> and send. Essex will take it from there.
+        </p>
+        <p class="why">
+          What to expect: about ten minutes. Essex will ask five to ten
+          short questions about how your business runs today &mdash; no
+          technical questions, no jargon. You answer in plain language.
+        </p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div>
+        <h3>Keep the summary.</h3>
+        <p>
+          When Essex feels you've covered enough ground, you'll get a
+          short summary back, written in business language, with names
+          and numbers anonymized. Save it somewhere you'll find it.
+        </p>
+        <p class="why">
+          What it's for: the summary is yours, and it's also the
+          starting input for stage 2. Claude Code reads it before it
+          starts advising you, so you don't have to tell your story
+          twice.
+        </p>
+      </div>
+    </div>
+
   </div>
-</div>
+</section>
 
-<div class="turn essex">
-  <div class="speaker">Essex</div>
-  <div class="bubble" markdown="1">
-Good catch, and the answer is *no, by design*. WSL lets you run several Linux installations side by side, each with its own name and its own files. We're going to create a brand-new one called **ESACP** and leave your existing Ubuntu completely alone.
-
-Here's the plan, and I'll narrate every step before we run it:
-
-- **What** — install a fresh Ubuntu 24.04, then re-import it under the name `ESACP`.
-- **Why** — a separate name means a separate filesystem. If anything ever goes wrong with the ESACP side, your other Ubuntu is untouched.
-- **Who** — only Microsoft (the WSL feature) and Canonical (the people who make Ubuntu). Nobody else is involved at this step.
-- **Cost** — zero. The disk space comes out of your laptop's drive (around 1.5 GB to start).
-
-Open **PowerShell** — the blue terminal, not the black one — and we'll do it together.
-  </div>
-</div>
-
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-Got it open. Now what?
-  </div>
-</div>
-
-<div class="turn essex">
-  <div class="speaker">Essex</div>
-  <div class="bubble" markdown="1">
-Two commands. The first one downloads Ubuntu 24.04 from Microsoft's catalogue:
-
-```powershell
-wsl --install -d Ubuntu-24.04 --no-launch
-```
-
-The `--no-launch` is intentional — we don't want it to start asking *you* for a username yet. It'll just sit there, ready.
-
-When that finishes (a minute or two), tell me and we'll do the second one.
-  </div>
-</div>
-
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-Done. It said "Ubuntu-24.04 has been installed."
-  </div>
-</div>
-
-<div class="turn essex">
-  <div class="speaker">Essex</div>
-  <div class="bubble" markdown="1">
-Perfect. Now we'll make the ESACP-branded copy. Three lines:
-
-```powershell
-mkdir C:\WSL\ESACP
-wsl --export Ubuntu-24.04 C:\WSL\ESACP\seed.tar
-wsl --import ESACP C:\WSL\ESACP C:\WSL\ESACP\seed.tar --version 2
-```
-
-In plain English: we made a folder, took a snapshot of the fresh Ubuntu you just installed, and registered that snapshot back under the name **ESACP**. You now have a Linux distribution called `ESACP` that is yours.
-
-Type `wsl -l -v` and you should see both `Ubuntu-24.04` and `ESACP` in the list.
-  </div>
-</div>
-
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-There they are. So now I just open the ESACP one?
-  </div>
-</div>
-
-<div class="turn essex">
-  <div class="speaker">Essex</div>
-  <div class="bubble" markdown="1">
-Almost. One more thing first — let's make the ESACP window *look* different from the other one, so you never have to guess which is which. This is a one-time setup in **Windows Terminal** (the app with the multicoloured icon in your Start menu).
-
-Open Windows Terminal, click the **down-arrow** next to the `+` tab, choose **Settings**, then **Open JSON file**. We'll add a profile for ESACP. I'll give you the exact block to paste:
-
-```json
-{
-  "name": "ESACP",
-  "commandline": "wsl.exe -d ESACP",
-  "icon": "🛠️",
-  "tabTitle": "ESACP",
-  "colorScheme": "Tango Dark",
-  "background": "#0f2a1d",
-  "startingDirectory": "//wsl$/ESACP/root"
-}
-```
-
-Save the file. Open a new tab — you'll see **ESACP** in the dropdown, in a deep-green window that's unmistakable.
-
-- **What** — a named, coloured terminal profile for ESACP.
-- **Why** — when you have three windows open and you're tired, the green one is always ESACP. Mistakes get cheaper.
-- **Who** — nobody outside Microsoft. The setting lives in a file on your laptop.
-- **Cost** — free.
-  </div>
-</div>
-
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-That's cute. Green window, ESACP. Got it. What if I mess everything up?
-  </div>
-</div>
-
-<div class="turn essex">
-  <div class="speaker">Essex</div>
-  <div class="bubble" markdown="1">
-That's the best question you've asked yet, and we have a clean answer.
-
-Before we change anything inside the ESACP room, we'll take a **snapshot** — a complete copy of the room as it is right now. If anything goes sideways later, you run one command and you're back to this exact state. Nothing else on your laptop is affected.
-
-Snapshot (run from PowerShell, not from inside ESACP):
-
-```powershell
-wsl --export ESACP C:\WSL\ESACP\snapshots\day-0.tar
-```
-
-Revert, if you ever need to:
-
-```powershell
-wsl --unregister ESACP
-wsl --import ESACP C:\WSL\ESACP C:\WSL\ESACP\snapshots\day-0.tar --version 2
-```
-
-I think of it as the **shelter** in a Minecraft survival world — a safe place you can always return to. An IT consultant would charge you several hundred dollars to set up a backup-and-restore system this clean. We just did it in two lines, and you own it.
-  </div>
-</div>
-
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-OK. Snapshot taken. Now do I go in?
-  </div>
-</div>
-
-<div class="turn essex">
-  <div class="speaker">Essex</div>
-  <div class="bubble" markdown="1">
-Now you go in. Open the green **ESACP** tab in Windows Terminal. You'll see a prompt that looks something like this:
-
-```text
-root@ESACP:~#
-```
-
-You're inside the ESACP room. From here I'll start the actual setup — installing the small set of tools the platform needs (a key manager, a signing utility, GitHub's command-line client, and a couple of others). Every install will get the same *What / Why / Who / Cost* explanation you've seen so far, and you'll click "yes" to each one.
-
-An IT consultant would take weeks to wire up everything we're about to set up, and would charge you accordingly. ESACP has all of it in its training. We'll go through it together at your pace.
-
-When you're ready, type `whoami` and press Enter. We'll start there.
-  </div>
-</div>
-
-<div class="turn buzz">
-  <div class="speaker">Buzz</div>
-  <div class="bubble" markdown="1">
-*[end of static mock — the next turns will come from the real chatbot when the backend lands. See `on_boarding/internal_docs/entry-architecture-notes.md`.]*
-  </div>
-</div>
+<footer class="page-footer">
+  <p>
+    Curious what Essex sounds like once you're past discovery?
+    <a href="essex-demo.html">See a worked example of a stage-2 conversation</a>
+    &mdash; a static walkthrough where Essex helps a small-business
+    owner set up the sandbox on a Windows 11 machine.
+  </p>
+  <p>
+    This is a working prototype. Stage 1 is a proof-of-concept you can
+    try today; stages 2 and 3 are under active construction. The
+    architecture this page seeds is documented in
+    <a href="https://github.com/martinhbramwell/ESACP/blob/on_boarding/on_boarding/internal_docs/entry-architecture-notes.md"><code>internal_docs/entry-architecture-notes.md</code></a>.
+  </p>
+  <p>
+    Source: <a href="https://github.com/martinhbramwell/ESACP">martinhbramwell/ESACP</a> on GitHub.
+  </p>
+</footer>

--- a/on_boarding/runJekyll.sh
+++ b/on_boarding/runJekyll.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$(readlink -f "$0")")/docs"
+
+if [[ ! -d vendor/bundle ]]; then
+  bundle config set --local path vendor/bundle
+  bundle install
+fi
+
+exec bundle exec jekyll serve --livereload


### PR DESCRIPTION
## Summary

Session-8 Sub-branch 2 against agenda [#489](https://github.com/martinhbramwell/ESACP/issues/489). Substantive landing-page sketch for \`on_boarding/docs/\`, prompted by the operator's request to evaluate the v0 Mode-A persona doc *in the context of the page Buzz sees first* — previously absent.

- \`on_boarding/docs/_layouts/landing.html\` (NEW) — minimal content-driven layout
- \`on_boarding/docs/assets/css/landing.scss\` (NEW) — sparse styling, system-serif/sans, ESACP terminal-green accent, white cards on warm off-white, mobile-first responsive grid
- \`on_boarding/docs/index.md\` (REPLACES the Session-5 chat-bubble mock at the same path) — landing page content: hero / three SME pain-point → competitive-advantage transformations / operator-verbatim ESACP intro / chain-on-girder narrative (§11) / three-stage cards / five-step Path-A-via-Project-Instructions getting-started / footer
- \`on_boarding/docs/essex-demo.md\` (NEW path, preserves the Session-5 chat-bubble mock) — cross-linked from the landing page footer as a Mode-B example

## Local view

\`\`\`
cd on_boarding/docs && bundle exec jekyll serve
\`\`\`

Open \`localhost:4000\` for the new landing; \`localhost:4000/essex-demo.html\` for the preserved chat-bubble mock.

## Scope reminder

**Sketch for review, not a final landing page.** Operator will read the v0 Mode-A persona doc against this sketch and decide:
- Merge as the base (Task 4 / iteration #1 then resumes against this context)
- Iterate copy or structure first (more sub-branches before iteration #1)
- Revise the persona doc itself in light of how it reads against the landing-page handoff

Per \`project_prototype_phase_scope\` memory: prototype-phase content. Production-grade copy editing, diagrams, video are deferred.

## Test plan

- [ ] Operator runs \`bundle exec jekyll serve\` from \`on_boarding/docs/\` and views the new landing page at \`localhost:4000\`
- [ ] Re-reads \`on_boarding/internal_docs/mode_a_persona_v0.md\` while imagining a small-business owner who just clicked through this landing page — do persona-doc turn 1 + landing-page footer flow together?
- [ ] Five-step Get Started reads as actionable for a low-tech-comfort owner-operator
- [ ] Three pain-points land as recognizable, not generic
- [ ] Chain-on-girder narrative paragraph is concrete enough to anchor

## References

- Agenda: [#489](https://github.com/martinhbramwell/ESACP/issues/489)
- Sub-branch issue: fixes [#499](https://github.com/martinhbramwell/ESACP/issues/499)
- Architectural rewrite of dead §10.2: [#497](https://github.com/martinhbramwell/ESACP/issues/497) (this sketch already implements the working alternative — Path-A-via-Project-Instructions — in the get-started flow)
- Canonical chain metaphor source: \`on_boarding/internal_docs/entry-architecture-notes.md\` §11
- Voice contract for everything user-facing: \`on_boarding/BUZZ_PERSPECTIVE.md\` (five-point contract: control, visibility/W-W-W-C, anchoring, tone, signup-honesty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)