### PR TITLE
feat(on_boarding): offer a one-time used machine as the safe sandbox

### DIFF
--- a/on_boarding/docs/first_dialog.md
+++ b/on_boarding/docs/first_dialog.md
@@ -144,7 +144,11 @@ yet. The detailed planning happens later, inside their paid Claude
 Code, which can examine their actual machine instead of asking about it.
 The two facts above are all you need here. If a real blocker shows up
 (no computer at all, phone-only, or a Mac as the only machine), name it
-plainly and let it inform the fit verdict.
+plainly — but it's rarely a dead end: an inexpensive used PC (a few
+hundred dollars, one time) is a common, low-cost way through, and it
+doubles as a safe, separate machine to experiment on. Mention that the
+door is open, leave the *how* to the later planning step, and let the
+fit verdict reflect that this is a small hurdle, not a wall.
 
 ---
 

--- a/on_boarding/docs/install_planner.md
+++ b/on_boarding/docs/install_planner.md
@@ -168,18 +168,48 @@ the first that fits:
    cupboard — becomes the Linux saconsole host. Zero monthly cost. If
    the operator has, or can free up, a second machine that meets the
    Layer-B checklist, this beats any paid option.
-3. **A remote VPS / cloud host — the fallback, not the default.** Only
-   when **no** local machine can meet the saconsole-host checklist
-   (not enough memory anywhere, no virtualization, no spare box) do you
-   propose renting a small Linux server. When you do: name it as a real
-   recurring cost, give a realistic figure as a *range* drawn from the
-   spec's resource math (not a number you invented), and say plainly
-   that it exists because the local hardware fell short — so the operator
-   understands the bill and could remove it later by adding local
-   capacity.
+3. **A one-time inexpensive used machine — the safe sandbox.** When the
+   operator has no spare box to free up, the next option is **not** a
+   recurring bill — it is a **single, one-time purchase**: an
+   inexpensive second-hand desktop to act as the Linux saconsole host.
+   This is often the *best* answer, not a compromise, and you should
+   raise it plainly:
+   - **It clears the bar cheaply.** A roughly ten-year-old small
+     business desktop — a 2015-era machine with 8–16 GB of memory, the
+     kind that sells used for about **CAD 300–500** — comfortably meets
+     the saconsole-host checklist (real CPU virtualization, ≥ 8 GiB for
+     a one-target lab, ample disk). Confirm against the figures you read
+     in §1; don't assert specs you didn't check.
+   - **It's a one-time cost, and it stays theirs.** Frame the contrast
+     honestly: a used machine is paid once and fully owned; a rented
+     server (step 4) is paid every month, forever, on someone else's
+     hardware. Within months the one-time machine is cheaper, and it
+     keeps the whole system on a computer the operator controls.
+   - **It's the safest place to experiment.** A dedicated separate
+     machine means nothing Beaverdam does ever touches their real or
+     work computer — the fenced-off, well-lit zone of their own, where
+     mistakes cost nothing. For a cautious operator this reassurance is
+     often worth more than the money.
 
-Never reach step 3 without having genuinely ruled out steps 1 and 2 for
-*this* operator's actual hardware.
+   So **ask** it, in plain terms: *"Would you consider picking up an
+   inexpensive used desktop — a few hundred dollars, one time — to be a
+   safe, separate machine to experiment on? It's often cheaper than
+   renting, and it stays entirely yours."*
+
+4. **A remote VPS / cloud host — the genuine last resort.** Only when
+   **no** local machine works and a one-time purchase isn't on the table
+   (step 3 declined or not feasible) do you propose renting a small
+   Linux server. When you do: name it as a real **recurring** cost, give
+   a realistic figure as a *range* drawn from the spec's resource math
+   (not a number you invented), and say plainly that it exists because
+   the local hardware fell short — so the operator understands the bill
+   and could remove it later by adding local capacity. It is the one
+   option that leaves their own-hardware ideal behind; treat it
+   accordingly.
+
+Never reach step 4 without having genuinely ruled out steps 1–3 for
+*this* operator — including whether a one-time used machine (step 3)
+would serve before any recurring rental.
 
 ---
 
@@ -244,8 +274,9 @@ unsupported install.
 
 - **Don't web-search the spec figures.** §1 is the source of truth; a
   failed fetch is said out loud, never papered over with a search.
-- **Don't propose a paid VPS before ruling out the free local paths**
-  (§4 steps 1–2) for this operator's actual hardware.
+- **Don't propose a paid recurring VPS before ruling out the cheaper
+  paths** — the free local options *and* a one-time used machine
+  (§4 steps 1–3) — for this operator's actual hardware.
 - **Don't recommend against the machine's measured capability.** If
   inspection (§3) says no virtualization or too little memory, that
   machine is not the saconsole host — say so, and find the role it *can*


### PR DESCRIPTION
## Summary
Adds the missing rung in the install planner's cost ladder. Today it jumps from *"a spare machine you already own"* (free) straight to a *recurring VPS* (paid forever) — skipping the option that's often **best**: a **one-time inexpensive used machine**.

## install_planner.md §4 — new step 3
*"A one-time inexpensive used machine — the safe sandbox."* Three honest axes:
- **Clears the bar cheaply** — a ~10-year-old / ≈2015-era 8–16 GB business desktop (~CAD 300–500) comfortably meets the saconsole Layer-B checklist (VT-x, ≥8 GiB one-target, ~50 GB disk). Deferred to the §1 spec-fetch — *"confirm against the figures you read; don't assert specs you didn't check."*
- **One-time, and stays theirs** — paid once, fully owned, keeps the whole system on operator-controlled hardware (the own-hardware ideal a VPS abandons).
- **Safest place to experiment** — a dedicated separate machine means nothing touches the operator's real/work computer (the fenced-off, well-lit zone).
- Ends with a plain-language **ask**.

VPS demoted to **step 4, "genuine last resort."** Updated §4 closing line + §7 cross-reference for the 1–3 / 4 split. Incidentally fixes a pre-existing off-by-one (§6 already said *"step 4 of §4 (a VPS)"* while VPS was step 3).

## first_dialog.md §4 — softened dead-end
Phone-only / Mac-only is no longer a near dead-end: *"an inexpensive used PC … is a common, low-cost way through, and doubles as a safe separate machine to experiment on."* Kept **light** — leaves the *how* to the planner, per §4's feasibility-not-a-plan contract.

## Acceptance
Merge triggers the Jekyll deploy; both docs must still serve 200 with the new §4 content live. Verified post-merge before closing #644.

fixes #644 · refs #602 (install planner), #633 (S18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)