### PR TITLE
fix(pipeline): R1 homepage content_type Page Builder->Rich Text — renders salvaged content (#456)

### DIFF
--- a/tools/vm_scripts/r1_recreate_web_page_home.py
+++ b/tools/vm_scripts/r1_recreate_web_page_home.py
@@ -19,8 +19,7 @@ TEMPLATE = (
     '    <div class="col-md-12 text-center">\n'
     '      <h1 class="display-4">{company}</h1>\n'
     '      <h3 class="text-muted my-4">{tag_line}</h3>\n'
-    '      <p class="lead">{description}</p>\n'
-    '    </div>\n  </div>\n</div>'
+    '      <p class="lead">{description}</p>\n    </div>\n  </div>\n</div>'
 )
 
 
@@ -63,7 +62,8 @@ def main():
         "title": company,
         "route": HOME_ROUTE,
         "published": 1,
-        "content_type": "Page Builder",
+        # "Rich Text" renders main_section; "Page Builder" => blank (#456)
+        "content_type": "Rich Text",
         "main_section": main_section,
     })
     doc.insert(ignore_permissions=True)


### PR DESCRIPTION
## #456 — V13→V16 website-root regression (R1 follow-on)

The R1 fix-script (#486, #480 umbrella) resolved the homepage **HTTP 404** by creating a `Web Page route='home'`, but set `content_type='Page Builder'`. In Page-Builder mode frappe renders from the empty web-page-block table and **ignores `main_section`** — so `/` returned 200 with a **blank `<main>`**. Browser verification (not curl) surfaced this; HTTP 200 alone masked it.

### Fix
One field: `content_type` `'Page Builder'` → `'Rich Text'`. Confirmed against V16 source (`frappe/website/utils.py:get_html_content_based_on_type`): only 'HTML'/'Markdown' read `main_section_html`/`_md`; everything else reads `main_section` (which the script already populates). Idempotent skip-if-exists preserved (never clobbers operator customization).

### Acceptance (browser, sub-rule #2 / #473 lesson)
- Deleted dev02's stale Page-Builder artifact → re-ran `applyV16PostMigrateFixups dev02` (exercises fresh create-path) → `[PROBE] home=created`.
- `https://dev02.iridium.blue/` → **HTTP 200**, body 10211→10679 bytes, `display-4`+`lead` markers present.
- **Screen-verified**: `<main>` now renders company name (H1), tag-line (H3), description (lead). Previously blank.

Reconstruction from salvaged singleton data, not pixel-parity with V13's richer original (by R1 design).

### QA
esacp-qa T1 pre-commit: `approve-with-conditions` (hard_block false) → all 3 conditions met (staged; trimmed 84→80 = baseline, no size_baselines change; staged size check exit 0).

fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)