### PR TITLE
docs(session-log): Session 108 — #480 V13→V15 catalog re-validation + #643 OS-per-major

### DIFF
--- a/internal_docs/SessionLogs/2026-06-07-0748-next-agenda.md
+++ b/internal_docs/SessionLogs/2026-06-07-0748-next-agenda.md
@@ -1,0 +1,87 @@
+# 2026-06-07 0748 — Next agenda (Session 109)
+
+> Carry-forward refs reconciled against live tracker state at S108 close. Run
+> `./tools/agenda_lint.py` to exit 0. Re-verify any `#N` with `gh issue view N` before treating
+> it as open work. Cross-repo refs carry explicit prefixes (`LSKB#NN`); bare `#NN` is ESACP.
+>
+> **S108 delivered the #480 V15 catalog re-validation** (umbrella re-targeted V13→V15 + V15→V16;
+> source-verified delta posted) and **filed #643** (OS-per-major template matrix) after the operator
+> set that direction. Plan `~/.claude/plans/beaverdam-v15-baseline-dual-template.md` §4 + the
+> end-state memory updated to OS-per-major.
+
+## State carried forward
+- **ESACP branch at next-session-start**: `main`, clean apart from Junior's untracked
+  `on_boarding/onBoardingQRcode.png` (leave). Kept branches: `feat/480-v15-catalog-delta`,
+  `feat/631-template-v15`, `feat/617-naming-series-probe`, `feat/626-server-script-enabled`,
+  `umbrella/v16-clean-run` (no prune).
+- **main tip**: S108 merge (`feat/480-v15-catalog-delta` — session logs only).
+- **Open issues**: ESACP **84** (re-confirm; S108 opened #643, closed none), LSKB **13**.
+- **#480**: re-targeted to **V13→V15 baseline + V15→V16 tracked**; v15 catalog delta posted as a
+  comment. Children step-classified: #617→V13→V15, #626→V13→V15, #618→V15→V16. Umbrella STAYS
+  OPEN — the dual-script build is the next increment.
+- **#643 (NEW)**: OS-per-major templates — dev13→22.04 / dev15→24.04 / dev16→26.04, latest-valid
+  deps. Source-verified v15 supports 24.04 (frappe `requires-python ">=3.10,<3.15"`). Deferred to
+  its own 1:1:1 (substantive Packer/pipeline work).
+- **dev15_01**: 22.04 **demonstrator** only (clean V15, generic, no prod data; hostname still
+  `packer-build` — identity gap is a non-issue for a template per operator). The OS-correct v15
+  baseline rebuilds on `template_v15`@24.04 (#643). wg 10.10.0.18; not yet in `~/.ssh/config`.
+- **dev02**: shut down (parked V16/tracked-line box). **dev01**: V13, unchanged.
+- **TRIVIAL_FIXES.md**: 1 entry (S33 LSMem T3 monitor).
+
+## Objective for Session 109 — TO BE PINNED (operator)
+
+Recommended (no-rework sequencing): **#643 — build `template_v15` on Ubuntu 24.04** (latest-valid
+deps), then provision the OS-correct v15 baseline. Rationale: the V13→V15 migration **script**
+(plan §2a) must be written + tested against a **data-bearing v15 box**, and that box should be on
+24.04 — building the script against the 22.04 demonstrator would be throwaway. #643 first → correct
+substrate → then the script increment.
+
+Alternative candidates (operator's call):
+- **V13→V15 migration script (plan §2a)** — the umbrella's terminal artifact. Needs prod-data
+  restore onto a v15 box + `bench migrate` to v15 + V13→V15 fixups (R3, #626 flag, #617 admin) +
+  assertions. Larger; depends on a data-bearing v15 substrate.
+- **#629 FAC smoke-test on the v15 baseline** — now unblocked (MCP-first path); moderate.
+
+## Out of scope (default)
+- Production cutover (READ-ONLY). CloudStack (gates V16). Plan B execution (parked).
+- Bespoke-apps-on-v15 (migration territory; downstream of the V13→V15 script).
+
+## Pre-flight checklist (S109 start)
+1. `bash platforms/kvm/sync_check.sh` — investigate FAILs only (dev02 expected-down).
+2. `gh issue list --repo martinhbramwell/ESACP --state open --limit 200 --json number --jq 'length'`.
+3. `gh issue list --repo martinhbramwell/LogiSoluKnowBase --state open --limit 200 --json number --jq 'length'` — expect 13.
+4. Branch off `main` per the pinned objective.
+5. Memory-grep before authoring (end-state, beaverdam-mcp-first-sequencing; for #643 also
+   feedback_frappe_v13_deps + the Packer build path under platforms/kvm).
+6. esacp-qa verdict before any commit / merge / push / destructive op / issue close.
+7. `git -C <dir>` for the LogiSoluMemory clone, not `cd && git`.
+
+## Carry-forward operator-reminders
+> Standing behavioural bindings live in MEMORY.md, not recycled here.
+
+Open, genuinely-actionable:
+- **#643** — OS-per-major template matrix (dev15→24.04 first; verify v16 `requires-python` for 26.04).
+- **#480** — dual-script build (V13→V15 + V15→V16) is the deferred terminal increment; needs a
+  data-bearing v15 substrate. Re-home R3 to also run on the V13→V15 line at build time; fix the
+  stale "R1 pending" comment on #486 (CLOSED).
+- **#629** — FAC smoke-test on the v15 baseline.
+- **dev01/dev02/dev15 rename + ssh_config** — add `dev15_01` to `~/.ssh/config`; the dev{13,15,16}
+  relabel approach (full re-provision vs hosts_map relabel) still open (plan §4).
+- **LogiSoluValidations** coverage audit/expansion — credible dual-line regression (plan §5/§6.5).
+- **FAC AGPL-3.0 posture** — decide before building on it.
+- **#614** real-names scrub policy; **#594** residual operator-identity literals (incl.
+  `METADATA_DIR` username path); **#563** de-dup guard; **#581/#580/#578** size/dead-config;
+  **#561** PERT view; **#552** tablet key-auth.
+- **LSKB#10 / LSKB#11 / LSKB#16 / LSKB#18 / LSKB#21 / LSKB#24 / LSKB#31 / LSKB#32**;
+  **#387 / #394 / #395 / #397** pre-S48 carry.
+
+## Reminders
+- Run `./tools/agenda_lint.py` at close — exit 0 before committing the agenda.
+- Author carry-forward from tracker STATE, not prose.
+- Lead with the decision, prune dead-end options.
+- plan-before-code: implement toward the approved V15-baseline plan.
+- No-real-names — `LogiSolu` alias; scrub real usernames/emails.
+
+## Estimated wall-clock
+#643 template_v15@24.04 build + provision (moderate–large — Packer rebuild + acceptance) <
+V13→V15 migration script (large) ; #629 FAC smoke-test (moderate).

--- a/internal_docs/SessionLogs/2026-06-07-0748-session-minutes.md
+++ b/internal_docs/SessionLogs/2026-06-07-0748-session-minutes.md
@@ -1,0 +1,73 @@
+# 2026-06-07 0748 — Session 108 minutes
+
+## Objective (operator-pinned)
+
+**#480 — re-target the V13→V16 umbrella to V13→V15 and re-validate the defect catalog against the
+live `dev15_01` V15 baseline.** Deliverable: a written v15 defect-catalog delta on the #480
+umbrella + the umbrella re-targeted. **Achieved**, plus a mid-session architectural decision
+captured (OS-per-major, ESACP#643).
+
+## Class
+
+Analysis + tracker + planning session under the #480 umbrella. No substantive ESACP code change —
+the deliverables landed on GitHub (#480 retarget + delta), an external plan file, and the
+LogiSoluMemory repo. The ESACP branch (`feat/480-v15-catalog-delta`) carries only these session
+logs. **Not** an introspection-sidebar (no MEMORY.md indexing edits; no carry-forward attrition of
+the mechanical kind). One new issue filed mid-session (#643, deferred to its own 1:1:1).
+
+## What happened
+
+### Pre-flight
+sync_check 48✅/10⚠️/2❌ — both ❌ are dev02 (parked V16 box, expected-down per agenda). Issues
+ESACP 83 / LSKB 13 (matched agenda's ~85/13). TRIVIAL_FIXES: 1 monitor-only entry (S33), no action.
+Branch `feat/480-v15-catalog-delta` cut from `main`. Memory-grep done (reference_erpnext_v16_desk_ui,
+project_v16_migration_triage_criterion, beaverdam-mcp-first-sequencing, end-state memory).
+
+### Method — read the live v15 source, not archaeology
+dev15_01 reached over WireGuard (`erpadm@10.10.0.18`, key hasan_mighty; not yet in ssh_config).
+All catalog classifications are **mechanism-level, read from live frappe/erpnext 15.110.0 source** on
+the box. The baseline is generic (no prod data), so data-level *reproduction* of each defect is
+deferred to the migration-with-data step; which **step** each defect lives on was settled by source.
+
+### v15 defect-catalog delta (posted on #480)
+| Row | v15 source finding | Step | vs. prior |
+|---|---|---|---|
+| **R1** Homepage salvage | `erpnext/portal/doctype/homepage` **alive** on v15 (issingle) | **V15→V16** | 🔄 FLIP (was V13→V15) |
+| **#626** server_script_enabled | v15 `is_safe_exec_enabled()` reads `get_common_site_config()` **only** — same as v16 | **V13→V15** | 🔄 REFUTES "per-site on v15" |
+| **#618** atajos masking | v15 sidebar does `pages.extend(private_pages)` — private workspaces **surfaced** | **V15→V16** | ✅ confirms |
+| **leaderboard** | Page **present** on v15 (`frappe/desk/page/leaderboard` + `erpnext/startup/leaderboard.py`) | **V15→V16** | ✅ confirms |
+| **#617** Naming Series | `Naming Series` DocType **gone** on v15 → `Document Naming Settings`/`Rule` (v14+ rename already in v15) | **V13→V15** (probe both) | ✅ confirms |
+| **R3** IRS-1099 | tenant-data orphan, version-agnostic fix | **V13→V15** | clarified |
+| **R5/R6** nginx | ESACP-template, version-independent | provision-time | clarified |
+| **R2** /tasks | stock v14+, accepted won't-fix | n/a | unchanged |
+
+Two prior assumptions overturned by source: **R1 is a v16 defect (Homepage alive on v15)**, and
+**#626's common-only gate is identical on v15 (fix still needed)**. Incidental: `v16_post_migrate_fixups.py`
+already contains both R1 and R3 (#486's "R1 pending" comment is stale).
+
+### #480 umbrella re-targeted
+Retitled "V13→**V16**" ⇒ "**V13→V15 baseline + V15→V16 tracked**". Delta posted as a comment.
+Step-assignments posted on children #617 (V13→V15) / #626 (V13→V15) / #618 (V15→V16). Tier-B
+#456/#457 untouched; R2 won't-fix unchanged. Used comments, not new label machinery (operator
+didn't request a label scheme).
+
+### Mid-session decision — OS-per-major (ESACP#643, NEW)
+Operator: each major inhabits its era-matched Ubuntu LTS with latest-valid deps — **dev13→22.04 /
+3.10** (v13 deps genuinely pinned), **dev15→24.04 / 3.12**, **dev16→26.04 / 3.12+**. Source-verified
+clean for v15: frappe v15.110 `requires-python = ">=3.10,<3.15"` → 24.04's Python 3.12 fully
+supported; the Python-3.12+ wall is v16-only (PEP-695). Consequence: the current dev15_01 (22.04) is
+a **demonstrator** on the wrong OS; the OS-correct v15 baseline rebuilds when `template_v15`@24.04
+lands (the Packer build is already frappe-major-parameterized — adds an OS build-arg). Operator: **no
+dev15_01 rebuild yet**; finish the planned catalog work. Filed #643 (deferred, own 1:1:1); updated
+plan §4 + the end-state memory (the "v15 runs on 22.04/3.10" framing was floor-not-ceiling).
+
+## Outcomes
+- **#480** re-targeted V13→V15 + V15→V16; v15 catalog delta written on the umbrella. (Stays OPEN —
+  the dual-script build is the deferred next increment.)
+- **#643 OPEN (NEW)** — OS-per-major template matrix; deferred to its own 1:1:1.
+- **#617 / #626 / #618** step-classified on v15 (V13→V15 / V13→V15 / V15→V16).
+- Catalog delta is OS-independent → stands against the future 24.04 v15.
+- Plan §4 + end-state memory updated to OS-per-major.
+
+## esacp-qa ledger
+(to be appended at pre-commit/pre-merge below)


### PR DESCRIPTION
Session 108 — analysis/tracker/planning under the #480 umbrella. Doc-only (session logs); the substantive deliverables landed on GitHub (#480 retarget + v15 catalog delta), an external plan file, and the memory repo.

- **#480** re-targeted V13→V16 ⇒ **V13→V15 baseline + V15→V16 tracked**; source-verified v15 catalog delta posted (read from live frappe/erpnext 15.110.0 on dev15_01). Children step-classified: #617/#626 → V13→V15, #618 → V15→V16.
- **#643** (NEW) — OS-per-major template matrix (dev13→22.04 / dev15→24.04 / dev16→26.04, latest-valid deps); deferred to its own 1:1:1.

esacp-qa: approve (pre-commit) · approve (pre-merge). No issue closed.

Refs #480, #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)