### PR TITLE
chore(process): agenda-lint gate + umbrella:480 grouping label (#560)

### DIFF
--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -279,3 +279,21 @@ Verify functions serve three roles:
 - Reads `hosts_map.yml`, writes `ansible/inventory/kvm.yml`
 - Excludes non-kvm backends: `attrs.get("backend", "kvm") != "kvm"`
 - Injects `ansible_ssh_common_args: "-o ProxyJump=..."` for hosts with a `hypervisor` field
+
+## agenda_lint.py — Session-close carry-forward gate (#560)
+
+`./tools/agenda_lint.py [path]` — scans a next-agenda for `#N` refs, looks up
+each one's live ESACP tracker state, and flags any that is CLOSED yet left
+*bare* (no `done`/`closed`/`✅`/`~~` stamp on its line). With no arg it lints
+the latest `internal_docs/SessionLogs/*-next-agenda.md`. Exit 1 if any flagged
+— run it at session close before committing the next agenda. Guards the root
+cause of #483/#541 staleness: hand-copied status that re-reads as a to-do.
+
+- **ESACP-repo-scoped by design.** `REF_RE`'s lookbehind skips letter-prefixed
+  refs, so cross-repo refs MUST be written with their prefix (`LSKB#16`), never
+  bare `#16` — a bare cross-repo ref is read as ESACP and may mis-flag.
+- **Live-query the #480 path** (its companion deliverable): the `umbrella:480`
+  label replaces the remembered "remaining on #480" sentence —
+  `gh issue list --repo martinhbramwell/ESACP --label umbrella:480 --state open`.
+- Pure core `bare_closed_refs(text, states)` is offline-testable; tests in
+  `tools/test_agenda_lint.py`.

--- a/tools/agenda_lint.py
+++ b/tools/agenda_lint.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Agenda-lint: flag bare CLOSED issue-refs in a next-agenda (#560).
+
+Flags any `#N` that is CLOSED in the ESACP tracker yet left bare — no stamp
+(`done`/`closed`/`✅`/`~~`) on its line (root cause of #483/#541 drift). Scope
+is ESACP-only; cross-repo refs MUST carry their prefix (`LSKB#16`), as REF_RE
+skips letter-prefixed refs.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = "martinhbramwell/ESACP"
+LOGS = Path(__file__).resolve().parent.parent / "internal_docs" / "SessionLogs"
+REF_RE = re.compile(r"(?<![A-Za-z_])#(\d+)")
+STAMP_TOKENS = ("done", "closed", "merged", "won't-fix", "wontfix", "✅", "~~")
+
+
+def bare_closed_refs(text, states):
+    """Return [(lineno, number, line)] per bare CLOSED ref (a line bearing any STAMP_TOKEN, case-insensitive, is stamped and skipped)."""
+    flagged = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stamped = any(tok in line.lower() for tok in STAMP_TOKENS)
+        for m in REF_RE.finditer(line):
+            num = int(m.group(1))
+            if states.get(num) == "CLOSED" and not stamped:
+                flagged.append((lineno, num, line.strip()))
+    return flagged
+
+
+def fetch_states(numbers):
+    """Look up live state per ESACP issue → (states, failures); a failed `gh` call is recorded, never silently treated as OPEN."""
+    states, failures = {}, []
+    for num in sorted(numbers):
+        cp = subprocess.run(
+            ["gh", "issue", "view", str(num), "--repo", REPO, "--json", "state"],
+            capture_output=True, text=True,
+        )
+        if cp.returncode == 0:
+            states[num] = json.loads(cp.stdout)["state"]
+        else:
+            failures.append(num)
+    return states, failures
+
+
+def latest_agenda():
+    return max(LOGS.glob("*-next-agenda.md"), key=lambda p: p.name)
+
+
+def main():
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else latest_agenda()
+    text = path.read_text()
+    states, failures = fetch_states({int(m.group(1)) for m in REF_RE.finditer(text)})
+    if failures:
+        print(f"agenda-lint: WARNING — gh lookup failed for {failures}; result incomplete.", file=sys.stderr)
+    flagged = bare_closed_refs(text, states)
+    for lineno, num, line in flagged:
+        print(f"  {path.name}:{lineno}  #{num} (CLOSED)  {line[:70]}")
+    if flagged:
+        print(f"agenda-lint: {path.name} — {len(flagged)} bare CLOSED ref(s).")
+    elif not failures:
+        print(f"agenda-lint: {path.name} — no bare CLOSED refs.")
+    return 1 if flagged else (2 if failures else 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_agenda_lint.py
+++ b/tools/test_agenda_lint.py
@@ -1,0 +1,46 @@
+"""Colocated test for agenda_lint bare-CLOSED-ref detection (#560)."""
+
+from tools.agenda_lint import bare_closed_refs
+
+STATES = {483: "CLOSED", 541: "CLOSED", 456: "OPEN", 560: "OPEN"}
+
+
+def test_bare_closed_ref_is_flagged():
+    text = "- remaining R6 family under #483 — walkthrough first"
+    flagged = bare_closed_refs(text, STATES)
+    assert len(flagged) == 1
+    assert flagged[0][1] == 483
+
+
+def test_stamped_closed_ref_is_not_flagged():
+    text = "- R6 (#483) DONE — deployed+probed S81"
+    assert bare_closed_refs(text, STATES) == []
+
+
+def test_strikethrough_stamp_suppresses_flag():
+    text = "- ~~#483 R6 nginx parity~~ resolved"
+    assert bare_closed_refs(text, STATES) == []
+
+
+def test_open_ref_is_never_flagged():
+    text = "- #456 faithful homepage rebuild; scope undecided"
+    assert bare_closed_refs(text, STATES) == []
+
+
+def test_cross_repo_ref_is_skipped():
+    # LSKB#483 must not be checked against ESACP state even though 483 is CLOSED.
+    text = "- LSKB#483 Phase-2 follow-on still open upstream"
+    assert bare_closed_refs(text, STATES) == []
+
+
+def test_multiple_refs_one_line_mixed_states():
+    # Bare line: closed #483 flagged, open #456 not; no stamp present.
+    text = "- carry #483 and #456 forward"
+    flagged = bare_closed_refs(text, STATES)
+    assert [f[1] for f in flagged] == [483]
+
+
+def test_lineno_is_reported():
+    text = "header\n\n- bare #541 rebrand underway"
+    flagged = bare_closed_refs(text, STATES)
+    assert flagged[0][0] == 3


### PR DESCRIPTION
## What

Closes the carry-forward-drift root cause behind #483/#541 staleness — the session agenda was a hand-copied cache of tracker status never invalidated on read, so a CLOSED issue kept re-reading as a to-do.

### Deliverables

1. **`tools/agenda_lint.py`** (70 lines, shebang + `chmod +x`) — scans a next-agenda for `#N` refs, looks up each one's live ESACP tracker state via `gh issue view`, and flags any CLOSED ref left **bare** (no `done`/`closed`/`✅`/`~~` stamp on its line). ESACP-repo-scoped: the `REF_RE` lookbehind skips letter-prefixed cross-repo refs (`LSKB#16`). A failed `gh` call is **recorded and surfaced** (stderr warning + exit 2), never silently treated as OPEN — no false-clean result (per QA no-masking condition).
2. **`tools/test_agenda_lint.py`** — 7 colocated tests of the pure core `bare_closed_refs`; all pass.
3. **`tools/CLAUDE.md`** — usage + the cross-repo explicit-prefix authoring rule.
4. **`umbrella:480` label** (GitHub state, not in this diff) applied to the #480 defect-fix children (#456 open; #483 #486 #498 #481 #472 #492 #503 #473 closed). `gh issue list --label umbrella:480 --state open` → just #456. Unblocks the #561 PERT view.

## Acceptance (#560)

- ✅ #480 children carry the grouping label.
- ✅ Agenda-lint flags any carry-forward `#N` whose tracker state is CLOSED — proven live: flagged #548 (a genuine bare closed-ref the issue predicted) on the S94 agenda.
- ⏳ Zero bare closed-refs in the next-agenda — demonstrated at S94 close when the S95 agenda is authored and linted.

## Test

```
7/7 colocated tests pass (driven under python3; pytest not installed in env)
pre_commit_size_check.py → exit 0
GPG-signed, conventional-commit, fixes #560
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)