### PR TITLE
feat(ci): GitHub Pages workflow — Jekyll build on_boarding/docs/ + raw-serve persona doc (#505)

### DIFF
--- a/.github/workflows/jekyll-pages.yml
+++ b/.github/workflows/jekyll-pages.yml
@@ -1,0 +1,68 @@
+name: Jekyll Pages (on_boarding)
+
+# Builds the Jekyll landing page under on_boarding/docs/ and stages the
+# Mode-A persona doc as a raw .md alongside the built site, then deploys
+# to GitHub Pages. Per ESACP#505 (unblocks #497 — persona-doc raw-serve
+# moved from gist.githubusercontent.com after robots.txt block).
+#
+# Baseurl handling: Option A from #505 — local _config.yml stays at
+# baseurl: "" for ergonomic localhost serve; CI builds with the flag.
+
+on:
+  push:
+    branches:
+      - on_boarding
+    paths:
+      - 'on_boarding/docs/**'
+      - 'on_boarding/internal_docs/mode_a_persona_v0.md'
+      - '.github/workflows/jekyll-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: on_boarding/docs
+
+      - name: Build site
+        working-directory: on_boarding/docs
+        run: bundle exec jekyll build --baseurl "/ESACP"
+
+      - name: Stage persona doc alongside site
+        run: |
+          install -d on_boarding/docs/_site/persona
+          install -m 0644 on_boarding/internal_docs/mode_a_persona_v0.md \
+                          on_boarding/docs/_site/persona/mode_a_v0.md
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: on_boarding/docs/_site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds `.github/workflows/jekyll-pages.yml`. Builds the Jekyll landing page under `on_boarding/docs/` with `--baseurl "/ESACP"` (Option A from #505 — keeps the shipped `_config.yml` at `baseurl: ""` so localhost serve stays ergonomic), stages `on_boarding/internal_docs/mode_a_persona_v0.md` alongside the built site at `_site/persona/mode_a_v0.md`, then deploys via the two-job Pages idiom (`actions/upload-pages-artifact@v3` → `actions/deploy-pages@v4`).

Unblocks the persona-doc-raw-serve half of #497 (gist.githubusercontent robots.txt block — GitHub Pages has no equivalent block).

Refs #505.

## Trigger topology — known gap, propagation by routine sync

The push trigger watches the `on_boarding` branch (paths: `docs/**`, `internal_docs/mode_a_persona_v0.md`, and this workflow file itself). GitHub Actions reads workflows from the branch receiving the push, so auto-trigger is **inert until this file reaches `on_boarding` via the next routine `main → on_boarding` sync** (Junior-side, per the issue's Follow-on section). `workflow_dispatch` is included for manual fires once that propagation has happened.

## Why no `fixes #505`

Issue stays open per [`feedback_no_downstream_of_merge_acceptance.md`](https://github.com/martinhbramwell/LogiSoluMemory/blob/main/feedback_no_downstream_of_merge_acceptance.md) — full AC requires:

- Operator flipping **Settings → Pages → Source: GitHub Actions** (post-merge operator action).
- First workflow run after Junior's next `on_boarding` sync confirms the persona doc serves at `https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md` (200 + `text/markdown`).

Both are post-merge steps Junior will close out in the next `on_boarding` session.

## Test plan

- [x] T1 pre-commit verdict (approve-with-conditions; both conditions addressed in commit body)
- [x] T3 pre-push verdict (approve)
- [ ] T2 pre-merge verdict (this PR, before merge)
- [ ] Operator flips Pages source to "GitHub Actions" (post-merge, manual)
- [ ] Junior next session: routine `main → on_boarding` sync brings the workflow file to `on_boarding`
- [ ] Junior pushes a touching edit (or fires `gh workflow run jekyll-pages.yml --ref on_boarding`); workflow runs green
- [ ] `curl -sI https://martinhbramwell.github.io/ESACP/` → 200
- [ ] `curl -sI https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md` → 200 + `content-type: text/markdown…`
- [ ] Junior closes #505 + #497 after iteration #1 result

🤖 Generated with [Claude Code](https://claude.com/claude-code)