### PR TITLE
ci(on_boarding): bump jekyll-pages.yml actions to Node-24 before 2026-06-16 cutover

### DIFF
--- a/.github/workflows/jekyll-pages.yml
+++ b/.github/workflows/jekyll-pages.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -48,7 +48,7 @@ jobs:
         run: bundle exec jekyll build --baseurl ""
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: on_boarding/docs/_site
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
GitHub **forces Node-24 on the Actions runner 2026-06-16** (Node-20 removed 2026-09-16). The `jekyll-pages.yml` Pages-deploy workflow pinned actions whose major tags declared `using: node20`. This bumps them to node24-declaring majors, verified against each action's `action.yml` `runs.using`:

| Action | From | To | runs.using |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | node24 |
| `actions/upload-pages-artifact` | `@v3` | `@v5` | composite (node24-era) |
| `actions/deploy-pages` | `@v4` | `@v5` | node24 |
| `ruby/setup-ruby` | `@v1` | unchanged | already node24 (rolling v1, updated 2026-05-20) |

Junior-editable per the #533 carve-out (on_boarding publishing workflow).

## Acceptance
The workflow runs on push to `on_boarding` when `.github/workflows/jekyll-pages.yml` changes — so merging this PR itself triggers a Pages build+deploy on node24. Green run + beaverdam.solutions still serving = acceptance.

fixes #639 · refs #633 (S18 time-critical housekeeping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)