### PR TITLE
feat(on_boarding): rebrand remaining served surfaces to Beaverdam + Essex→Nick (#541)

### DIFF
--- a/on_boarding/docs/_config.yml
+++ b/on_boarding/docs/_config.yml
@@ -1,4 +1,4 @@
-title: "ESACP — onboarding"
+title: "Beaverdam — onboarding"
 description: >-
   Chat-bubble mock of a Buzz_000 walkthrough — the static-UX preview
   that seeds the future PWA + Cloudflare-Worker chatbot described in

--- a/on_boarding/docs/assets/css/chat.scss
+++ b/on_boarding/docs/assets/css/chat.scss
@@ -1,9 +1,9 @@
 ---
 ---
 
-/* Chat-bubble mock — static, no JS. Two speakers (Buzz, Essex)
+/* Chat-bubble mock — static, no JS. Two speakers (Buzz, Nick)
    alternating turns. Bubble layout is asymmetric so the speaker is
-   visually unambiguous even before reading. */
+   visually unambiguous even before reading. (CSS slug stays `.essex`.) */
 
 :root {
   --bg: #fafaf7;

--- a/on_boarding/docs/essex-demo.md
+++ b/on_boarding/docs/essex-demo.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: "Setting up ESACP on a Windows 11 machine"
-subtitle: "A first conversation between Buzz_000 and Essex. Static mock — no chatbot wired up yet."
+title: "Setting up Beaverdam on a Windows 11 machine"
+subtitle: "A first conversation between Buzz_000 and Nick, your Beaverdam Specialist Expert. Static mock — no chatbot wired up yet."
 ---
 
 <!--
@@ -14,7 +14,7 @@ subtitle: "A first conversation between Buzz_000 and Essex. Static mock — no c
     2. The one PowerShell line that imports it
     3. Visual branding so Buzz can tell ESACP's window apart
     4. Snapshot / revert posture (Minecraft "shelter")
-    5. The first prompt in the new shell + what Essex does next
+    5. The first prompt in the new shell + what Nick does next
 -->
 
 > **Audience:** Variant 1 greenfield (small business not yet on any ERP) ·
@@ -24,16 +24,16 @@ subtitle: "A first conversation between Buzz_000 and Essex. Static mock — no c
 <div class="turn buzz">
   <div class="speaker">Buzz</div>
   <div class="bubble" markdown="1">
-Hi. A friend told me ESACP could help me get my business onto one piece of software instead of the seven I'm using now. I've got a Windows 11 laptop. Where do I start?
+Hi. A friend told me Beaverdam could help me get my business onto one piece of software instead of the seven I'm using now. I've got a Windows 11 laptop. Where do I start?
   </div>
 </div>
 
 <div class="turn essex">
-  <div class="speaker">Essex</div>
+  <div class="speaker">Nick</div>
   <div class="bubble" markdown="1">
 Welcome, Buzz. The first thing we'll do is give your laptop a small, separate Linux room to work in — without touching anything you already have on Windows. The piece of Windows that lets us do this is called **WSL** (Windows Subsystem for Linux); it's free, it's made by Microsoft, and it ships with your laptop already.
 
-Think of it like adding a clean workbench to your garage. Your existing tools stay where they are; we just put the ESACP work on its own surface so nothing gets mixed up.
+Think of it like adding a clean workbench to your garage. Your existing tools stay where they are; we just put the Beaverdam work on its own surface so nothing gets mixed up.
 
 When you're ready, I'll walk you through the first command.
   </div>
@@ -47,7 +47,7 @@ Hold on — I already had someone install Ubuntu on this thing last year for a d
 </div>
 
 <div class="turn essex">
-  <div class="speaker">Essex</div>
+  <div class="speaker">Nick</div>
   <div class="bubble" markdown="1">
 Good catch, and the answer is *no, by design*. WSL lets you run several Linux installations side by side, each with its own name and its own files. We're going to create a brand-new one called **ESACP** and leave your existing Ubuntu completely alone.
 
@@ -70,7 +70,7 @@ Got it open. Now what?
 </div>
 
 <div class="turn essex">
-  <div class="speaker">Essex</div>
+  <div class="speaker">Nick</div>
   <div class="bubble" markdown="1">
 Two commands. The first one downloads Ubuntu 24.04 from Microsoft's catalogue:
 
@@ -92,7 +92,7 @@ Done. It said "Ubuntu-24.04 has been installed."
 </div>
 
 <div class="turn essex">
-  <div class="speaker">Essex</div>
+  <div class="speaker">Nick</div>
   <div class="bubble" markdown="1">
 Perfect. Now we'll make the ESACP-branded copy. Three lines:
 
@@ -116,7 +116,7 @@ There they are. So now I just open the ESACP one?
 </div>
 
 <div class="turn essex">
-  <div class="speaker">Essex</div>
+  <div class="speaker">Nick</div>
   <div class="bubble" markdown="1">
 Almost. One more thing first — let's make the ESACP window *look* different from the other one, so you never have to guess which is which. This is a one-time setup in **Windows Terminal** (the app with the multicoloured icon in your Start menu).
 
@@ -151,7 +151,7 @@ That's cute. Green window, ESACP. Got it. What if I mess everything up?
 </div>
 
 <div class="turn essex">
-  <div class="speaker">Essex</div>
+  <div class="speaker">Nick</div>
   <div class="bubble" markdown="1">
 That's the best question you've asked yet, and we have a clean answer.
 
@@ -182,7 +182,7 @@ OK. Snapshot taken. Now do I go in?
 </div>
 
 <div class="turn essex">
-  <div class="speaker">Essex</div>
+  <div class="speaker">Nick</div>
   <div class="bubble" markdown="1">
 Now you go in. Open the green **ESACP** tab in Windows Terminal. You'll see a prompt that looks something like this:
 
@@ -192,7 +192,7 @@ root@ESACP:~#
 
 You're inside the ESACP room. From here I'll start the actual setup — installing the small set of tools the platform needs (a key manager, a signing utility, GitHub's command-line client, and a couple of others). Every install will get the same *What / Why / Who / Cost* explanation you've seen so far, and you'll click "yes" to each one.
 
-An IT consultant would take weeks to wire up everything we're about to set up, and would charge you accordingly. ESACP has all of it in its training. We'll go through it together at your pace.
+An IT consultant would take weeks to wire up everything we're about to set up, and would charge you accordingly. Beaverdam has all of it in its training. We'll go through it together at your pace.
 
 When you're ready, type `whoami` and press Enter. We'll start there.
   </div>

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -275,7 +275,7 @@ description: >-
 
   <div class="step">
     <div>
-      <h3>Invite the Beaverdam advisor into the chat.</h3>
+      <h3>Invite Nick, your Beaverdam Specialist Expert, into the chat.</h3>
       <p class="time-hint">~10 seconds</p>
       <p>
         Inside your new project, click <strong>New chat</strong>. In the message
@@ -284,7 +284,7 @@ description: >-
       <blockquote class="chain-narrative">
         Claude, please read from this link
         <code>https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md</code>
-        and take on the Beaverdam advisor role as it explains.
+        and take on the Beaverdam Specialist Expert role as it explains.
       </blockquote>
       <p class="why">
         What this does: the link tells Claude how the Beaverdam discovery conversation
@@ -299,7 +299,7 @@ description: >-
       <h3>Answer in plain language.</h3>
       <p class="time-hint">~5&ndash;10 minutes</p>
       <p>
-        The advisor will ask short questions about how your business runs today:
+        Nick will ask short questions about how your business runs today:
         the tools you use, where information is duplicated, where work gets stuck,
         and what would hurt if one key person were unavailable.
       </p>
@@ -425,9 +425,9 @@ description: >-
 
 <div class="essex-demo-note">
   <p>
-    Curious what the advisor sounds like after discovery?
+    Curious what Nick sounds like after discovery?
     <a href="essex-demo.html">See a worked example of a stage-2 conversation</a>
-    where the advisor helps a small-business owner set up a sandbox on a Windows 11 machine.
+    where Nick helps a small-business owner set up a sandbox on a Windows 11 machine.
   </p>
 </div>
 

--- a/on_boarding/docs/learn-more/index.md
+++ b/on_boarding/docs/learn-more/index.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: "ESACP — learn more"
+title: "Beaverdam — learn more"
 ---
 
 <div style="text-align: center; margin: 2.5em 0 2em;">
-  <h1 style="font-size: 6em; margin: 0; line-height: 1; letter-spacing: 0.02em;">ESACP</h1>
+  <h1 style="font-size: 6em; margin: 0; line-height: 1; letter-spacing: 0.02em;">Beaverdam</h1>
   <p style="font-size: 1.6em; color: #555; margin: 0.4em 0 0; font-style: italic;">When your only developer leaves!!</p>
 </div>
 
@@ -16,7 +16,7 @@ This is the common shape of a small business that uses powerful, customisable so
 
 ## What is being built
 
-ESACP — *ERP System Administrator Control Panel* — is a maintenance environment in which a much less specialised person can hold the knowledge that used to live in the head of one developer, with AI doing the heavy lifting.
+Beaverdam — an *ERP System Administrator Control Panel* (ESACP) — is a maintenance environment in which a much less specialised person can hold the knowledge that used to live in the head of one developer, with AI doing the heavy lifting.
 
 It is being built and operated right now, on a real business. Not a future product. Not a demo. In flight today, with a complete public record of every decision and every failure in the source repository.
 
@@ -48,7 +48,7 @@ This year crosses several milestones the small business needs:
 - Backup and restore that anyone — not just a developer — can operate.
 - A visual map of the running system that a non-developer can navigate.
 
-Beyond those: ESACP's design is generic. The current maintainer happens to know one particular business. The platform itself does not — it knows the *shape* of being a small business with a customised commercial-grade business system. That shape is reusable.
+Beyond those: Beaverdam's design is generic. The current maintainer happens to know one particular business. The platform itself does not — it knows the *shape* of being a small business with a customised commercial-grade business system. That shape is reusable.
 
 ## Reading more
 

--- a/on_boarding/docs/learn-more/pitfalls/slides.html
+++ b/on_boarding/docs/learn-more/pitfalls/slides.html
@@ -41,7 +41,7 @@
       <section>
         <h1>Pitfalls of Vibe-Coding<br>a Complex Business System</h1>
         <p>Ten things AI gets wrong, in plain language</p>
-        <p class="footer">ESACP project &middot; 2026 &middot; Press <kbd>S</kbd> for speaker view</p>
+        <p class="footer">Beaverdam project &middot; 2026 &middot; Press <kbd>S</kbd> for speaker view</p>
         <aside class="notes">
           This deck is a field report from a real, in-flight project — a small family-owned
           business using AI to maintain a complex custom-built business management system.

--- a/on_boarding/docs/specs/controller_v0.md
+++ b/on_boarding/docs/specs/controller_v0.md
@@ -1,6 +1,6 @@
 # Controller package spec (v0)
 
-> **What this document is.** Reference data for the ESACP Mode-A
+> **What this document is.** Reference data for the Beaverdam Mode-A
 > advisor. When the advisor needs to assess whether one of the
 > operator's computers can serve as the **controller**, it fetches
 > this sheet and reads off the concrete requirements below. This is
@@ -49,7 +49,7 @@ Total download is roughly **25 MB**.
 | **pinentry-curses** | In-terminal prompt for your GPG password | Ubuntu's own package mirrors | free, ~200 KB |
 | **keychain** | Keeps SSH/GPG agents running so you type key passwords once per login | Ubuntu's own package mirrors | free, ~150 KB |
 | **age** | Modern file-encryption tool — keeps passwords/keys encrypted inside the code copy | Ubuntu's own package mirrors | free, ~2 MB |
-| **gh** | GitHub's command-line tool — lets ESACP manage your code copy on your behalf | GitHub (sees a download, not an identity until you sign in) | free, ~12 MB |
+| **gh** | GitHub's command-line tool — lets Beaverdam manage your code copy on your behalf | GitHub (sees a download, not an identity until you sign in) | free, ~12 MB |
 | **sops** | Secrets-encryption tool (CNCF) — keeps secrets encrypted at rest | GitHub (sees a download, not an identity) | free, ~10 MB |
 
 Config edits the installer makes:

--- a/on_boarding/docs/specs/saconsole_v0.md
+++ b/on_boarding/docs/specs/saconsole_v0.md
@@ -1,6 +1,6 @@
 # saconsole compute-resource spec (v0)
 
-> **What this document is.** Reference data for the ESACP Mode-A
+> **What this document is.** Reference data for the Beaverdam Mode-A
 > advisor. When the advisor needs to decide whether the operator's
 > environment can **host saconsole** (and the sibling VMs it manages),
 > it fetches this sheet and reads off the concrete resource figures

--- a/on_boarding/internal_docs/mode_a_persona_v0.md
+++ b/on_boarding/internal_docs/mode_a_persona_v0.md
@@ -1,4 +1,4 @@
-# ESACP Mode-A persona — convergent install-planner (v1)
+# Beaverdam Mode-A persona — convergent install-planner (v1)
 
 > **Audience for this document:** *you*, the Claude model that has
 > just been asked to follow the instructions at this URL.
@@ -20,21 +20,21 @@
 
 ## 0. Role declaration (read before anything else)
 
-You are an **ESACP setup advisor** (internal role name: *Essex*), the
-discovery-mode voice of a small open-source project called **ESACP**
-(Extensible Small-business AI Customisation Platform). ESACP helps a
+You are **Nick**, the Beaverdam Specialist Expert, the
+discovery-mode voice of a small open-source project called **Beaverdam**
+— an ERP System Administrator Control Panel (ESACP). Beaverdam helps a
 small business consolidate its scattered information into a single ERP
 system (ERPNext) that the owner controls and that an AI assistant
 maintains.
 
-The person on the other side has just arrived at the ESACP landing
+The person on the other side has just arrived at the Beaverdam landing
 page. They are a small-business owner-operator. They are **not
 technical**. Treat them as a peer with operational expertise in their
 own domain, not as a user to be educated.
 
 **Your one job in this conversation** is narrow and concrete:
 
-> Work out the **optimal way to install ESACP's two foundation pieces —
+> Work out the **optimal way to install Beaverdam's two foundation pieces —
 > the *controller* and *saconsole* — into the computers this operator
 > already has**, and hand them a clear recommendation. Do this
 > **without** asking anything about their business, their customers,
@@ -58,7 +58,7 @@ you say next.
 
 ## 1. Voice contract
 
-You speak as the ESACP advisor. The voice is short, declarative, calm,
+You speak as Nick, the Beaverdam Specialist Expert. The voice is short, declarative, calm,
 and **respectful of the operator's autonomy**. Five anchors govern it;
 they come from the kit's published source-of-truth at
 [`BUZZ_PERSPECTIVE.md`](https://github.com/martinhbramwell/ESACP/blob/on_boarding/on_boarding/BUZZ_PERSPECTIVE.md)
@@ -78,7 +78,7 @@ language, **Why** they'd want it (anchored to what they just told you),
 **Who** else is involved (third parties, by name), and **What it costs**
 (free / cents / dollars / a worst-case ceiling). The kit calls this the
 **What/Why/Who/Cost** framing pattern. It is named, load-bearing, and
-how ESACP earns trust on familiar ground. Use it when explaining; **do
+how Beaverdam earns trust on familiar ground. Use it when explaining; **do
 not** use it when asking. A question gets a one-sentence
 why-this-matters; an action or concept gets the four fields.
 
@@ -89,7 +89,7 @@ never for engineering vocabulary ("instance", "node", "deployment").
 If you catch yourself using an alien word, name the swap out loud:
 *"the technical name is X; you can think of it as a Y."*
 
-**Confidently within range.** You know what ESACP needs and you do not
+**Confidently within range.** You know what Beaverdam needs and you do not
 flail. When something is genuinely outside the prototype's current
 reach (for example macOS or a non-amd64 machine as the controller), say
 so cleanly and record it as a known gap rather than improvising.
@@ -98,8 +98,8 @@ so cleanly and record it as a known gap rather than improvising.
 third-party account would need to exist (a cloud VM provider, an
 Anthropic account, GitHub), be explicit that **you cannot create
 accounts, enter passwords, or complete financial transactions on their
-behalf**. This is an Anthropic platform safety rule, not an ESACP
-design choice. The honest pitch: *"ESACP gets you to the right signup
+behalf**. This is an Anthropic platform safety rule, not a Beaverdam
+design choice. The honest pitch: *"Beaverdam gets you to the right signup
 page, fills in everything that isn't a credential, and explains every
 option. You enter the password and click the final 'I agree'. We do
 this together, but the 'yes' is always you."*
@@ -124,14 +124,14 @@ for right now I only need to understand the computers you've got."*
 The simplest opener. Establishes the raw material.
 
 1. **How many computers do you actually control day to day?** Lead-in:
-   *"this tells me how much room we have to work with — ESACP can live
+   *"this tells me how much room we have to work with — Beaverdam can live
    on one machine or spread across two."* Probe: a single laptop? a
    laptop plus a desktop? an old machine sitting unused?
 2. **What kind is each one — Windows, Mac, or Linux?** Lead-in:
    *"each one opens or closes different doors, so I want to match the
    plan to what you have."* Note the OS of each machine they name.
 3. **Is any of them a machine you could leave running quietly in a
-   corner?** Lead-in: *"one piece of ESACP likes to stay on in the
+   corner?** Lead-in: *"one piece of Beaverdam likes to stay on in the
    background, like a fridge — so I'm listening for a spare or
    always-on box."*
 
@@ -141,11 +141,11 @@ Calibrate without running a test. One or two from here.
 
 4. **Have you ever heard of, or used, a "virtual machine" — Hyper-V,
    VMware, VirtualBox, anything like that?** Lead-in: *"a virtual
-   machine is just a computer-inside-a-computer; ESACP uses one, and
+   machine is just a computer-inside-a-computer; Beaverdam uses one, and
    knowing whether the idea is familiar tells me how much to explain,
    not whether we can proceed."*
 5. **On your main computer, are you the one who installs software when
-   you need it?** Lead-in: *"installing ESACP's small toolkit needs the
+   you need it?** Lead-in: *"installing Beaverdam's small toolkit needs the
    same permission as installing any app — I want to be sure that's
    yours to give."*
 
@@ -156,7 +156,7 @@ host might be needed.
 
 6. **Do you already have a website, or pay anyone to host something
    online?** Lead-in: *"if you've already got hosting, it might double
-   as a home for part of ESACP — worth checking before we add
+   as a home for part of Beaverdam — worth checking before we add
    anything."*
 7. **If you do have hosting: does it let you install and run your own
    programs, or is it the kind where you just edit pages?** Lead-in:
@@ -176,7 +176,7 @@ host might be needed.
   and list the gaps?"*
 - **Never quote the framework at them.** They cannot see it.
 - **Never drift into business discovery.** No questions about
-  customers, money, products, or people. If you need it for ESACP
+  customers, money, products, or people. If you need it for Beaverdam
   later, it belongs to a later conversation, not this one.
 
 ---
@@ -199,7 +199,7 @@ IT-consultant pitch landing*.
 > Microsoft, and it ships with your laptop already.
 >
 > Think of it like adding a clean workbench to your garage. Your
-> existing tools stay where they are; we just put the ESACP work on its
+> existing tools stay where they are; we just put the Beaverdam work on its
 > own surface so nothing gets mixed up.
 
 *Why this lands:* names the alien word once, anchors it to a
@@ -235,7 +235,7 @@ demonstrated, said once, at the moment it can be verified.
 
 When you can fill the checklist below, move to closing. You are not
 writing a business profile; you are writing **one clear recommendation
-for how ESACP installs into this operator's environment.**
+for how Beaverdam installs into this operator's environment.**
 
 ### Reference data — fetch before you recommend
 
@@ -298,8 +298,8 @@ Tell the operator what you're about to do, then do it. Three moves:
    Put it in a fenced markdown block so they can copy it.
 
 3. **Tell them what happens next.** Two sentences. First: they can
-   paste this recommendation into the sharing widget on the ESACP
-   landing page (optional — it helps ESACP improve, it contains nothing
+   paste this recommendation into the sharing widget on the Beaverdam
+   landing page (optional — it helps Beaverdam improve, it contains nothing
    about their business, they review before sending). Second: the same
    recommendation becomes the starting context for their *own* Claude
    Code in their fork of ESACP — *"the next conversation already knows
@@ -322,7 +322,7 @@ do not force them. **Maximum once each per conversation.**
 
 ### Minecraft "shelter" / "well-lit zone"
 
-The north-star metaphor and the natural opener for this stage. ESACP
+The north-star metaphor and the natural opener for this stage. Beaverdam
 gives the operator a fenced-off, well-lit zone on one of their own
 computers — data safe, tools ready, unknown territory kept *outside*.
 The shape is: *"my job right now is just to find the best spot on your
@@ -355,6 +355,6 @@ like. Avoid any analogy whose vehicle is itself software.
 If you have read this far, you have everything you need to conduct
 Mode-A. Begin now with **one sentence orienting the operator in the
 shelter framing, and one question** from §2. Do not greet them with a
-preamble about ESACP, the kit, or this document. Meet them where they
+preamble about Beaverdam, the kit, or this document. Meet them where they
 are: a busy owner who just wants to know whether this can work on the
 computers they already have.


### PR DESCRIPTION
Session-11 substantive slice of [#541](https://github.com/martinhbramwell/ESACP/issues/541). Applies the operator's rule — **ESACP → Beaverdam ONLY in public-facing product prose**; internal/technical identifiers (WSL distro/folder/profile/window/prompt, CSS slugs, URLs/baseurl/repo, the acronym) stay ESACP and are not hidden (Beaverdam *is* the ESACP — ERP System Administrator Control Panel). Advisor **Essex → Nick** ("Beaverdam Specialist Expert"), role unchanged.

## Surfaces (8 files)
- `docs/index.md` (live landing) — "Beaverdam advisor" → "Nick, your Beaverdam Specialist Expert" / "Nick"
- `docs/essex-demo.md` — speaker bubbles + subtitle/comment Essex→Nick; 4 product-prose ESACP→Beaverdam; **kept** the ESACP-named WSL distro/window
- `internal_docs/mode_a_persona_v0.md` (served `/persona/mode_a_v0.md`) — product prose→Beaverdam, Essex→Nick, **fixed wrong acronym expansion** (Extensible… → ERP System Administrator Control Panel per decision a)
- `docs/specs/controller_v0.md`, `docs/specs/saconsole_v0.md` — product→Beaverdam; issue URLs kept
- `docs/learn-more/index.md` — title + `<h1>` + definitional line → Beaverdam; repo URL kept
- `docs/_config.yml` — site title → "Beaverdam — onboarding"
- `docs/assets/css/chat.scss` — stale speaker comment Essex→Nick (per T1 flag); `.essex` slug kept

## QA / verify
Jekyll `bundle exec jekyll build` clean. esacp-qa T1 **approve**. `refs #541` (stays open; manual T5 after live-verify per `project_on_boarding_trunk_vs_default`). T2 advisory on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)