### PR TITLE
feat(qa): plan-substrate lint (#674)

### DIFF
--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -613,6 +613,23 @@ else
     fix "Rebase stale umbrella/* branches; esacp-qa hard-blocks commits/merges on a stale base"
 fi
 
+# ── 20. Plan-substrate currency (#674) ────────────────────────────────────────
+hdr "20. Plan-substrate currency"
+
+# S116 root cause: the S115 plan asserted "branch off the umbrella", "register
+# dev15_01" — already done on main by pickup. A plan reads true-now but is only
+# true-when-written. plan_lint verifies the latest agenda's declared plan-check
+# block (base branch currency + creates-host not already registered) against live
+# state. WARN surface; no block ⇒ soft pass (legacy agendas).
+PLAN_OUT="$(cd "${PROJ_ROOT}" && ./tools/plan_lint.py 2>&1)"; PLAN_RC=$?
+printf '%s\n' "${PLAN_OUT}"
+if [[ ${PLAN_RC} -eq 0 ]]; then
+    ok "Plan-substrate assertions match live state"
+else
+    warn "Plan-substrate drift — the agenda's declared base/host no longer matches live state"
+    fix "Re-ground the plan against live git + hosts_map before accepting the objective"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -298,6 +298,37 @@ cause of #483/#541 staleness: hand-copied status that re-reads as a to-do.
 - Pure core `bare_closed_refs(text, states)` is offline-testable; tests in
   `tools/test_agenda_lint.py`.
 
+## plan_lint.py — Plan-substrate currency gate (#674)
+
+`./tools/plan_lint.py [agenda-path]` — verifies a plan/agenda's **declared**
+substrate against **live** state at pickup, the session-start counterpart of
+`agenda_lint` (which runs at close). Root cause: S116 accepted an S115 plan
+asserting "branch off the umbrella" / "register dev15_01" — already done on
+main by pickup. A plan reads true-now but is only true-when-written.
+
+The agenda declares a machine-checkable block (an HTML comment, invisible in
+rendered markdown), authored at session close alongside the carry-forward:
+
+```
+<!-- plan-check
+base: umbrella/v16-clean-run
+creates-host: dev15_01
+-->
+```
+
+- `base:` — the branch the next session builds on. Must exist AND be current
+  with origin/main (reuses `branch_currency.behind_count`, #673 — one source of
+  truth). A stale base ⇒ FAIL.
+- `creates-host:` — a host the plan will register. Must NOT already be in
+  `hosts_map.yml` ⇒ FAIL if present (someone already did it).
+- No block ⇒ soft pass (legacy agendas). Exit 1 if any declared assertion fails.
+
+Surfaced at session start by `sync_check.sh` §20 (WARN). Pure cores
+`parse_block` / `check_creates_host` / `evaluate` are offline-testable; tests in
+`tools/test_plan_lint.py`. **When authoring a next-agenda whose objective builds
+on a specific branch or registers a host, include the plan-check block** so the
+pickup session's `sync_check` catches drift before any branch op.
+
 ## run_tests.py — Colocated test-execution gate (#663)
 
 `./tools/run_tests.py` — discovers every `test_*.py` under `tools/` (excluding

--- a/tools/plan_lint.py
+++ b/tools/plan_lint.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Plan-substrate lint (#674).
+
+Verify a plan/agenda's *declared* substrate against *live* state at pickup —
+the S116 root cause was accepting an S115 plan ("branch off the umbrella",
+"register dev15_01") whose assertions were already stale on main. A plan reads
+true-now but is only true-when-written; this makes that difference mechanical.
+
+The agenda declares a `<!-- plan-check ... -->` block (format + rationale in
+tools/CLAUDE.md) with:
+  base:         a branch the session builds on — must exist + be current (#673).
+  creates-host: a host it will register — must NOT already be in hosts_map.yml.
+No block => soft pass (legacy agendas). Exit 1 if any declared assertion fails.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.branch_currency import behind_count, _git  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[1]
+LOGS = REPO / "internal_docs" / "SessionLogs"
+HOSTS_MAP = REPO / "hosts_map.yml"
+
+BLOCK_RE = re.compile(r"<!--\s*plan-check\s*(.*?)-->", re.DOTALL)
+KEY_RE = re.compile(r"^\s*([a-z][a-z-]*):\s*(\S.*?)\s*$", re.M)
+
+
+def parse_block(text):
+    """Extract the plan-check block as {key: [values]}; None if absent."""
+    m = BLOCK_RE.search(text)
+    if not m:
+        return None
+    out = {}
+    for key, val in KEY_RE.findall(m.group(1)):
+        out.setdefault(key, []).append(val)
+    return out
+
+
+def check_creates_host(host, hosts_map_text):
+    """(level, msg) — a host the plan will create must NOT already be registered."""
+    if re.search(rf"^\s*{re.escape(host)}:\s*$", hosts_map_text, re.M):
+        return ("fail", f"creates-host '{host}' already in hosts_map — plan is stale")
+    return ("ok", f"creates-host '{host}' not yet present — safe to create")
+
+
+def check_base(branch):
+    """(level, msg) — base branch must exist and be current with origin/main."""
+    if _git("rev-parse", "--verify", "--quiet", branch).returncode != 0:
+        return ("fail", f"base '{branch}' does not exist")
+    behind = behind_count(branch)
+    if behind is None:
+        return ("warn", f"base '{branch}': currency unknown — rev-list failed")
+    if behind > 0:
+        return ("fail", f"base '{branch}' is {behind} commit(s) behind origin/main — stale plan")
+    return ("ok", f"base '{branch}' current with origin/main")
+
+
+def evaluate(text, hosts_map_text):
+    """Run every declared check. Returns (rows, has_block)."""
+    block = parse_block(text)
+    if block is None:
+        return ([], False)
+    rows = [check_base(b) for b in block.get("base", [])]
+    rows += [check_creates_host(h, hosts_map_text) for h in block.get("creates-host", [])]
+    return (rows, True)
+
+
+def _latest_agenda():
+    return max(LOGS.glob("*-next-agenda.md"), key=lambda p: p.name)
+
+
+def main():
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else _latest_agenda()
+    rows, has_block = evaluate(path.read_text(), HOSTS_MAP.read_text())
+    if not has_block:
+        print(f"  plan-lint: {path.name} — no plan-check block (legacy/soft-pass)")
+        return 0
+    glyph = {"ok": "✅", "warn": "⚠️ ", "fail": "❌"}
+    for level, msg in rows:
+        print(f"  {glyph[level]} {msg}")
+    return 1 if any(level == "fail" for level, _ in rows) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_plan_lint.py
+++ b/tools/test_plan_lint.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Colocated test for plan_lint (#674) — pure, offline cores."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.plan_lint import parse_block, check_creates_host, evaluate  # noqa: E402
+
+HOSTS_MAP = "  kvm:\n    dev15_01:\n      hostname: dev15_01\n    dev02:\n      hostname: dev02\n"
+
+BLOCK = "<!-- plan-check\nbase: umbrella/v16-clean-run\ncreates-host: dev15_01\n-->"
+
+
+def test_parse_block_extracts_keys():
+    d = parse_block(f"intro\n{BLOCK}\nrest")
+    assert d["base"] == ["umbrella/v16-clean-run"]
+    assert d["creates-host"] == ["dev15_01"]
+
+
+def test_parse_block_absent_is_none():
+    assert parse_block("a plain agenda with no block") is None
+
+
+def test_creates_host_already_registered_is_fail():
+    # The exact S116 trap: plan says "register dev15_01" but main already has it.
+    level, msg = check_creates_host("dev15_01", HOSTS_MAP)
+    assert level == "fail"
+    assert "already in hosts_map" in msg
+
+
+def test_creates_host_absent_is_ok():
+    level, _ = check_creates_host("dev99", HOSTS_MAP)
+    assert level == "ok"
+
+
+def test_evaluate_no_block_soft_passes():
+    rows, has_block = evaluate("no block here", HOSTS_MAP)
+    assert has_block is False
+    assert rows == []
+
+
+def test_evaluate_flags_stale_creates_host():
+    rows, has_block = evaluate(BLOCK, HOSTS_MAP)
+    assert has_block is True
+    # creates-host dev15_01 is already present → at least one fail row.
+    assert any(level == "fail" for level, _ in rows)
+
+
+if __name__ == "__main__":
+    from tools.testkit import run_module_tests
+    raise SystemExit(run_module_tests(globals()))


### PR DESCRIPTION
Closes #674. Second of three S116 session-integrity guardrails (#673 merged via #676).

**Root cause:** I accepted an S115 plan asserting "branch off the umbrella" + "register dev15_01" — both already stale/done on main by pickup. A plan reads true-now but is only true-when-written.

- `tools/plan_lint.py` — parses a `<!-- plan-check base:… creates-host:… -->` block from the latest next-agenda; verifies `base:` exists + is current with origin/main (reuses #673's `behind_count`) and `creates-host:` is not already in hosts_map. No block ⇒ soft pass.
- `sync_check.sh` §20 — session-start surfacing (WARN).
- `tools/CLAUDE.md` — the plan-check block convention.

**Live acceptance:** an S116-shaped block is flagged on both counts; a current block passes; legacy agendas soft-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)