### PR TITLE
chore(pipeline): align _run_r1 / _run_r3 invocation — bench venv + sudo + sites/ cwd (#503)

### DIFF
--- a/tools/pipeline/orchestration/test_v16_post_migrate_fixups.py
+++ b/tools/pipeline/orchestration/test_v16_post_migrate_fixups.py
@@ -45,7 +45,7 @@ def test_both_fresh_apply_sets_changed():
     assert "home=created" in result.message and "disabled=1" in result.message
     cmds = [c.args[1] for c in s.call_args_list]
     assert all(s in cmds[0] for s in ("r1_recreate_web_page_home.py", "sudo -u erpadm", "/sites &&"))
-    assert "r3_disable_irs_1099_pf.py" in cmds[1]
+    assert all(s in cmds[1] for s in ("r3_disable_irs_1099_pf.py", "sudo -u erpadm", "/sites &&"))
 
 
 def test_both_idempotent_skip_no_change():

--- a/tools/pipeline/orchestration/v16_post_migrate_fixups.py
+++ b/tools/pipeline/orchestration/v16_post_migrate_fixups.py
@@ -40,8 +40,13 @@ def _run_r1(config: Config, emit: Emit) -> TaskResult:
 
 
 def _run_r3(config: Config, emit: Emit) -> TaskResult:
-    cmd = (f"python3 {R3_SCRIPT} --bench-dir {config.bench_dir} "
-           f"--site {config.site_url}")
+    # Same invocation shape as _run_r1 (#503): bench venv + sudo + cwd at
+    # sites/ even though R3 only does raw mysql today — prevents the silent
+    # venv-mismatch trap if a future R3 edit (or copy-paste descendant)
+    # adds Frappe imports.
+    cmd = (f"sudo -u {config.erp_user} bash -c 'cd {config.bench_dir}/sites "
+           f"&& {config.bench_dir}/env/bin/python {R3_SCRIPT} "
+           f"--bench-dir {config.bench_dir} --site {config.site_url}'")
     return run_fix_script(config, emit, "R3", cmd,
                           R3_EXPECTED, R3_CHANGED_MARKER)
 

--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -107,7 +107,7 @@
   "tools/pipeline/orchestration/test_hub_seed_iso.py": 57,
   "tools/pipeline/orchestration/test_substrate_apply.py": 80,
   "tools/pipeline/orchestration/test_v16_post_migrate_fixups.py": 70,
-  "tools/pipeline/orchestration/v16_post_migrate_fixups.py": 62,
+  "tools/pipeline/orchestration/v16_post_migrate_fixups.py": 67,
   "tools/pipeline/orchestration/verify_build_vm.py": 80,
   "tools/pipeline/orchestration/verify_vpn.py": 77,
   "tools/pipeline/orchestration/virsh.py": 15,


### PR DESCRIPTION
## Summary

Aligns `_run_r3` invocation shape with `_run_r1` in
`tools/pipeline/orchestration/v16_post_migrate_fixups.py`. Both fix-script
runners now use `sudo -u $ERP_USER bash -c 'cd $BENCH_DIR/sites && $BENCH_DIR/env/bin/python $SCRIPT ...'` regardless of whether the specific script imports Frappe today.

## Context

S83 (PR#502, #486) landed R1 and surfaced an invocation asymmetry: R3 was using bare `python3` (system Python) while R1 needed bench venv + sudo + cwd at `sites/`. R3 worked today because its script only does raw `mysql -e` — but the asymmetry is silent. A future R3 edit that imports Frappe (or a copy-paste descendant that does) would fail the same way R1 hit during S83 acceptance: `ImportError` or `FileNotFoundError` on the relative `../logs/database.log` path.

## Changes

- `_run_r3` cmd string rewritten to match `_run_r1` (bench venv + sudo + sites/ cwd) with a comment naming the WHY (#503).
- Test `test_both_fresh_apply_sets_changed` extended to assert R3 cmd also contains `sudo -u erpadm` and `/sites &&` (was only asserting on R1 before).
- `tools/size_baselines.json` bumped for `v16_post_migrate_fixups.py` 62 → 67 (documentation + cmd-string lengthening; still well under the 80-line pipeline cap).

## Test plan

- [x] `pytest tools/pipeline/orchestration/test_v16_post_migrate_fixups.py -v` — 5/5 green
- [x] `python3 tools/pre_commit_size_check.py` — clean after baseline bump
- [x] `./tools/esacp.py applyV16PostMigrateFixups dev02` — R1 probe=home=present + R3 probe=disabled=1, both idempotent (no-op on already-applied state)

## Parent

Child of #480 (V13→V16 re-migration umbrella). Closes the latent risk flagged by esacp-qa at S83 PR#502 close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)