### PR TITLE
chore(cli): remove unused ssh key config parameter

### DIFF
--- a/tools/cli/_common.py
+++ b/tools/cli/_common.py
@@ -64,8 +64,8 @@ def hub_vm(config: dict) -> Optional[str]:
     return None
 
 
-def ssh_key_path(config: dict) -> str:
-    """Operator key path via operator_ssh_key (config kept for call-site compat)."""
+def ssh_key_path() -> str:
+    """Operator key path via operator_ssh_key."""
     return operator_ssh_key()
 
 

--- a/tools/cli/build_vm.py
+++ b/tools/cli/build_vm.py
@@ -15,7 +15,7 @@ def run(args, config: dict) -> int:
     banner(f"Build VM: {vm}")
 
     try:
-        build_vm(vm, vm_info, project_root, ssh_key_path(config), console.print)
+        build_vm(vm, vm_info, project_root, ssh_key_path(), console.print)
     except RuntimeError as exc:
         console.print(f"[red]❌  {exc}[/red]")
         return 1

--- a/tools/cli/confirm_prerequisites.py
+++ b/tools/cli/confirm_prerequisites.py
@@ -21,7 +21,7 @@ def run(args, config: dict) -> int:
 
     console.print()
     console.print("[bold cyan]File checks[/bold cyan]")
-    file_results = check_files(project_root, ssh_key_path(config), emit=console.print)
+    file_results = check_files(project_root, ssh_key_path(), emit=console.print)
     file_issues = [(p, d) for p, d, exists in file_results if not exists]
 
     console.print()
@@ -52,7 +52,7 @@ def run(args, config: dict) -> int:
     if file_issues:
         console.print()
         console.print("[yellow]Missing files:[/yellow]")
-        ssh_key = Path(ssh_key_path(config))
+        ssh_key = Path(ssh_key_path())
         for path, desc in file_issues:
             if "age/keys.txt" in str(path):
                 console.print(f"  age key: age-keygen -o {path}")

--- a/tools/cli/display/config_tree.py
+++ b/tools/cli/display/config_tree.py
@@ -26,7 +26,7 @@ def build_tree(config: dict) -> Tree:
     _add_wireguard(tree, hosts_map, all_vars)
     _add_vms(tree, kvm_hosts(config))
     add_controller(tree, controller_info(config))
-    add_ssh(tree, kvm_vars, vm_user(config), ssh_key_path(config))
+    add_ssh(tree, kvm_vars, vm_user(config), ssh_key_path())
     add_ports(tree, all_vars)
     add_alerts(tree, all_vars)
     add_system(tree, all_vars)

--- a/tools/cli/provision_vm.py
+++ b/tools/cli/provision_vm.py
@@ -16,7 +16,7 @@ def run(args, config: dict) -> int:
 
     banner(f"Provision VM: {vm}")
     ok = provision_vm(
-        vm, hypervisor, project_root, ssh_key_path(config),
+        vm, hypervisor, project_root, ssh_key_path(),
         console.print, check=args.check,
         skip_fresh_snapshot=args.skip_fresh_snapshot,
     )

--- a/tools/cli/validate_observability.py
+++ b/tools/cli/validate_observability.py
@@ -21,7 +21,7 @@ def run(args, config: dict) -> int:
 
     console.print("Retrieving Grafana credentials...")
     user, password = source_grafana_creds(
-        vm_user=vm_user(config), ssh_key=ssh_key_path(config),
+        vm_user=vm_user(config), ssh_key=ssh_key_path(),
         emit=console.print,
     )
     if password is None:

--- a/tools/cli/verify_vpn.py
+++ b/tools/cli/verify_vpn.py
@@ -11,7 +11,7 @@ def run(args, config: dict) -> int:
     all_ok = verify_vpn(
         hosts=kvm_hosts(config),
         vm_user=vm_user(config),
-        ssh_key=ssh_key_path(config),
+        ssh_key=ssh_key_path(),
         emit=console.print,
     )
     console.print()

--- a/tools/test_cli_common.py
+++ b/tools/test_cli_common.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Colocated tests for CLI shared helpers."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.cli import _common  # noqa: E402
+
+
+def test_ssh_key_path_has_no_ignored_config_parameter():
+    assert list(inspect.signature(_common.ssh_key_path).parameters) == []
+
+
+def test_ssh_key_path_delegates_to_operator_identity(monkeypatch):
+    monkeypatch.setattr(_common, "operator_ssh_key", lambda: "/tmp/operator-key")
+
+    assert _common.ssh_key_path() == "/tmp/operator-key"
+
+
+if __name__ == "__main__":
+    from tools.testkit import run_module_tests
+
+    raise SystemExit(run_module_tests(globals()))


### PR DESCRIPTION
## Summary
- Remove the ignored `config` parameter from `ssh_key_path()` now that it delegates to `operator_ssh_key()`.
- Update CLI call sites to use the no-argument helper.
- Add colocated tests pinning the helper signature and delegation behavior.

## Test Plan
- [x] `python3 -m pytest tools/test_cli_common.py tools/test_host_identity.py -q`
- [x] `python3 -m py_compile tools/cli/_common.py tools/cli/build_vm.py tools/cli/display/config_tree.py tools/cli/confirm_prerequisites.py tools/cli/provision_vm.py tools/cli/validate_observability.py tools/cli/verify_vpn.py tools/test_cli_common.py`

## Notes
- `bash platforms/kvm/sync_check.sh` was run first per repo instructions, but this local cron host is missing environment prerequisites (Cloudflare MCP, Telegram SOPS token, colocated suite baseline red: 54/64 files passed). I did not change those unrelated host-level prerequisites in this scoped issue.

Fixes #581
