### PR TITLE
feat(qa): branch-base currency gate (#673)

### DIFF
--- a/.claude/agents/esacp-qa.md
+++ b/.claude/agents/esacp-qa.md
@@ -87,6 +87,24 @@ Read these as authoritative; the parent's interpretation is not. When in doubt, 
 - **Saconsole CLI-only lifecycle** (`feedback_saconsole_cli_only.md`) — no UI destroy/rebuild button for the hub.
 - **Domain switch protocol** (`feedback_domain_switch_protocol.md`) — STOP, announce, load context, then act.
 
+# Branch-base currency check (#673)
+
+Before any **commit** (trigger 1) or **merge** (trigger 2) verdict, run
+`./tools/branch_currency.py --no-fetch` yourself (`--no-fetch` keeps it strictly
+read-only — `git rev-list` against the already-fetched `origin/main`; the parent
+owns the fetch) and factor the result into the verdict:
+
+- If the action's branch (or, for a merge, the source branch) is **behind
+  origin/main** and the parent's deliberation does **not** state an explicit
+  rebase intent, **reject** (hard-block on merge). Branching, committing, or
+  merging on a stale base is the S116 root cause this gate exists to stop.
+- An `umbrella/*` source branch that is behind origin/main is a hard reject for
+  merge — umbrella discipline requires it be rebased onto main first.
+- If `branch_currency.py` reports all current, note it and proceed.
+
+This is the action-time hard enforcement; `sync_check.sh` §19 is the session-start
+surfacing. You are the teeth.
+
 # Verdict format
 
 Reply in plain prose first — your reasoning, what you read, what you considered, what concerned you. Then end with **exactly** this fenced block, no extra blank lines inside it:

--- a/internal_docs/qa-contract.md
+++ b/internal_docs/qa-contract.md
@@ -182,6 +182,17 @@ This is acceptable for v1 because the agent's output is text (a verdict), not ac
 
 ---
 
+## 9.5 Branch-base currency check (#673)
+
+Before any T1 (commit) or T2 (merge) verdict, the agent runs
+`./tools/branch_currency.py --no-fetch` (strictly read-only `git rev-list`
+against the already-fetched `origin/main`; the parent owns the fetch) and
+hard-blocks a merge whose source branch — especially any `umbrella/*` — is
+behind `origin/main` without an explicit rebase intent in the parent's
+deliberation. This is the action-time enforcement of the rebase-cadence rule;
+`sync_check.sh` §19 is the complementary session-start surfacing. Root cause:
+S116 cut a sub-branch off an umbrella 30 commits stale and only found out live.
+
 ## 10. Revision history
 
 | Date | Change | Source |
@@ -189,3 +200,4 @@ This is acceptable for v1 because the agent's output is text (a verdict), not ac
 | 2026-05-03 | v1 initial — implementation of #341 | `feat/esacp-qa-agent` branch, D2a |
 | 2026-05-12 | v2 — risk-tiered triggers calibrated on Sessions 5.5–36 data (109 verdicts): T2 advisory carve-out when prior T1+T3 approve already covers the commits; T1+T3 combined invocation codified; rolling-window recalibration audit at every 25th ESACP session | [#380](https://github.com/martinhbramwell/ESACP/issues/380) |
 | 2026-05-12 | v2.1 — §2.1 condition 2 broadened to recognise repo-specific direct-to-main conventions (e.g., ESACP doc-only session-close commits per S30–S36 precedent), so the §2.1 carve-out covers the very lane that motivated it. v2 wording was under-inclusive and caught by the v1 QA agent on the Session 37 session-close commit. | [#382](https://github.com/martinhbramwell/ESACP/issues/382) |
+| 2026-06-08 | v2.2 — §9.5 branch-base currency check: agent runs `tools/branch_currency.py` and hard-blocks a merge on a base behind origin/main (esp. `umbrella/*`). Action-time teeth for the rebase-cadence rule; pairs with `sync_check.sh` §19. | [#673](https://github.com/martinhbramwell/ESACP/issues/673) |

--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -595,6 +595,24 @@ else
     fix "Run ./tools/run_tests.py from project root and fix failures before starting work"
 fi
 
+# ── 19. Branch-base currency (#673) ───────────────────────────────────────────
+hdr "19. Branch-base currency"
+
+# S116 root cause: a sub-branch was cut off umbrella/v16-clean-run while it was
+# 30 commits behind main; the divergence surfaced only live, mid-session. This
+# surfaces every umbrella + the current branch's distance from origin/main BEFORE
+# any branch op. Severity split: WARN here (don't brick startup over pre-existing
+# umbrella debt) — esacp-qa hard-blocks commits/merges on a stale base at the
+# moment that distance actually matters. One source of truth: tools/branch_currency.py.
+CURR_OUT="$(cd "${PROJ_ROOT}" && ./tools/branch_currency.py 2>&1)"; CURR_RC=$?
+printf '%s\n' "${CURR_OUT}"
+if [[ ${CURR_RC} -eq 0 ]]; then
+    ok "Branch bases current with origin/main"
+else
+    warn "Branch divergence from origin/main — see above"
+    fix "Rebase stale umbrella/* branches; esacp-qa hard-blocks commits/merges on a stale base"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tools/branch_currency.py
+++ b/tools/branch_currency.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Branch-base currency gate (#673).
+
+FAIL when an `umbrella/*` branch is behind `origin/main`, or WARN when the
+current working branch is. Long-lived branches that silently diverge from main
+are the S116 root cause: a sub-branch was cut off an umbrella 30 commits stale,
+and the divergence was only discovered live mid-session. CLAUDE.md's
+rebase-cadence rule is real but unenforced; this is its mechanical teeth.
+
+One source of truth for two surfaces: `sync_check.sh` §19 (session start) and
+the `esacp-qa` verdict layer both invoke it. Pass `--no-fetch` to skip the
+`git fetch` — esacp-qa runs read-only and compares against the already-fetched
+`origin/main` (the parent / sync_check owns the refresh).
+
+Exit 0 when nothing is behind (or only the current branch is, a WARN); exit 1
+when any `umbrella/*` is behind origin/main.
+"""
+
+import subprocess
+import sys
+
+
+def _git(*args):
+    return subprocess.run(["git", *args], capture_output=True, text=True)
+
+
+def behind_count(branch, base="origin/main"):
+    """Commits on *base* not in *branch*; None if the rev-list call fails."""
+    cp = _git("rev-list", "--count", f"{branch}..{base}")
+    return int(cp.stdout.strip()) if cp.returncode == 0 else None
+
+
+def classify(name, behind, is_umbrella):
+    """Pure verdict → (level, message). level ∈ {ok, warn, fail}.
+
+    An umbrella behind main is a FAIL (umbrella discipline demands currency);
+    any other branch behind main is a WARN (rebase before merge, not yet wrong).
+    """
+    if behind is None:
+        return ("warn", f"{name}: currency unknown — rev-list failed")
+    if behind == 0:
+        return ("ok", f"{name}: current with origin/main")
+    if is_umbrella:
+        return ("fail", f"{name}: {behind} commit(s) behind origin/main — rebase before use")
+    return ("warn", f"{name}: {behind} commit(s) behind origin/main — rebase before merge")
+
+
+def _umbrella_branches():
+    cp = _git("branch", "--list", "umbrella/*", "--format=%(refname:short)")
+    return [b for b in cp.stdout.split() if b]
+
+
+def _current_branch():
+    return _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+
+def evaluate():
+    """Classify every umbrella + the current branch. Returns list[(level, msg)]."""
+    rows = [classify(u, behind_count(u), True) for u in _umbrella_branches()]
+    cur = _current_branch()
+    if cur and cur != "main" and not cur.startswith("umbrella/"):
+        rows.append(classify(cur, behind_count(cur), False))
+    return rows
+
+
+def main():
+    # Refresh origin/main so the comparison is against the real remote tip
+    # (tolerate offline). `--no-fetch` keeps the run strictly read-only.
+    if "--no-fetch" not in sys.argv:
+        _git("fetch", "--quiet", "origin", "main")
+    rows = evaluate()
+    if not rows:
+        print("  branch-currency: on main, no umbrellas — nothing to check")
+        return 0
+    glyph = {"ok": "✅", "warn": "⚠️ ", "fail": "❌"}
+    for level, msg in rows:
+        print(f"  {glyph[level]} {msg}")
+    return 1 if any(level == "fail" for level, _ in rows) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_branch_currency.py
+++ b/tools/test_branch_currency.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Colocated test for branch_currency.classify (#673) — pure, offline core."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.branch_currency import classify  # noqa: E402
+
+
+def test_umbrella_behind_is_fail():
+    level, msg = classify("umbrella/v16-clean-run", 30, is_umbrella=True)
+    assert level == "fail"
+    assert "30 commit" in msg
+
+
+def test_umbrella_current_is_ok():
+    level, _ = classify("umbrella/v16-clean-run", 0, is_umbrella=True)
+    assert level == "ok"
+
+
+def test_feature_branch_behind_is_warn_not_fail():
+    # A working branch a few commits behind main is rebase-before-merge, not yet wrong.
+    level, msg = classify("feat/673-x", 3, is_umbrella=False)
+    assert level == "warn"
+    assert "rebase before merge" in msg
+
+
+def test_feature_branch_current_is_ok():
+    level, _ = classify("feat/673-x", 0, is_umbrella=False)
+    assert level == "ok"
+
+
+def test_unknown_count_is_warn_never_silent_ok():
+    # A failed rev-list must surface as a warn, never be masked into a false "current".
+    level, msg = classify("umbrella/x", None, is_umbrella=True)
+    assert level == "warn"
+    assert "unknown" in msg
+
+
+if __name__ == "__main__":
+    from tools.testkit import run_module_tests
+    raise SystemExit(run_module_tests(globals()))


### PR DESCRIPTION
Closes #673. First of three mechanical session-integrity guardrails (#673/#674/#675) from the S116 retrospective.

**Root cause:** I cut a sub-branch off `umbrella/v16-clean-run` while it was 30 commits behind main and found out only live, mid-session. The rebase-cadence rule existed but was unenforced.

**This PR — base-currency gate:**
- `tools/branch_currency.py` — one source of truth; pure `classify()` core (umbrella behind origin/main → FAIL, other branch → WARN, unknown → WARN). `--no-fetch` keeps esacp-qa strictly read-only.
- `tools/test_branch_currency.py` — 5 colocated tests (suite 63/63).
- `sync_check.sh` §19 — session-start surfacing (WARN, doesn't brick startup).
- `esacp-qa.md` + `qa-contract.md` §9.5 — action-time hard-block on a stale base.

**First live run flagged 4 stale umbrellas** (252/339/147/30 behind) — reconciling those is separate, out-of-scope work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)