### PR TITLE
chore(claude-config): scoped Edit/Write allowlist for session-housekeeping paths (#653)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Edit(internal_docs/SessionLogs/**)",
+      "Write(internal_docs/SessionLogs/**)",
+      "Edit(.claude/hooks/session_close_audit.sh)"
+    ]
+  },
   "hooks": {
     "UserPromptSubmit": [
       {


### PR DESCRIPTION
## Problem

Routine session-close edits (session-log minutes/agendas, the close-audit hook, memory-dir files) fell through to interactive permission prompts every session — 4–5 in a row with no safety benefit (the operator is already supervising). #653.

## Fix

Tightly-scoped, path-prefixed allow rules — no blanket `Edit(**)`:

- **Checked-in `.claude/settings.json`** (shared, project-relative): `Edit/Write internal_docs/SessionLogs/**`, `Edit .claude/hooks/session_close_audit.sh`.
- **Local `.claude/settings.local.json`** (gitignored, controller-specific encoded memory-dir path): `Edit/Write` the LogiSoluMemory mount — added out-of-band, not committable.

Substantive code edits (`tools/pipeline/**`, ansible, SOPS) still prompt.

## Acceptance

Permission rules load at **session start**, so the no-prompt behaviour takes effect next session: a session-log/memory-file edit completes without a prompt, while a `tools/pipeline/**` edit still prompts. Verified end-to-end at next session start.

fixes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)