### PR TITLE
feat(on_boarding): copy-to-clipboard button on landing-page invitation snippet (#630)

### DIFF
--- a/on_boarding/docs/_layouts/landing.html
+++ b/on_boarding/docs/_layouts/landing.html
@@ -232,5 +232,61 @@
       activate(initial, { silent: true });
     })();
   </script>
+
+  <script>
+    // Copy-to-clipboard for the "invite Nick" paste line. Reads the visible
+    // snippet text (single source of truth), normalises whitespace, and falls
+    // back to execCommand where the async Clipboard API is unavailable.
+    (function () {
+      var buttons = document.querySelectorAll('.copy-snippet');
+      if (!buttons.length) return;
+
+      function fallbackCopy(text) {
+        try {
+          var ta = document.createElement('textarea');
+          ta.value = text;
+          ta.setAttribute('readonly', '');
+          ta.style.position = 'absolute';
+          ta.style.left = '-9999px';
+          document.body.appendChild(ta);
+          ta.select();
+          var ok = document.execCommand('copy');
+          document.body.removeChild(ta);
+          return ok;
+        } catch (e) { return false; }
+      }
+
+      Array.prototype.forEach.call(buttons, function (btn) {
+        var snippet = btn.closest('.chain-snippet');
+        var textEl  = snippet && snippet.querySelector('.snippet-text');
+        if (!textEl) return;
+        var label    = btn.querySelector('.copy-label') || btn;
+        var original = label.textContent;
+        var timer;
+
+        function feedback(ok) {
+          label.textContent = ok ? 'Copied!' : 'Press Ctrl/⌘+C';
+          btn.classList.toggle('copied', ok);
+          clearTimeout(timer);
+          timer = setTimeout(function () {
+            label.textContent = original;
+            btn.classList.remove('copied');
+          }, 2000);
+        }
+
+        btn.addEventListener('click', function () {
+          var text = (textEl.textContent || '').replace(/\s+/g, ' ').trim();
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(
+              function () { feedback(true); },
+              function () { feedback(fallbackCopy(text)); }
+            );
+          } else {
+            feedback(fallbackCopy(text));
+          }
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -445,6 +445,43 @@ body.tabs-overflow .hamburger  { visibility: visible; pointer-events: auto; }
   strong { color: var(--accent-strong); }
 }
 
+/* copy-to-clipboard snippet (the "invite Nick" paste line) */
+
+.chain-snippet {
+  position: relative;
+  padding-right: 5.25rem;        /* leave room for the copy button */
+
+  .snippet-text { display: block; }
+}
+
+.copy-snippet {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.32rem 0.7rem;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--accent);
+  background: var(--card);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  &:hover { background: var(--accent); color: var(--card); }
+  &:focus-visible { outline: 2px solid var(--accent-strong); outline-offset: 2px; }
+
+  &.copied {
+    background: var(--accent);
+    color: var(--card);
+    border-color: var(--accent);
+  }
+}
+
 /* stages */
 
 .stages {
@@ -709,6 +746,19 @@ body.tabs-overflow .hamburger  { visibility: visible; pointer-events: auto; }
   .step::before { font-size: 1.5rem; }
 
   .chain-narrative { padding: 0.95rem 1.05rem; font-size: 0.98rem; }
+  .chain-snippet {
+    padding-right: 1.05rem;       /* button moves below the text on narrow screens */
+
+    .copy-snippet {
+      position: static;
+      display: block;
+      width: 100%;
+      margin-top: 0.7rem;
+      padding: 0.5rem;
+      text-align: center;
+    }
+    .copy-snippet .copy-label { display: inline; }
+  }
   .stage, .pain, .caveat { padding: 0.95rem 1rem 1.1rem; }
 
   .nav-arrows-bottom { margin-top: 2rem; }

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -199,7 +199,7 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
     ... you brain-dump &mdash; in one message, in plain language, and only what you're comfortable sharing &mdash; about the information your business runs on, what you'd most like a computer to handle, what computers you have, and how comfortable you are with computers, AI, and "the cloud".  Bring any doubts, too. 
     </p>
     <p>
-          Nick answers your questions, checks that what you've got can run Beaverdam at all, and names the one unavoidable cost up front: a <strong>Claude Code</strong> subscription, about $20 a month.  Nothing touches your computer, and no sensitive customer or financial detail is needed here.
+          Nick answers your questions, checks that you can actually run Beaverdam, and names the one unavoidable cost up front: a <strong>Claude Code</strong> subscription, about $20 a month.  Nothing touches your computer, and no sensitive customer or financial detail is needed here.
     </p>
     <p class="comment">
       No installation. No commitment. No disruption. The summary is useful even
@@ -289,10 +289,13 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
         Inside your new project, click <strong>New chat</strong>. In the message
         box, paste this one line and press <strong>Send</strong>:
       </p>
-      <blockquote class="chain-narrative">
-        Claude, please read from this link
+      <blockquote class="chain-narrative chain-snippet">
+        <span class="snippet-text">Claude, please read from this link
         <code>https://beaverdam.solutions/first_dialog.md</code>
-        and take on the Beaverdam specialist expert role "Nick" as it explains.
+        and take on the Beaverdam specialist expert role "Nick" as it explains.</span>
+        <button type="button" class="copy-snippet" aria-label="Copy this line to your clipboard">
+          <span class="copy-label">Copy</span>
+        </button>
       </blockquote>
       <p class="why">
         What this does: the link tells Claude how the Beaverdam discovery conversation
@@ -304,7 +307,7 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
   <div class="step">
     <div>
       <h3>Answer in plain language.</h3>
-      <p class="time-hint">~5&ndash;10 minutes</p>
+      <p class="time-hint">As long as you need until you're satisfied</p>
       <p>
         Nick reads your brain-dump, answers any doubts, makes an honest call on whether Beaverdam fits, and &mdash; if it does &mdash; shows you the one next step: setting up Claude Code.
       </p>


### PR DESCRIPTION
## #630 — one-click copy for the "invite Nick" paste line

The landing page asks the visitor to paste an exact one-line invitation (with the `first_dialog.md` URL) into Claude.ai. Hand-selecting is error-prone, especially on mobile, and the URL must be exact. This adds a **Copy** button to that blockquote.

### Changes
- **index.md** — blockquote → `.chain-snippet`; snippet wrapped in `.snippet-text`; `<button class="copy-snippet">` with `aria-label`. Also **promotes the operator's `index_01.md`** wording edits (scratch copy deleted): "checks that you can actually run Beaverdam" + time-hint "As long as you need until you're satisfied" (de-scarcity, consistent with the #622 `first_dialog.md` rewrite).
- **landing.scss** — `.copy-snippet` styling on existing tokens; on ≤40rem the button stacks below the text.
- **landing.html** — self-contained IIFE: copies the visible `.snippet-text` (single source of truth), whitespace-normalised, `navigator.clipboard` + `execCommand` fallback, "Copied!" feedback for 2s, keyboard-accessible, no-op if the button is absent.

### Verified
`jekyll build` exits 0; built `_site` contains the markup, JS, compiled CSS, and the intact invitation URL.

### Acceptance (operator, post-deploy)
Per esacp-qa T1 condition: confirm on the live site that the button copies the exact line (URL intact), shows "Copied!", is keyboard-accessible, and the other two `.chain-narrative` blockquotes are unaffected — **before** the #630 T5 close.

`fixes #630` — manual T5 close on on_boarding. Merge deploys live (operator authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)