### PR TITLE
chore(housekeeping): domain-loader hygiene — repoint core ghosts + repopulate map (#575, #576)

### DIFF
--- a/platforms/kvm/session_start.py
+++ b/platforms/kvm/session_start.py
@@ -36,17 +36,20 @@ SYNC_CHECK = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sync_chec
 # ── Domain → file mapping ──────────────────────────────────────────────────
 DOMAINS = {
     'core': [
-        # Always loaded: workflow, behavioural rules, mission
+        # Always loaded: workflow, behavioural rules, mission.
+        # Issues-as-memory + bug-workflow detail now live in CLAUDE.md
+        # (always loaded); core wires only the surviving memory docs.
         'mission_vision.md',
-        'feedback_github_issues.md',
-        'feedback_issue_workflow.md',
-        'feedback_metacognition.md',
-        'feedback_naming_conventions.md',
+        'feedback_issue_branch_session_discipline.md',  # was github_issues/issue_workflow
+        'feedback_stop_and_redesign.md',                # was metacognition
+        'feedback_no_real_client_names.md',             # was naming_conventions
         'feedback_scc_command.md',
     ],
     'erpnext': [
-        # ERPNext production topology, ce_sri scripts, frappe deps
+        # ERPNext topology + V16/Plan-B strategy, ce_sri scripts, frappe deps
         'project_production_erpnext.md',
+        'project_erpnext_idiomatic_refactor.md',
+        'project_end_state_v16_lts_current_stack.md',
         'feedback_envars_secrets_pattern.md',
         'feedback_frappe_v13_deps.md',
         'feedback_lab_passwords.md',
@@ -64,8 +67,9 @@ DOMAINS = {
         'production_topology.md',
     ],
     'cytoscape': [
-        # Empty after S98 purge (stale prototype-era notes removed).
-        # Repopulation tracked in ESACP#575.
+        # Control-plane / topology UI work (Stage 2.3).
+        'feedback_topology_ui_first.md',
+        'feedback_chrome_mcp_cytoscape.md',
     ],
 }
 
@@ -90,11 +94,13 @@ for dom in active_domains:
 
 # ── Build context ──────────────────────────────────────────────────────────
 parts = []
+missing = []
 for f in to_load:
     path = os.path.join(MEMORY_DIR, f)
     if os.path.exists(path):
         parts.append('=== ' + f + ' ===\n' + open(path).read())
     else:
+        missing.append(f)
         parts.append('=== ' + f + ' === [FILE NOT FOUND]')
 
 # ── Sync check — only when KVM domain is active ────────────────────────────
@@ -118,6 +124,8 @@ ctx = '\n'.join(parts) + sync_output + (('\n' + bucket_output) if bucket_output 
 
 # ── Header note ───────────────────────────────────────────────────────────
 loaded_summary   = f"domains={active_domains}, buckets={active_buckets}, files={len(to_load)}"
+if missing:
+    loaded_summary += f"  ⚠️ MISSING DOMAIN FILES (map drift — repair the DOMAINS map): {missing}"
 unloaded_summary = (
     f"INACTIVE domains (files NOT loaded): {inactive_domains}. "
     f"To activate, add domain name to memory/session_focus.txt and start a new session. "


### PR DESCRIPTION
Single domain-loader-hygiene session (S99). Touches `platforms/kvm/session_start.py` (this repo) and `context_domains.md` (LogiSoluMemory, committed there separately).

## #576 (bug) — core domain ghosts + visible drift
The always-loaded `core` domain referenced **4 never-present files** (`feedback_github_issues`, `feedback_issue_workflow`, `feedback_metacognition`, `feedback_naming_conventions`), emitting `[FILE NOT FOUND]` at every session start. Repointed to existing equivalents (issues-as-memory + bug-workflow detail now lives in CLAUDE.md, always loaded):
- github_issues / issue_workflow → `feedback_issue_branch_session_discipline.md`
- metacognition → `feedback_stop_and_redesign.md`
- naming_conventions → `feedback_no_real_client_names.md`

The loader's silent soft-fail is now **loud**: a `⚠️ MISSING DOMAIN FILES` warning is appended to the SessionStart `systemMessage` (per `feedback_check_hooks_before_delete`).

## #575 (chore) — repopulate the thinned map
- `cytoscape` (was empty) → `feedback_topology_ui_first.md` + `feedback_chrome_mcp_cytoscape.md`
- `erpnext` enriched → `project_erpnext_idiomatic_refactor.md` + `project_end_state_v16_lts_current_stack.md`
- `kvm`/`docker` left as-is — their lost files' content now lives in always-loaded subdir CLAUDE.md files.

## Acceptance
- Zero `[FILE NOT FOUND]` across **all** domains (verified by importing DOMAINS + os.path.exists).
- Missing-file warning fires (bogus-file injection test).
- `py_compile` OK.

## Notes
- esacp-qa: approve (pre-commit approve-with-conditions → both conditions discharged; pre-push approve).
- Decomposition of the now-143-line `session_start.py` tracked separately in **#578** (above the advisory gradient; not ratchet-covered).

fixes #575, fixes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)