### PR TITLE
feat(on_boarding): cut canonical Pages URL over to beaverdam.solutions

### DIFF
--- a/.github/workflows/jekyll-pages.yml
+++ b/.github/workflows/jekyll-pages.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build site
         working-directory: on_boarding/docs
-        run: bundle exec jekyll build --baseurl "/ESACP"
+        run: bundle exec jekyll build --baseurl ""
 
       - name: Stage persona doc alongside site
         run: |

--- a/on_boarding/docs/CNAME
+++ b/on_boarding/docs/CNAME
@@ -1,0 +1,1 @@
+beaverdam.solutions

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -293,7 +293,7 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
       </p>
       <blockquote class="chain-narrative">
         Claude, please read from this link
-        <code>https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md</code>
+        <code>https://beaverdam.solutions/persona/mode_a_v0.md</code>
         and take on the Beaverdam specialist expert role "Nick" as it explains.
       </blockquote>
       <p class="why">

--- a/on_boarding/internal_docs/entry-architecture-notes.md
+++ b/on_boarding/internal_docs/entry-architecture-notes.md
@@ -1014,7 +1014,7 @@ URL query strings cap at 2–8KB, so the persona doc itself must be
 fetched at the destination URL, not embedded in the query string.
 
 Prototype + production hosting: **GitHub Pages raw-serve**
-(`https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md`,
+(`https://beaverdam.solutions/persona/mode_a_v0.md`,
 staged by `.github/workflows/jekyll-pages.yml`). The original
 gist-raw pin was **invalidated** — see the amendment below.
 
@@ -1174,7 +1174,7 @@ landed in Session 8 against agenda #489 / sub-branch #493:
 > **Transport superseded (Session 9, 2026-05-29, #497).** The gist
 > URLs below are **dead** — gist-raw is blocked by robots.txt (see the
 > §10.2 amendment). The live transport is GitHub Pages raw-serve:
-> `https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md`,
+> `https://beaverdam.solutions/persona/mode_a_v0.md`,
 > staged by `.github/workflows/jekyll-pages.yml`. The bullets are kept
 > as historical record of the Session-8 instantiation.
 
@@ -1184,7 +1184,7 @@ landed in Session 8 against agenda #489 / sub-branch #493:
   GH-Pages raw-serve path on push to `on_boarding`. *(Session 8 said
   "re-push to the gist" — superseded; no gist involved.)*
 - **Live raw URL** (for §10.2 URL-paste-with-framing):
-  `https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md`.
+  `https://beaverdam.solutions/persona/mode_a_v0.md`.
   ~~Original gist pin
   `https://gist.githubusercontent.com/martinhbramwell/f00ad381b2dc3d9c0995108ad87d2e21/raw/mode_a_persona_v0.md`~~
   — dead (robots.txt).
@@ -1194,7 +1194,7 @@ landed in Session 8 against agenda #489 / sub-branch #493:
   auth-wall per §10.2):
 
   > Please read from this link
-  > https://martinhbramwell.github.io/ESACP/persona/mode_a_v0.md
+  > https://beaverdam.solutions/persona/mode_a_v0.md
   > and take on the ESACP advisor role as it explains.
 
 - **First test input**: Buzz_002, the small-condo-property-
@@ -1225,11 +1225,11 @@ at `/specs/…`):
 
 - **Controller spec** — source
   [`on_boarding/docs/specs/controller_v0.md`](../docs/specs/controller_v0.md)
-  → live `https://martinhbramwell.github.io/ESACP/specs/controller_v0.md`
+  → live `https://beaverdam.solutions/specs/controller_v0.md`
   (#530). Derived from `on_boarding/tools/bootstrap.py`.
 - **saconsole spec** — source
   [`on_boarding/docs/specs/saconsole_v0.md`](../docs/specs/saconsole_v0.md)
-  → live `https://martinhbramwell.github.io/ESACP/specs/saconsole_v0.md`
+  → live `https://beaverdam.solutions/specs/saconsole_v0.md`
   (#531). Derived from the `virt-install` build figures (2 vCPU /
   4 GiB / 20 GB / NAT).
 

--- a/on_boarding/internal_docs/mode_a_persona_v0.md
+++ b/on_boarding/internal_docs/mode_a_persona_v0.md
@@ -243,10 +243,10 @@ Two spec sheets hold the concrete requirements. **Fetch both** and use
 them as your convergence checklist — do not recommend from memory:
 
 - **Controller spec** —
-  `https://martinhbramwell.github.io/ESACP/specs/controller_v0.md`
+  `https://beaverdam.solutions/specs/controller_v0.md`
   (what a machine needs to be the controller).
 - **saconsole spec** —
-  `https://martinhbramwell.github.io/ESACP/specs/saconsole_v0.md`
+  `https://beaverdam.solutions/specs/saconsole_v0.md`
   (what a machine — or hosting plan — needs to host saconsole and the
   ERP itself).
 


### PR DESCRIPTION
Implements #585 — the custom domain `beaverdam.solutions` serves at root, but CI was building with `--baseurl "/ESACP"`, so every asset 404'd → unstyled page.

## Changes
1. **`jekyll-pages.yml:46`** — `--baseurl "/ESACP"` → `--baseurl ""` (Junior-editable per #533 carve-out). Fixes the unstyled page.
2. **`on_boarding/docs/CNAME`** (new) — `beaverdam.solutions`, so Jekyll copies it into `_site` every build (Actions-deploy doesn't persist the dashboard custom-domain setting).
3. **`on_boarding/docs/index.md`** — persona invite URL → `https://beaverdam.solutions/persona/mode_a_v0.md`.
4. **`mode_a_persona_v0.md`** (served via the workflow's stage step) — 2 specs URLs → beaverdam.solutions.
5. **`entry-architecture-notes.md`** — 6 current-truth live-transport refs → beaverdam.solutions. Strikethrough/dead gist URLs left intact; `SESSIONS.md` S8 historical row left intact.

## Local verification
- `jekyll build --baseurl ""` exits 0; built `index.html` asset paths now root-relative (`/assets/css/landing.css`, was `/ESACP/assets/…`); CNAME copied into output; invite URL renders as beaverdam.solutions.

## Post-merge (acceptance — needs the deploy + operator)
The merge to `on_boarding` triggers the Pages workflow. After deploy:
- [ ] `beaverdam.solutions` renders fully styled (light+dark)
- [ ] `github.io/ESACP/` redirects to beaverdam.solutions
- [ ] persona invite URL fetches + loads Nick
- [ ] **(operator)** tick *Enforce HTTPS* once GitHub's DNS check clears + cert issues; keep Cloudflare DNS-only through cert issuance

QA: T1 approve.

fixes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)