### PR TITLE
feat(wireguard): enroll iconia tablet as external WG peer + tmux satellite terminal (#383)

### DIFF
--- a/Cld.sh
+++ b/Cld.sh
@@ -4,6 +4,13 @@
 # Run this from the ESACP project root instead of calling `claude` directly.
 # Ensures the Cloudflare MCP OAuth token is fresh before Claude Code starts,
 # preventing the "Cloudflare tools not available" silent failure.
+#
+# Satellite terminal (ESACP#383): by default Claude Code runs inside a shared
+# tmux session ("esacp") so a second terminal — e.g. the Iconia tablet over
+# WireGuard — can attach to the SAME live session and drive it:
+#     ssh you@10.10.0.2 -t 'tmux attach -t esacp'
+# `window-size largest` keeps this terminal full-size when the smaller tablet
+# screen attaches. Set ESACP_NO_TMUX=1 to launch claude directly (no mirror).
 
 set -euo pipefail
 
@@ -13,4 +20,16 @@ if [[ -f .needs-cf-mcp ]]; then
   cf-mcp-refresh && rm -f .needs-cf-mcp
 fi
 
-claude --chrome
+SESSION="${ESACP_TMUX_SESSION:-esacp}"
+
+# Already inside tmux, or mirroring opted out, or tmux missing → run directly.
+if [[ -n "${TMUX:-}" || "${ESACP_NO_TMUX:-0}" == "1" ]] || ! command -v tmux >/dev/null 2>&1; then
+  exec claude --chrome
+fi
+
+# Attach to an existing shared session, or create one running Claude Code.
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+  tmux new-session -d -s "$SESSION" "claude --chrome"
+  tmux set-option -t "$SESSION" window-size largest    # don't shrink to the smallest client (#383)
+fi
+exec tmux attach -t "$SESSION"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -28,6 +28,17 @@ wg_pubkey_dev03: "9joY/mn1ZrvczXKnF+L6qvP5M3cYFKgRTIOR0RDHHiA="
 wg_pubkey_target5: "8AFeP+XoqOyPTRNq6dINJxICREcixQ/wz7B1gZpdFRA="
 wg_pubkey_dev01: "ySQtN5mnR8+zEYM/Saxx/j9kO+nAq0liiLhtma/a3zw="
 wg_pubkey_dev02: "98Ht2/Cg08OSlPy11FJbpPoQhaK2nosu2e5vMx6WwXo="
+wg_pubkey_iconia: "XiykEtgWS7n6TnfpLYMznhGlofQKz/S8JbIgBcul61I="
+
+# ── External WireGuard peers (manually configured; ansible never connects) ──
+# Roaming/mobile devices that join the mesh as spokes but are NOT in the
+# ansible inventory (ansible_managed: false in hosts_map.yml, so excluded by
+# generate_inventory.py). The hub renders a [Peer] block for each from this
+# list. Keys live in config/wireguard/keys.sops.yml exactly like every other
+# peer; the PSK key is "<name>_<hub_key>". (ESACP#383)
+wg_external_peers:
+  - name: iconia
+    wg_ip: "10.10.0.20"
 
 # ── System configuration ───────────────────────────────────────────────────
 system_timezone: "America/New_York"

--- a/ansible/roles/wireguard/templates/wg0.conf.j2
+++ b/ansible/roles/wireguard/templates/wg0.conf.j2
@@ -17,6 +17,15 @@ AllowedIPs          = {{ hostvars[host]['wg_ip'] }}/32
 # No Endpoint — {{ host }} initiates the connection to the hub.
 
 {% endfor %}
+{% for _peer in (wg_external_peers | default([])) %}
+# ── External peer: {{ _peer.name }} (manual / roaming) ─────────────────────
+[Peer]
+PublicKey           = {{ wg_keys[_peer.name].public_key }}
+PresharedKey        = {{ wg_keys.preshared_keys[_peer.name + '_' + hub_key] }}
+AllowedIPs          = {{ _peer.wg_ip }}/32
+# No Endpoint — {{ _peer.name }} initiates the connection to the hub.
+
+{% endfor %}
 {% else %}
 {% set _key = 'controller' if inventory_hostname in ['controller', 'localhost'] else inventory_hostname %}
 # ── Peer: {{ hub_display_name }} (hub) ────────────────────────────────────

--- a/config/wireguard/keys.sops.yml
+++ b/config/wireguard/keys.sops.yml
@@ -1,39 +1,43 @@
 controller:
-    private_key: ENC[AES256_GCM,data:eEb5SnoGmVYdz4elpQR+fwlCkdUqrowLajPvrHmr6OKIv5SvAU9M8qvrdN8=,iv:X5eUVyFghfTuIOd1T07hDClPO5gDPTA58F/72xrRS9Y=,tag:UYrefTxnBV1ksrmB2ycCvQ==,type:str]
-    public_key: ENC[AES256_GCM,data:Fz4jtFAJmi7IYsD+8L4bRnp1Tjk71d49nxFcdaocP3joCwHrM8/WZ54zR/I=,iv:4djSvdM6WHv+3RksNGX5G1LfUGxcIuPcqQzjUdhqECc=,tag:Mj7apx8/GszPe0sz48yI+A==,type:str]
+    private_key: ENC[AES256_GCM,data:897JSlMmI/9WBxbG43GjNRAQJQ9WBEGt5GZRXukDOG6qkabu4Ljk6prtv3s=,iv:NDTuJb7Kd05Mc6VjIFuhXjLJM/A9wME/XVYRWzwfRIk=,tag:hgIMYT2x5YixMtSpE98JIw==,type:str]
+    public_key: ENC[AES256_GCM,data:RsGpdYJA6SVwlCAQfQ5QlfQ3Oqwj/00gcvLhiJc+vKMgXn+iWx2kTdJ1Glw=,iv:T750j237Pog5twycDgA1FoFNCxtfbuHDrJ3B7leet+A=,tag:+6mdi8k94pZ6oFEL62KzoQ==,type:str]
 saconsole:
-    private_key: ENC[AES256_GCM,data:cBZeES4Eh+wVwhV88/azPmswMnadS9xEqDpQ3BnKNPa9F5uyxer3zEvq8NU=,iv:2z3y9iqNl8Oc6WAodLrrwJonDO7L8+ZTlBH0yinHYg0=,tag:dw/8ClEwFbKr1d5Ig53P+g==,type:str]
-    public_key: ENC[AES256_GCM,data:ODjFfjEChT7jzb2+D48xZ5CIwTRMYXiOuVbEYE/HqDJCLQ1Fx859UVs9f7g=,iv:jOUp8ui9Xnjb/6sxFA3G1dz9xB8EvUkLQVQTrrktN1k=,tag:O4BqsCYrsGhhJc7EEVBk+A==,type:str]
+    private_key: ENC[AES256_GCM,data:2opnNAD5YPRyyWbVUR0xlQ86eAWWablfi7inNjvFWM+cYwYCSTkwV8jLLQM=,iv:O1u+k2tUlw5v/l3uok0cvJfXFMPYwEHkRi6mle4vgRc=,tag:c1mx8qR+i2NlkO2AWjfuGQ==,type:str]
+    public_key: ENC[AES256_GCM,data:gfSAZpPxgifMfvG6aBjCMCVaY7Of0G1EPsQjxhSIxpzXCzSuzpH6BPreDGc=,iv:QPbqK4EoNHiLnwiM6jzp/yEvPcnUbsfz/yxINJtSstg=,tag:u7E28fsGUaJF0IVvfQ6lrA==,type:str]
 dev03:
-    private_key: ENC[AES256_GCM,data:KfsWNq21O8HVlqnJXL+Je5pHX0Z/nOTIRnbrVOWmNYQU8DISPLIq2WG7vbk=,iv:VCzjQS0NgirG9jwf5LIf5iSctpb6DAfVzhDuYrvBSHU=,tag:aN9lbxYagt11e50IrXci9g==,type:str]
-    public_key: ENC[AES256_GCM,data:sQ95N5C3nZno77lg3qTY6dFl8H3Y/pCdBRBH6bai62bFlgfd2xnccO51xGQ=,iv:wJIkIbqR2NO6+62Fe2JlVpd0tiiJ3w/4sAd8eMEdXLA=,tag:IGKR3CkNZFPYU8lY078gYQ==,type:str]
+    private_key: ENC[AES256_GCM,data:C08kOVv/mS1pE7pqqAnCpkTGKCoGHAsvisfpVHwHpfLzJDcp3NRPvv6Tc7o=,iv:8An2vIeOUkzu+2Bq55BoYdupi5gWj+xMqwcSA2lOKd0=,tag:TwUpEF5mj5SBZoIRD0IT5g==,type:str]
+    public_key: ENC[AES256_GCM,data:XL21eyrsNnvRVNX728+Z8CNL/lCNZANyHrRQwxD0LZbx6TeZJhbJKyOXxA8=,iv:KdAprvA/hb98xsXwW6BZHJcSLY1/enNVGlMgoatmPVo=,tag:cvoFEI3n8lmRsT2faaQ6FA==,type:str]
 target5:
-    private_key: ENC[AES256_GCM,data:OYVsoJu8nLidj5Nq7hcUgs2SsjAZyzOFqlJQusPWjslD69sAL9DRau7ffMg=,iv:xDPPrXgvB72pLYTZAXjuQph6FvaRylAsJDB4rj51QoA=,tag:4UZQokvzccaX2Mk5NyPOwA==,type:str]
-    public_key: ENC[AES256_GCM,data:Lie+rbZRfWaNbwvKkvtZvDJlf03xi8qyR7fqA6a9eElL1sqMq6WcOLzSUzs=,iv:GJBupSrAyTu26AkVvj5yzmfn9URIy7Sh+3lYHvKz5tY=,tag:T+RtEqkCoWsnkomOX0Fszg==,type:str]
+    private_key: ENC[AES256_GCM,data:iowo2pBjT1m5Q1a/R04yhjr4Y3p/gUsaV44fR/hy6x5gqYNzZqlTbnmDBWQ=,iv:puqkHIldCRf8iLo/RNhe1f7hNhDF5WLqgPQq7dsU3Ps=,tag:yJx4xYhRXCz6BIZXyCwtUQ==,type:str]
+    public_key: ENC[AES256_GCM,data:swjeR07I+1Z+zoG6A6Kug6rNJtTCi7zkt/OFNQIYhDfBAX0BTdIg9nibszw=,iv:oZiZPBHomJ+ZbP44/BbM6LmSMXPaWA47kzssKsc+8wY=,tag:vQRhd2UQhoWOK7fgUUGysQ==,type:str]
 dev01:
-    private_key: ENC[AES256_GCM,data:6+CHVpcJOkNhRAPURyGUdt/WrtWcXjEUJnJSy82GRstvFFRp6BmdkEPc4SQ=,iv:Mjc+4L7+C/sLxGikEh9ECfmpfNbojurW+EeZkLiSbfs=,tag:DrG0146alVHdcQaAcjIrjQ==,type:str]
-    public_key: ENC[AES256_GCM,data:MQWhTu2BVstPquzoW73S6D6ZdfMOM7FBybo1xnC9wkLEbtlUJSNdM7OANPs=,iv:tyvOE+ghEIUku2IfpoQEsIM6TAxgK7RN/lw5ryaMEfo=,tag:rxoT3dvolEO0sDF4DhsuiA==,type:str]
+    private_key: ENC[AES256_GCM,data:cgqVYw4ShfNkEdaGyI3K1AVZeOLcpmg542Rp2bPA0Krv1q/EetcC3zsEGWw=,iv:HGU/b4O4VeLzS6qsCJE1ew1yp7WkNXZB/gRYZooLFZw=,tag:0cchTjfQrHlUC7lTlWDEww==,type:str]
+    public_key: ENC[AES256_GCM,data:+b2bbG0giDFFAHJ3TOQ9QAErO2nv6g600uGZbHHeY/TuNUO6adc8Xz264UE=,iv:RfRmGsYbcFV7XCWf2qqh9gDykieoD9dnEHxPmk49uro=,tag:nF9+Nymwis5I47m7mJxVTA==,type:str]
 dev02:
-    private_key: ENC[AES256_GCM,data:sD78ynUW80P23i99S+CidGq5pPsLT+uGrMiSBGm3yUzTBZ5Pb4G0qXAG+yA=,iv:ppARKav57Syt98+4mIlF08Hxpj9EymYWuy0/irOaGNI=,tag:fQvh+1pxTnnfnOpMJTxItg==,type:str]
-    public_key: ENC[AES256_GCM,data:gr9QJLrnIh/txb4BBXTWCZl53USrcfBY4YlAHKYiSF2UYw0oxp2NA2eNa4M=,iv:QrTlGoTiE7WpdcDHjj0togJysr6yLeXiYANmqpdvlNs=,tag:R64esPEpP35/nV9VHfLqDA==,type:str]
+    private_key: ENC[AES256_GCM,data:nHN4FHXXW5EK6C0RAxN2hC7385o+6ITbFmlJZTEs1HMYLo3GT7uDr087/IM=,iv:kReNt3tRsUvinb1/kChkb9jeD3kIpGNXW9HEDxh6lMc=,tag:+xHh91rG1rlWmTw9f0/45A==,type:str]
+    public_key: ENC[AES256_GCM,data:Z8BS3q9qFsWaptWb10ccuW3vgUS8QTrVUTjufTeuNuy/xXWF+/P2EtNsyps=,iv:upBxAKGuJZF9lRXcCZMI70+4ZuTn282ohmG6W4FzKDA=,tag:05zFIHuN204fMkKa8X/leg==,type:str]
+iconia:
+    private_key: ENC[AES256_GCM,data:vaVUOEvBg1S0ezNpCnUTnz95gW1fCocQXaGfTMRLynJ/MTw65y0CsC/IYR0=,iv:niKW0Ov2EOwwb19I5CP8aNd0pI/vjiHG+aAcQYbdPTo=,tag:XVsKuy69QU0X7LTsC1FqJw==,type:str]
+    public_key: ENC[AES256_GCM,data:A48F15hgwVyvpPvgHPIisTo/1dzR5sLGK41f/PCBegbtcRidgOwrIdzTI8Q=,iv:CLbuKtaCv71FHYbmFzm8Gi7yg8OCnNRitPm701+Gz0k=,tag:R0aoMXkQ/rXG9s9WTCDZpA==,type:str]
 preshared_keys:
-    controller_saconsole: ENC[AES256_GCM,data:MSeMYz0xU0WGxgVKzFTZ4e/R/3qxpLumzlu5a8CVUdZ0qOApLYtLY/ryPrw=,iv:BJTk24U265lGCPdSRiz1ewUShUyIWn1QWI0oc8nqhcA=,tag:nmc4cubCgJx895qp34tjwQ==,type:str]
-    dev03_saconsole: ENC[AES256_GCM,data:q073P3z4HBK3KuVS55+2aqZR43Kh5G6khcTmspJqiYk5TJbLQesWNodBM5Y=,iv:YwbEccu2gEVcn0tndUa0tUBc9+uZUDYrXcevU+UM/80=,tag:/IBq/ENnTl4YDLg/9WBFpg==,type:str]
-    target5_saconsole: ENC[AES256_GCM,data:uER3nq2wkeGLEz/slKm7dw0IwqnUQh7P9/iVETaKps0PIBjT5QNu08S+RNI=,iv:oE0OZYWylrdAerZE61hUYg3bekIaFG/x6IW+8kfDqew=,tag:odlTwAObhBpcIeaoVnKQNg==,type:str]
-    dev01_saconsole: ENC[AES256_GCM,data:RA4ktdXS0dklu5Fps3Sr/+vGXJxPA6eht+MpcWiLUHhUia35P4MBcJcW89E=,iv:mGTSljH1CtJyJCnXAUk+NR0vOm3sbt0loH33KHfU/34=,tag:ik4BJnu4hZqm0lcLO52bYQ==,type:str]
-    dev02_saconsole: ENC[AES256_GCM,data:lllbZRckTctxDqEvnNc/ViePxg4C6GhRP1V48kvcuPAwuyu1R3nl5oPVICM=,iv:EuZRZqQOUffvL9cTIuSSAAiQ29NjhbQVdHab4Ip72Lg=,tag:s6+WLSbSYJBz7zHcSYj9BA==,type:str]
+    controller_saconsole: ENC[AES256_GCM,data:RkkLcezfa6OWhqAwHqn7nrb+U9xHeL5GtSvlODnuKNxUIkJF1eDXO76dGVs=,iv:sD2q64+GT9yeJTJ9FK1ZiQHHNp2c9i7j8X0nqLWI2DQ=,tag:s1PNY442BwhkIH/k5Pq15g==,type:str]
+    dev03_saconsole: ENC[AES256_GCM,data:tXQl2DPnmLm5vxtgI1TLZp+Ih2uHkBf5bIvaGKubHMQ6WmNCPDMdVpHc/64=,iv:VyVI/TnCkZ+JEfX1M8UNoWBnbMGoNG0HZJ40A1KsIfs=,tag:aYtNdnqTQOvAx6i4FKO1Tw==,type:str]
+    target5_saconsole: ENC[AES256_GCM,data:c2RXQx7UVUKTiISWPOlh9yRzDDJzqSCi6OJ7SRC9cGZIKeP/k9rTcosfwsM=,iv:kBvuH/OgYAgacVG/tcxVb27MCOEgbKF3P5eqjYOKsrI=,tag:i9WMKAFemylR0LdxI35B6A==,type:str]
+    dev01_saconsole: ENC[AES256_GCM,data:9yp2tzNDWLYH7wmdwBImEMEoqHhI2K/pj0UIJbCeBRX8Sx2NwOdwP1fIOlc=,iv:aaDBCgd7exARrDznARqV7g9ogPgpmiHo3vsZYpe3dFo=,tag:Hcau01KFYD20jHjgpOCo9A==,type:str]
+    dev02_saconsole: ENC[AES256_GCM,data:S2CUdUSWFnKDfRD29MYkX1KPqfvNf8kR2T8iMSHGNkVLLAd4SMJ0YkKhCl0=,iv:phhCKBITOI8waxpuP6hO6hul8OdDd6yzL3j3xjd4k2M=,tag:mIM0uUYPe49XoJNiOrRNXQ==,type:str]
+    iconia_saconsole: ENC[AES256_GCM,data:XlJSL3IHsLwZAlBEpcymsQpxfUi6bK2xfwy+FXG+HZ9dG/l3rYg/PWttUwc=,iv:xqkhHfaywKrE8Mi4pFDB1drMZGb/iaKWvZJXRvuOqDE=,tag:E9J36yl3vTOi+MLlAyCcTA==,type:str]
 sops:
     age:
         - recipient: age185wy6suru3x53leqjf866zsz02vece8cnsy6g92tz7ae0ykw45dsjp2sl8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrcVVUWlp1MW8wUDUyMXR6
-            bmhQZ2xsYlRoU2lSNGZreTJOeU9ob3ovM0JRCkpXRG43WTlkeHRXbmhLVjNibjlj
-            MUJ4eE5BbzlISlMxbmRnKzVkbkZQdFUKLS0tIGh1cWJDQjU5RTJTdjlSc3ZYaXpH
-            eWRNaWY5Q0ZQQ0VzQXRiVlNrU2F6VzQK8d8UKuyGQ/1D4TAr5+y2s1rqMjziDnju
-            3IxyNzrpOY/HMXGKdwhqjIGZenHU14nRrZObv6m6bWUTwK5OtahoHQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTWXU3cGZDaklzNGFZWEN0
+            amo1cG9iVFpXc3QwVHB0bHNzakVWWk91WWowCm5yYXVQUlExNUtrbVVKYnpvek05
+            dkZOdmNPNzBPVFVqaCtLKzczVHBYVWcKLS0tIGExckpRc01icllnTnJoTWxLdGUy
+            R04yVnJCOFo0bWhuR3pVQkxCM3VROTAKnjvyhgYFV9SrPE/2364mfdb8qvvH3xgz
+            Cqnm3qIjjS0uiVkic2BcAg8QMlkjQCIEsOnFMCydczfZTvHcN9wIHQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-21T19:15:09Z"
-    mac: ENC[AES256_GCM,data:7nizlXDRGpe+FDpyMxzwL+rGyvn5hlQbyqFQ/VHU+lmJ0IITuzGcElKSw3AYu0IizvUifv33XOERvt0KFmBbmhLxmWbfELRJmK3k/3ciRrIr2Pj5Omi1ErP+1gYhV88ySHQCRKSALjG5Kxqc9l52/hzzlw0Koo3Ol5ZnDEMIXeU=,iv:yfuxBrXLHKkfTYCGAHG+UoQPsjKHxC0wp7ijeVizN0s=,tag:+/TR7cUUshgN+Vk0pCDv6A==,type:str]
+    lastmodified: "2026-06-01T11:04:33Z"
+    mac: ENC[AES256_GCM,data:Bs5GWCOOKC7zozJ2orVurUj4T2tNqlj51GBqHefuTmYAByIvQgBolg0JnHTEUJof+2MQxcGy8COzKZbYErUAnChtvMPo1rYrq0VQt26O84SFXaO6IZtP5h97ZjsbIsEpsaO4vczXZ7jLc2qwJzKG0Lhx819seTFL+yvsaig/rxg=,iv:3SlH78xvgnTk8P0HXrD0J0dMAOQ4D0IVt+e5UN0NzQ4=,tag:5cIbUkwkDo0F0VVs7Dp4ig==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1

--- a/hosts_map.yml
+++ b/hosts_map.yml
@@ -153,6 +153,25 @@ groups:
       ansible_groups:
         - controller
 
+  # ── Mobile / roaming peers (manually configured WireGuard) ────────────────
+  # ansible_managed: false → excluded from the generated Ansible inventory;
+  # the hub learns these peers via `wg_external_peers` in group_vars/all.yml.
+  # Ansible never connects to them (Windows/Android, configured by hand). The
+  # standard spoke config (AllowedIPs 10.10.0.0/24 + hub forwarding) gives them
+  # full-mesh reachability. (ESACP#383)
+  mobile:
+    iconia:
+      hostname: iconia
+      display_name: "Iconia Tablet"
+      nickname: iconia
+      wg_ip: "10.10.0.20"
+      wg_role: spoke
+      ansible_managed: false
+      platform: windows
+      device_class: tablet
+      ansible_groups:
+        - mobile
+
   # ── Future groups — define now, activate by populating ────────────────────
   dev_group: {}
   stage_group: {}

--- a/internal_docs/RUNBOOK.md
+++ b/internal_docs/RUNBOOK.md
@@ -29,6 +29,9 @@ Stage 1.5 — Failure Injection & Observability Validation
    - [promtail\_stopped](#promtail_stopped)
    - [grafana\_stopped](#grafana_stopped)
 4. [Troubleshooting](#4-troubleshooting)
+5. [Enrolling a Mobile / Satellite Terminal (WireGuard + tmux)](#5-enrolling-a-mobile--satellite-terminal-wireguard--tmux)
+   - [Enroll a new WireGuard peer](#5a-enroll-a-new-wireguard-peer)
+   - [Attach a satellite mirrored terminal](#5b-attach-a-satellite-mirrored-terminal)
 
 ---
 
@@ -508,3 +511,64 @@ If a false positive occurs, verify group membership:
 ```bash
 ansible-inventory -i ansible/inventory/dev.yml --list | python3 -m json.tool | grep -A5 '"production"'
 ```
+
+---
+
+## 5. Enrolling a Mobile / Satellite Terminal (WireGuard + tmux)
+
+Mobile/roaming devices (a Windows tablet, a phone) join the mesh as **manual
+spokes** — `ansible_managed: false` in `hosts_map.yml`, so `generate_inventory.py`
+excludes them and Ansible never connects to them. The hub learns each one via the
+`wg_external_peers` list in `ansible/group_vars/all.yml`. (ESACP#383)
+
+### 5a. Enroll a new WireGuard peer
+
+1. **Generate keys** (from project root):
+   ```bash
+   bash config/wireguard/add_peer.sh <name>      # e.g. iconia
+   ```
+   Note the printed `wg_pubkey_<name>`.
+2. **Register the peer** in three files:
+   - `hosts_map.yml` → add under the `mobile:` group (`wg_ip`, `wg_role: spoke`,
+     `ansible_managed: false`). Pick a free `10.10.0.x` (≥ `.20` for mobile).
+   - `ansible/group_vars/all.yml` → add `wg_pubkey_<name>` and an entry under
+     `wg_external_peers` (`name` + `wg_ip`).
+   - (no inventory edit — `generate_inventory.py` skips unmanaged hosts; the
+     summary line confirms `[manual]`).
+3. **Apply the hub config** (renders the new `[Peer]` into saconsole's `wg0.conf`):
+   ```bash
+   cd ansible
+   ansible-playbook -i inventory/kvm.yml site-kvm.yml --limit saconsole --tags wireguard
+   ```
+4. **Build the client config** and transfer it securely to the device (it holds
+   the private key — never commit it):
+   ```bash
+   # produces ~/<name>-wg0.conf (mode 0600); Endpoint = toshy.iridium.blue:51820
+   ```
+   On **Windows**: install *WireGuard for Windows*, "Add Tunnel" → import the
+   `.conf`, activate. On the **home/office LAN** `toshy.iridium.blue` resolves
+   directly; from a foreign network you need a public DDNS name with UDP/51820
+   forwarded to the hypervisor (out of v1 scope).
+5. **Verify**: on the device, the tunnel shows a recent handshake;
+   `ping 10.10.0.1` (hub) and `ping 10.10.0.2` (controller) succeed. The standard
+   spoke config (`AllowedIPs = 10.10.0.0/24` + hub forwarding) gives full-mesh
+   reachability.
+
+### 5b. Attach a satellite mirrored terminal
+
+`Cld.sh` launches Claude Code inside a shared tmux session (`esacp`) by default.
+A second terminal attaches to the **same live session** and can drive it:
+
+```bash
+ssh you@10.10.0.2 -t 'tmux attach -t esacp'      # from the tablet, over WireGuard
+```
+
+- Both terminals render the same output and accept input (turn-taking — one
+  input stream).
+- `window-size largest` (set by `Cld.sh`) keeps the controller terminal full-size
+  when the smaller tablet attaches; the tablet shows a scrolled view of the larger
+  geometry.
+- `ESACP_NO_TMUX=1 ./Cld.sh` launches Claude Code directly, without the shared
+  session.
+- The tablet's SSH **public** key must be in the controller's
+  `~/.ssh/authorized_keys`.

--- a/internal_docs/RUNBOOK.md
+++ b/internal_docs/RUNBOOK.md
@@ -560,9 +560,13 @@ excludes them and Ansible never connects to them. The hub learns each one via th
 A second terminal attaches to the **same live session** and can drive it:
 
 ```bash
-ssh you@10.10.0.2 -t 'tmux attach -t esacp'      # from the tablet, over WireGuard
+ssh you@10.10.0.2 -t "tmux attach -t esacp"      # from the tablet, over WireGuard
 ```
 
+- **Use double quotes.** Windows `cmd.exe` passes single quotes through
+  literally, so the remote shell receives `'tmux attach -t esacp'` as one word
+  and reports `command not found`. Double quotes are correct on `cmd.exe`, bash,
+  and macOS alike. (ESACP#383)
 - Both terminals render the same output and accept input (turn-taking — one
   input stream).
 - `window-size largest` (set by `Cld.sh`) keeps the controller terminal full-size


### PR DESCRIPTION
fixes #383

Enrolls the iconia Windows 10 tablet as a full-mesh WireGuard spoke and
launches Claude Code inside a shared tmux session (`esacp`), so the
controller terminal and the tablet drive one live session.

## Changes
- **keys.sops.yml**: iconia keypair + `iconia_saconsole` PSK (via `add_peer.sh`).
- **hosts_map.yml**: new `mobile:` group; iconia at `10.10.0.20`, `ansible_managed: false`.
- **group_vars/all.yml**: `wg_pubkey_iconia` + new `wg_external_peers` list — manual/roaming peers kept distinct from inventory-managed spokes, leaving `generate_inventory.py`'s managed-only contract untouched.
- **wg0.conf.j2**: hub-only second loop rendering external peers.
- **Cld.sh**: tmux-aware launch (session `esacp`, `window-size largest`, `ESACP_NO_TMUX=1` escape hatch).
- **RUNBOOK §5**: enroll-mobile-peer + attach-satellite-terminal procedures, with the §5b SSH command corrected to **double quotes** (cmd.exe passes single quotes through literally → `command not found`).

## Acceptance (verified S90)
- WireGuard full-mesh reachability: pings to `10.10.0.1` (hub) and `10.10.0.2` (controller) succeed from the tablet.
- Live shared tmux session: `ssh hasan@10.10.0.2 -t "tmux attach -t esacp"` from the tablet mirrors the controller session; operator confirmed the mirror renders and accepts input.

## Follow-on
- **#552** — key auth falls back to password on the tablet (pubkey installed but not offered). Split out per 1:1:1; non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)