### PR TITLE
fix(pipeline): emit full bench-migrate stdout/stderr in applySubstrateMigration (#447)

### DIFF
--- a/tools/pipeline/orchestration/substrate_apply.py
+++ b/tools/pipeline/orchestration/substrate_apply.py
@@ -23,17 +23,25 @@ from tools.pipeline.stages.common.ssh import rsync_to_vm, ssh_run
 from tools.pipeline.stages.common.types import Config, Emit, TaskResult
 
 
+def _emit_block(emit: Emit, label: str, text: str) -> None:
+    """Emit a captured stream in full, indented under *label*. No truncation —
+    the migrate output is the defect-capture signal a substrate trial exists for
+    (ESACP#447)."""
+    text = text.rstrip()
+    if not text:
+        return
+    emit(f"    {label}:")
+    for line in text.splitlines():
+        emit(f"      {line}")
+
+
 def _run_step(config: Config, emit: Emit, label: str, cmd: str, *, timeout: int = 600) -> bool:
     r = ssh_run(config, cmd, timeout=timeout)
-    if r.returncode == 0:
-        emit(f"  [OK] {label}")
-        return True
-    emit(f"  [FAIL] {label}: rc={r.returncode}")
-    if r.stdout.strip():
-        emit(f"    stdout: {r.stdout.strip()[-500:]}")
-    if r.stderr.strip():
-        emit(f"    stderr: {r.stderr.strip()[-500:]}")
-    return False
+    status = "OK" if r.returncode == 0 else f"FAIL: rc={r.returncode}"
+    emit(f"  [{status}] {label}")
+    _emit_block(emit, "stdout", r.stdout)
+    _emit_block(emit, "stderr", r.stderr)
+    return r.returncode == 0
 
 
 def apply_substrate_migration(config: Config, emit: Emit) -> TaskResult:

--- a/tools/size_baselines.json
+++ b/tools/size_baselines.json
@@ -100,7 +100,7 @@
   "tools/pipeline/orchestration/observability_creds.py": 73,
   "tools/pipeline/orchestration/snapshot_ops.py": 39,
   "tools/pipeline/orchestration/sops_key_remove.py": 73,
-  "tools/pipeline/orchestration/substrate_apply.py": 64,
+  "tools/pipeline/orchestration/substrate_apply.py": 72,
   "tools/pipeline/orchestration/template_metadata.py": 46,
   "tools/pipeline/orchestration/test_fix_script_runner.py": 63,
   "tools/pipeline/orchestration/test_hosts_map_remove.py": 57,


### PR DESCRIPTION
## Problem

`applySubstrateMigration` discarded `bench migrate` stdout on success and truncated stderr to the last 500 chars on failure (`substrate_apply.py:_run_step`), losing the defect-capture surface a substrate trial exists to produce. Recovery forced bypassing the named primitive — the exact thing #418 closed.

## Fix

`_run_step` now emits full stdout **and** stderr (via a small `_emit_block` helper) on **both** success and failure paths, untruncated. `emit` stays the only output mechanism — no VM-side temp file, no path-emit, no new escaping layers.

## Acceptance

- Live `./tools/esacp.py applySubstrateMigration dev02` → exit 0, **2,574 lines** of full migrate output captured (previously a single `[OK] bench migrate` line); g1/g2 protection output now visible; ended `✅ substrate migration applied`.
- Existing 4 colocated tests pass (assert on result/commands, unaffected by emit-format change).
- Mocked checks confirm: success path emits full 800-line stdout; failure path emits full 2 KB stderr head+tail (no 500-char truncation).

## Notes

- `substrate_apply.py` 64→72 lines (within the 80-line pipeline cap; size_baselines.json bumped in the same commit). esacp-qa: approve.
- `test_substrate_apply.py` is at the 80-line cap; capture-path unit tests intentionally not added to avoid a cap-violating decomposition out of scope for a one-function bugfix.

fixes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)