### PR TITLE
feat(on_boarding): publish updated landing page (#537)

### DIFF
--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -1,143 +1,157 @@
 ---
 layout: landing
-title: "Run your whole business from one screen, with AI as your guide"
+title: "ESACP — Turn scattered business operations into one understandable system"
 description: >-
-  ESACP — the ERP System Administrator Control Panel — helps a
-  family-owned business move from a half-dozen tools to one ERP
-  system, in three guided stages, without needing a developer on
-  staff. Built for owner-operated businesses with 5 to 50 employees.
+  ESACP helps owner-operated SMEs move gradually from spreadsheets,
+  QuickBooks, Zoho, email, binders, and tribal knowledge toward one
+  coherent open-source business system, with AI-guided setup and
+  human engineering judgment built in.
 ---
 
 <section data-panel="problem" id="problem">
 
 <header class="hero">
   <p class="brand-tag">ESACP &mdash; the ERP System Administrator Control Panel</p>
-  <h1>Run your whole business from one screen.</h1>
+  <h1>You already do ERP.<br>But is it <i>systematic</i> ERP?</h1>
   <p class="tagline">
-    Move off the spreadsheets, the accounting app, and the binder by the
-    printer &mdash; onto one open-source business system, with AI guiding
-    you through every step.
+    You already <strong>P</strong>lan allocation of your scarce <strong>E</strong>nterprise <strong>R</strong>esources,
+    but where's the info?  Spreadsheets, QuickBooks, Zoho, email threads, notebooks, shared folders, <strong>everyone's heads?</strong>
+  </p>
+  <p class="tagline">
+    The data is there. The connecting tissue isn't.
+  </p>
+  <p class="tagline">
+    ESACP is a guided path from that scattered reality toward one coherent 
+    source of truth for the whole business &mdash; introduced gradually,
+    explained clearly, and designed so the company does not become dependent
+    on one technical person forever.
   </p>
   <p class="audience-filter">
-    Built for owner-operated businesses with 5&ndash;50 employees that
-    have outgrown spreadsheets but aren't big enough for SAP.
+    Built for owner-operators who've outgrown ad-hoc tools but can't justify commercial packages and an IT department.
   </p>
   <p class="hero-cta">
-    <a href="#start" class="cta-primary">See how it starts &mdash; 10 minutes, free &rsaquo;</a>
-    <a href="#catch" class="cta-secondary">Or read the catches first &rsaquo;</a>
+    <a href="#start" class="cta-primary">Start with the 10-minute discovery step &rsaquo;</a>
+    <a href="#catch" class="cta-secondary">Read the catches first &rsaquo;</a>
   </p>
 </header>
 
-<h2>Three problems every small business owner knows</h2>
+<h2>The familiar mess that quietly becomes risk</h2>
 
 <div class="pains pains-problem">
 
   <div class="pain">
     <span class="tag pain-tag">Information sprawl</span>
-    <h3>Your information lives in a half dozen places.</h3>
+    <h3>The business exists in too many places.</h3>
     <p>
-      Spreadsheets, the accounting app, marketplace dashboards, email
-      threads, the binder by the printer, a notebook in your pocket.
-      Answering one customer question takes ten minutes because nothing
-      is in one place.
+      Quotes in one file. Orders in another. Accounting in QuickBooks.
+      Customer promises in email. Inventory in a spreadsheet that only one
+      person trusts. Answering a simple question becomes a small investigation.
     </p>
   </div>
 
   <div class="pain">
-    <span class="tag pain-tag">Repetitive admin</span>
-    <h3>Half of every month is the same assembly job.</h3>
+    <span class="tag pain-tag">Manual repetition</span>
+    <h3>Every month repeats the same assembly job.</h3>
     <p>
-      Invoices, monthly reports, AGM packets, quarterly compliance,
-      reminders to chase vendors. The same rituals every period &mdash;
-      they don't add value, but you can't skip them.
+      Invoices, reminders, reports, compliance packets, vendor follow-ups,
+      stock checks. The work is predictable enough to be structured, but it
+      still gets rebuilt by hand because the tools do not talk to each other.
     </p>
   </div>
 
   <div class="pain">
     <span class="tag pain-tag">Tribal knowledge</span>
-    <h3>When someone leaves, business knowledge goes with them.</h3>
+    <h3>One person becomes the operating manual.</h3>
     <p>
-      Years of "how-we-do-things" lives in one person's head. When they
-      walk out, the institutional memory walks out with them. The next
-      hire takes months to ramp up because nothing is written down.
+      A manager, bookkeeper, consultant, or developer slowly becomes the only
+      person who understands how the business really runs. If they leave, the
+      business does not just lose labour. It loses memory.
     </p>
   </div>
 
 </div>
 
-<p class="panel-cue">Recognise any of these? <a href="#why" class="panel-cue-link">See how ESACP fixes them &rsaquo;</a></p>
+<p class="panel-cue">Recognise the pattern? <a href="#why" class="panel-cue-link">See what ESACP changes &rsaquo;</a></p>
 
 </section>
 
 <section data-panel="why" id="why">
 
-<h2>What changes when everything lives in one place</h2>
+<h2>What changes when operations become understandable</h2>
 
 <p class="intro">
-  ESACP is a guided setup for ERPNext &mdash; the open-source business
-  system that runs everything from manufacturing to invoicing to
-  inventory. What makes ESACP work isn't the AI alone; it's the
-  pairing of two things most &ldquo;AI for business&rdquo; pitches
-  have only one of:
+	You hear wild stories about AI, both bad and good.  You can try to "vibe-code" your own ERP system, but AI has no <b>authentic</b> understanding of what it's doing.  <b>Will you?</b> Also, why re-invent the wheel? ESACP brings four decades of tight budget, big systems expertise towards training an AI to be <strong>your private, personal 24/365 ERP systems consultant</strong>.
 </p>
 
 <ul class="pairing-list">
   <li>
-    <strong>AI&rsquo;s knowledge and speed</strong> &mdash; vast,
-    instant, no fatigue, no &ldquo;I&rsquo;ll check Monday.&rdquo;
+    <strong>AI brings speed and patience</strong> &mdash; you can ask it structured
+    questions, it'll remember the answers, explain unfamiliar concepts, and help turn
+    messy descriptions into a usable operating picture.
   </li>
   <li>
-    <strong>Forty years of human judgment</strong> at the highest
-    systems-architecture standards &mdash; knowing what to automate
-    and what <em>not</em> to, where the safety nets go, what should
-    fail loudly and what should fail quietly.
+    <strong>Human engineering judgment decides what's best</strong> &mdash; what to
+    automate, what not to automate, where backups belong, what must fail loudly,
+    and where the business owner must remain in control.
   </li>
 </ul>
 
+<hr/>
+
+
 <p class="intro">
-  The AI types fast and remembers everything. The human design
-  decides what happens at 11pm on a Friday when something breaks.
-  ESACP needs both &mdash; that&rsquo;s why it works, and why it
-  isn&rsquo;t a chatbot bolted onto an ERP.
+  Work on ESACP began in a real family-owned biochemical factory ... ordinary small enterprise reality: operational
+  knowledge scattered across accounting software, spreadsheets, documents,
+  regulatory obligations, custom processes, and people&rsquo;s heads.
 </p>
+<p class="comment">It isn't a magic chatbot and it's not another dollars/user/month SaaS.</p>
+
+<h3>It's a guided adoption framework around a free and open-source (FOSS) business system called ERPNext.</h3>
+
+<p class="intro">
+  ERPNext will handle your sales, purchasing, inventory, manufacturing, accounting, service,
+  HR, and much more in one fully integrated platform.  It can connect: complaint -> customer -> sales invoice -> sold item -> its defect -> its manufacturing step -> its component part -> purchase invoice -> supplier.
+</p>
+
+<p class="intro">
+	The embedded AI can explore a chain like that and tell you in plain language what happened and why ... but that's just one example.
+</p>
+
 
 <div class="pains pains-gain">
 
   <div class="pain">
-    <span class="tag gain-tag">One source of truth</span>
-    <h3>Ask, in plain English, about anything.</h3>
+    <span class="tag gain-tag">Clarity</span>
+    <h3>Ask plain business questions.</h3>
     <p>
-      Type <em>"Who hasn't paid us yet?"</em> and get the list of
-      overdue invoices in two seconds. Type <em>"What did we ship to
-      Acme last month?"</em> and get the answer in business language,
-      not in SQL. One question, one place, one answer.
+      Instead of hunting through disconnected tools, the business moves toward one
+      place where orders, invoices, customers, inventory, and workflows can be seen
+      and queried in plain language.
     </p>
   </div>
 
   <div class="pain">
-    <span class="tag gain-tag">Workflows, not assembly</span>
-    <h3>The repetitive half runs itself.</h3>
+    <span class="tag gain-tag">Structure</span>
+    <h3>Turn repeated work into workflows.</h3>
     <p>
-      Invoicing, reminders, monthly packets, compliance &mdash; the
-      patterns the system can recognise, the system handles. You
-      approve; you don't assemble. The hours come back to the parts of
-      the job you actually do well.
+      The recurring admin work does not disappear by wishful thinking. It becomes
+      defined, visible, repeatable, and eventually automatable where automation is safe.
     </p>
   </div>
 
   <div class="pain">
-    <span class="tag gain-tag">Memory that stays</span>
-    <h3>What your team knows stays in the system.</h3>
+    <span class="tag gain-tag">Continuity</span>
+    <h3>Keep business memory inside the system.</h3>
     <p>
-      Decisions, workflows, vendor preferences &mdash; captured as you
-      work, queryable later. The next hire learns from the system, not
-      from someone's memory.
+      Decisions, procedures, preferences, and operating rules become documented as
+      the business works. The next person learns from the system, not from a panic tour
+      through somebody else&rsquo;s memory.
     </p>
   </div>
 
 </div>
 
-<p class="panel-cue"><a href="#how" class="panel-cue-link">Curious how it actually gets installed? &rsaquo;</a></p>
+<p class="panel-cue"><a href="#how" class="panel-cue-link">How do you get there without blowing up Monday morning? &rsaquo;</a></p>
 
 </section>
 
@@ -148,66 +162,69 @@ description: >-
 <p>An analogy first:</p>
 
 <blockquote class="chain-narrative">
-  To attach a heavy chain to a beam that's far too high, you don't try
-  to throw the chain. It's too heavy and it falls. You throw a
-  <strong>shoe with a string attached</strong>. The string is light,
-  the shoe is easy to throw. Once the shoe is over the beam, you tie
-  the string to a <strong>rope</strong>, and the string pulls the rope
-  up. Then you tie the rope to the <strong>chain</strong>, and the
-  rope pulls the chain up. Each step is easy on its own. Skip any one
-  of them and you fail.
+  To get a heavy chain over a high beam, you don't throw the chain first.
+  You throw a <strong>shoe with a string attached</strong>. The shoe is light
+  enough to succeed. The string pulls a <strong>rope</strong>. The rope pulls
+  the <strong>chain</strong>. Each step is manageable. Skip the light steps and
+  the heavy step becomes an awful headache.
 </blockquote>
 
-<p>That's how we set ESACP up &mdash; light step, medium step, full system.</p>
+<p>
+  ESACP uses the same idea. It does not begin by replacing your business system.
+  It begins by understanding the one you already have, even if that system is
+  currently scattered across half a dozen tools and two people&rsquo;s memories.
+</p>
 
 <div class="stages">
 
   <div class="stage">
     <p class="role">Stage 1 &mdash; the shoe on a string</p>
-    <h3>Ten minutes talking to Claude about your business.</h3>
+    <h3>A short AI-guided discovery conversation.</h3>
     <p>
-      You tell it in general terms what your existing setup looks like
-      &mdash; what tools you use, what's painful, what you wish was
-      different. It listens, asks short questions, and at the end gives
-      you a written summary of where you stand. The summary is yours;
-      it's also the starting point for stage 2.
+			We want to guide you towards installing ESACP in a safe, fenced-off sandbox on one of your computers.
+		</p>
+    <p>
+	    The goal is clear and simple - figure out the best way to get you started using the computing power you already have and how confident you are in exploiting it.  So ...
+    </p>
+    <p>
+    ... you and the AI discuss your current computing capabilities in general terms, <strong>no specifics!</strong> 
+    </p>
+    <p>
+          How many computers do you control?  How many run Windows? MacOS? or Linux? Do you understand virtual machines
+  like Hyper-V, VMWare or similar?  Do you already have an Internet presence.  Does your hosting service permit installing and
+  running your own programs?
     </p>
     <p class="comment">
-      Light, throwable, no commitment. No software on your machine. No
-      money spent. About ten minutes. At the end you'll know whether
-      ESACP is worth your time.
+      No installation. No commitment. No disruption. The summary is useful even
+      if you go no further.
     </p>
   </div>
 
   <div class="stage">
     <p class="role">Stage 2 &mdash; the rope</p>
-    <h3>A test version of ESACP on your own computer, with AI as your guide.</h3>
+    <h3>A safe local test environment.</h3>
     <p>
-      The test version installs like any other app &mdash; it lives in
-      its own folder, doesn't touch the rest of your computer, and
-      deletes cleanly when you want it gone. Claude Code (Anthropic's
-      developer tool) reads your stage-1 summary and walks you through
-      every step toward stage 3, in plain English.
+      A test version of ESACP and ERPNext is introduced in an isolated environment,
+      with AI guidance explaining what is happening and why. The purpose is not to
+      rush migration. The purpose is to let the business see structure before risking operations.
     </p>
     <p class="comment">
-      Still recoverable. If anything looks wrong you back out and try
-      again. Nothing else on your computer is affected.
+      Reversible by design. If it does not make sense, you stop before anything
+      business-critical depends on it.
     </p>
   </div>
 
   <div class="stage">
     <p class="role">Stage 3 &mdash; the chain</p>
-    <h3>Your real business runs on it.</h3>
+    <h3>A real operating system for the business.</h3>
     <p>
-      Monday morning, you open one browser tab. You see today's open
-      quotes, overdue invoices, low-stock alerts, pending approvals
-      &mdash; on one dashboard, not seven. New orders come in through
-      that same system. The AI keeps watch on the back end, flags
-      anything odd, and tells you what changed overnight.
+      Selected business functions move into ERPNext: customers, orders, inventory,
+      invoicing, workflows, reports, and the operating knowledge needed to keep them
+      reliable. ESACP adds the surrounding guidance, documentation, monitoring, and recovery discipline.
     </p>
     <p class="comment">
-      The full system, on a small hosting bill. What stages 1 and 2
-      built up to.
+      The goal is not fashionable software. The goal is a business that can be
+      understood, maintained, and handed on.
     </p>
   </div>
 
@@ -222,7 +239,7 @@ description: >-
 <h2>Get started &mdash; your first conversation</h2>
 
 <p>
-  Stage 1 is five steps, about twelve minutes total. Free.
+  Stage 1 is deliberately small: about ten to twelve minutes, free, and useful on its own.
 </p>
 
 <div class="steps">
@@ -235,26 +252,23 @@ description: >-
         Go to <a href="https://claude.ai">claude.ai</a> and sign up.
       </p>
       <p class="why">
-        Why claude.ai: it's Anthropic's consumer site. The conversation
-        lives on their servers, not yours. Nothing about ESACP touches
-        your machine until stage 2. If you decide ESACP isn't for you,
-        there's nothing to uninstall.
+        Why claude.ai: it gives you a simple place to run the first discovery
+        conversation. Nothing about ESACP touches your computer in stage 1.
       </p>
     </div>
   </div>
 
   <div class="step">
     <div>
-      <h3>Create a Project. Call it &ldquo;ESACP Onboarding&rdquo;.</h3>
+      <h3>Create a Project. Call it &ldquo;ESACP Discovery&rdquo;.</h3>
       <p class="time-hint">~30 seconds</p>
       <p>
-        In claude.ai's left sidebar, click <strong>Projects</strong>,
-        then <strong>+ New project</strong>.
+        In claude.ai&rsquo;s left sidebar, click <strong>Projects</strong>, then
+        <strong>+ New project</strong>.
       </p>
       <p class="why">
-        Why a Project: it lets you give Claude permanent instructions
-        that apply to every chat inside it. We use this to tell Claude
-        what kind of conversation to have with you.
+        Why a Project: it lets the advisor keep the right role and instructions
+        throughout the conversation instead of drifting into generic chatbot advice.
       </p>
     </div>
   </div>
@@ -264,19 +278,18 @@ description: >-
       <h3>Invite the ESACP advisor into the chat.</h3>
       <p class="time-hint">~10 seconds</p>
       <p>
-        Inside your new project, click <strong>New chat</strong>. In
-        the message box, paste this one line and press <strong>Send</strong>:
+        Inside your new project, click <strong>New chat</strong>. In the message
+        box, paste this one line and press <strong>Send</strong>:
       </p>
       <blockquote class="chain-narrative">
         Claude, please read from this link
-        <code>https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md</code> and take on the
-        ESACP advisor role as it explains.
+        <code>https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md</code>
+        and take on the ESACP advisor role as it explains.
       </blockquote>
       <p class="why">
-        What this does: the link points to a public page that tells
-        Claude how the ESACP discovery conversation works and which
-        questions to ask. Without it you'd get general-purpose Claude,
-        who doesn't know your context.
+        What this does: the link tells Claude how the ESACP discovery conversation
+        works and which questions to ask. Without it you get general-purpose Claude,
+        which is helpful but not focused on this process.
       </p>
     </div>
   </div>
@@ -286,14 +299,13 @@ description: >-
       <h3>Answer in plain language.</h3>
       <p class="time-hint">~5&ndash;10 minutes</p>
       <p>
-        Within a few seconds, Claude will reply and ask a first
-        question or two about your business. Type your answer normally
-        and send.
+        The advisor will ask short questions about how your business runs today:
+        the tools you use, where information is duplicated, where work gets stuck,
+        and what would hurt if one key person were unavailable.
       </p>
       <p class="why">
-        What to expect: five to ten short questions about how your
-        business runs today &mdash; no technical questions, no jargon.
-        Use whatever words you'd use with a colleague.
+        No technical vocabulary is required. Use the same words you would use with
+        a sensible colleague over coffee.
       </p>
     </div>
   </div>
@@ -303,15 +315,12 @@ description: >-
       <h3>Keep the summary.</h3>
       <p class="time-hint">~30 seconds</p>
       <p>
-        When the advisor feels you've covered enough ground, you'll get
-        a short written summary, in business language, with names and
-        numbers anonymised. Save it somewhere you'll find it.
+        At the end, you receive a short written summary of your current operating
+        picture, in business language. Save it somewhere you can find it.
       </p>
       <p class="why">
-        What it's for: the summary is yours, and it's also the
-        starting input for stage 2. Claude Code reads it before it
-        starts advising you, so you don't have to tell your story
-        twice.
+        The summary is yours. It is also the starting input for stage 2, so you do
+        not have to explain the same business twice.
       </p>
     </div>
   </div>
@@ -320,25 +329,24 @@ description: >-
 
 <div class="essex-demo-note">
   <p>
-    <strong>Stage 1 done.</strong> Your summary in hand is the
-    deliverable.
+    <strong>Stage 1 done.</strong> Your summary is the deliverable.
   </p>
   <p>
-    Stage 2 &mdash; installing ESACP on your own computer with
-    Claude Code as your guide &mdash; is under active construction.
-    The self-serve walkthrough will land on this page when it's ready.
+    Stage 2 &mdash; installing a safe local ESACP test environment with Claude Code
+    as your guide &mdash; is under active construction. The self-serve walkthrough
+    will land on this page when it is ready.
   </p>
   <p>
-    <strong>Want a human first?</strong> If you'd rather talk to a
-    person before installing anything, email your stage-1 summary to
+    <strong>Want a human first?</strong> If you would rather talk before installing
+    anything, email your stage-1 summary to
     <a href="mailto:mhb.warehouseman@gmail.com">mhb.warehouseman@gmail.com</a>
-    and we'll walk you through stage 2 personally. Or
-    <a href="https://github.com/martinhbramwell/ESACP">watch the
-    GitHub repo</a> to track progress.
+    and we can walk through the next step. Or
+    <a href="https://github.com/martinhbramwell/ESACP">watch the GitHub repo</a>
+    to track progress.
   </p>
 </div>
 
-<p class="panel-cue"><a href="#catch" class="panel-cue-link">Before you start &mdash; what's the catch? &rsaquo;</a></p>
+<p class="panel-cue"><a href="#catch" class="panel-cue-link">Before you start &mdash; what&rsquo;s the catch? &rsaquo;</a></p>
 
 </section>
 
@@ -347,90 +355,79 @@ description: >-
 <h2>What&rsquo;s the catch?</h2>
 
 <p class="intro">
-  Honest version, up front. No marketing tricks &mdash; if any of these
-  are dealbreakers for you, better to know now than three weeks in.
+  The honest version, up front. If any of these are dealbreakers, better to know
+  before anyone wastes time pretending software projects are powered by optimism and conference badges.
 </p>
 
 <div class="caveats">
 
   <div class="caveat">
-    <span class="tag caveat-tag">Heads up</span>
-    <h3>This is a working prototype.</h3>
+    <span class="tag caveat-tag">Maturity</span>
+    <h3>This is an evolving prototype, not a polished SaaS product.</h3>
     <p>
-      Stage 1 (the claude.ai conversation) is something you can
-      genuinely try today. Stages 2 and 3 are under active construction
-      &mdash; the architecture is decided, the parts are being built,
-      and the design is documented openly. You're early. That's the
-      deal: in exchange for being a guinea pig, you get a direct line
-      to the people building it.
+      Stage 1 is usable today. Stages 2 and 3 are being built from real operational
+      work and public design notes. Early users get more influence and more direct
+      help, but also less polish than they would get from a finished commercial platform.
+    </p>
+  </div>
+
+  <div class="caveat">
+    <span class="tag caveat-tag">Scope</span>
+    <h3>ESACP does not replace business judgment.</h3>
+    <p>
+      The AI can ask better questions, organise messy answers, explain unfamiliar
+      systems, and guide setup steps. It should not make business decisions for you.
+      Owners still decide what matters, what changes, and what risk is acceptable.
     </p>
   </div>
 
   <div class="caveat">
     <span class="tag caveat-tag">Cost</span>
-    <h3>Stage 1 is free. Stages 2 and 3 are about $30&ndash;$50 a month, all-in.</h3>
+    <h3>The first conversation is free. Real operation has real costs.</h3>
     <p>
-      Stage 1 uses the free claude.ai tier &mdash; you'll bump into its
-      message limits eventually, but a discovery conversation fits
-      comfortably inside them. Stage 2 needs Claude Code (Anthropic's
-      developer tool), about $20 a month &mdash; same ballpark as a
-      Netflix subscription, and cancellable any time. Stage 3 adds
-      hosting for your real system &mdash; comparable to a Squarespace
-      or Shopify monthly bill, in the $10&ndash;$30 range depending on
-      size. Both bills are monthly, both cancellable, and the amounts
-      only run while you're actually using the thing.
-    </p>
-    <p>
-      <strong>All-in:</strong> expect roughly $30&ndash;$50 a month
-      once you're in production. Less than a phone line.
+      Stage 1 can be tried with a free Claude account. Later stages may require
+      Claude Code, hosting, backups, and occasional human help. The target is around 
+      100 bucks a month all included, once the system becomes real.
     </p>
   </div>
 
   <div class="caveat">
     <span class="tag caveat-tag">Privacy</span>
-    <h3>We&rsquo;d like to learn from your conversation. You decide.</h3>
+    <h3>You decide what to share.</h3>
     <p>
-      When the advisor hands you the stage-1 summary, you can voluntarily
-      share the transcript with us to help improve the next version.
-      It's anonymised before it leaves your screen. Saying no is fine;
-      nothing in stage 2 or 3 depends on it.
+      The discovery conversation will try to avoid any sensitive details. A summary
+      will be anonymised and shared voluntarily to improve the process. Saying no is fine;
+      the system should not depend on harvesting your business secrets like some Silicon Valley raccoon.
     </p>
   </div>
 
   <div class="caveat">
     <span class="tag caveat-tag">Lock-in</span>
-    <h3>You can leave with everything.</h3>
+    <h3>The direction is ownership, not hostage data.</h3>
     <p>
-      ERPNext is open-source. ESACP is open-source. The data is yours,
-      the configuration is yours, the AI conversation transcripts are
-      yours. If at any stage you decide to walk away, you take
-      everything with you. There is no proprietary format and no
-      hostage data.
+      ERPNext is open-source. ESACP is being developed openly. The aim is that your
+      data, configuration, documentation, and operating knowledge remain portable and
+      understandable. If a tool cannot be explained or exited, it does not belong in the core path.
     </p>
   </div>
 
   <div class="caveat">
-    <span class="tag caveat-tag">AI honesty</span>
-    <h3>The AI guides; you decide.</h3>
+    <span class="tag caveat-tag">Disruption</span>
+    <h3>The slow path is intentional.</h3>
     <p>
-      Claude asks the right questions and walks you through each
-      sequence. Decisions about your business stay yours &mdash; the AI
-      helps you think, not think for you. If the system ever feels like
-      it's pushing you toward something you don't want, push back.
-      That's how it's designed.
+      A rushed ERP migration can damage a business faster than the old spreadsheet mess.
+      ESACP starts with discovery, then a test environment, then selected operational
+      migration. The point is controlled progress, not heroic big-bang transformation.
     </p>
   </div>
-
 
 </div>
 
 <div class="essex-demo-note">
   <p>
-    Curious what the advisor sounds like once you're past discovery?
-    <a href="essex-demo.html">See a worked example of a stage-2
-    conversation</a> &mdash; a static walkthrough where the advisor
-    helps a small-business owner set up the sandbox on a Windows 11
-    machine.
+    Curious what the advisor sounds like after discovery?
+    <a href="essex-demo.html">See a worked example of a stage-2 conversation</a>
+    where the advisor helps a small-business owner set up a sandbox on a Windows 11 machine.
   </p>
 </div>
 
@@ -443,35 +440,37 @@ description: >-
 <h2>Who&rsquo;s doing this?</h2>
 
 <p class="intro">
-  ESACP is built by <strong>Martin H. J. Bramwell</strong>, an
-  independent developer. The work that ESACP is based on is the most
-  recent of a long list: consolidating all the information sources of
-  a small family-owned biochemical factory into ERPNext. ESACP is that
-  work made repeatable for the next business in line &mdash; you.
+  ESACP is being built by <strong>Martin H. J. Bramwell</strong>, an independent
+  systems engineer and developer. The current work grows out of helping a small
+  family-owned biochemical factory move from scattered operational information
+  towards planning allocation of their scarce enterprise resources using ERPNext.
 </p>
 
-<p>Earlier work, for reassurance that the lights are on:</p>
+<p class="intro">
+  That matters because ESACP is not being invented from a whiteboard fantasy about
+  &ldquo;SME digital transformation.&rdquo; It comes from the less glamorous reality:
+  spreadsheets, accounting tools, custom processes, regulatory pressure, fragile
+  knowledge transfer, and the need to keep the business running while improving it.
+</p>
+
+<p>Earlier work, spanning many very different fields of expertise:</p>
 
 <ul class="bio-list">
   <li>
     Control software for a
-    <a href="https://en.wikipedia.org/wiki/Stoneblower">railway
-    track-bed restoration machine</a> &mdash; pictured below, leaning
-    on the rail.
+    <a href="https://en.wikipedia.org/wiki/Stoneblower">railway track-bed restoration machine</a>
+    &mdash; pictured below, with Martin on the deck leaning against the handrail.
   </li>
   <li>
     Independent verification &amp; validation of the firmware for the
-    <a href="https://en.wikipedia.org/wiki/Upper_Atmosphere_Research_Satellite#Wind_Imaging_Interferometer_(WINDII)">WINDII
-    instrument</a> on NASA's Upper Atmosphere Research Satellite
-    (launched 1991).
+    <a href="https://en.wikipedia.org/wiki/Upper_Atmosphere_Research_Satellite#Wind_Imaging_Interferometer_(WINDII)">WINDII instrument</a>
+    on NASA&rsquo;s Upper Atmosphere Research Satellite.
   </li>
   <li>
-    The management and cost-control system for the maritime port of
-    Guayaquil, Ecuador.
+    The management and cost-control system of the maritime port of Guayaquil, Ecuador.
   </li>
   <li>
-    The first fully open-source government-to-business platform in
-    Latin America &mdash; for the revenue service of Ecuador.
+    An open-source government-to-business platform for the revenue service of Ecuador.
   </li>
 </ul>
 
@@ -480,22 +479,19 @@ description: >-
        alt="Stoneblower track-bed restoration machine on the rails, with Martin standing on the deck leaning against the railing."
        loading="lazy" />
   <figcaption>
-    Commissioning a Stoneblower track-bed restoration machine &mdash;
-    Martin on the deck, leaning on the rail.
+    Commissioning a Stoneblower track-bed restoration machine.
   </figcaption>
 </figure>
 
 <p>
-  The work on ESACP happens in public. Entire history at
+  The work happens in public. Entire history at
   <a href="https://github.com/martinhbramwell/ESACP">github.com/martinhbramwell/ESACP</a>.
 </p>
 
 <p>
-  Looking for the earlier framing of ESACP &mdash; what is being
-  built, how AI fails at this kind of work, and the pitfalls research
-  that came out of 60+ working sessions?
-  <a href="{{ '/learn-more/' | relative_url }}">Read the original
-  landing page</a>.
+  Want the deeper technical and project-history version?
+  <a href="{{ '/learn-more/' | relative_url }}">Read the background page</a>, including
+  the pitfalls research from many AI-assisted working sessions.
 </p>
 
 <p class="panel-cue"><a href="#start" class="panel-cue-link">&lsaquo; Ready to throw the shoe? Back to Getting Started</a></p>


### PR DESCRIPTION
## What
Publishes the operator-provided new landing-page version to the live GitHub Pages root, replacing `on_boarding/docs/index.md` (the file the live root actually serves — Pages `build_type=workflow` builds `on_boarding/docs/` on the `on_boarding` branch; the API `source=main /docs` field is vestigial/ignored).

## Diligence
- **Tenant-detail scrub** clean (no real client names — public surface).
- **Local jekyll build** clean; layout/assets/links resolve; all panels render.
- **Three copy defects fixed at T1** before commit: `commerical`→`commercial`; broken privacy-panel sentence; `<hr/>` un-wrapped from invalid `<p class="intro">`.

## QA
T1 (approve-with-conditions → all three applied) and T3 both approved by `esacp-qa`. `refs` not `fixes` — acceptance is the post-deploy live-root check; manual T5 after deploy.

## Territory
Entirely `on_boarding/` — no root/Senior edit. Operator-directed; Senior to be flagged (he had assumed landing publish was his, on the disproven "main /docs" premise — #533).

refs #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)