### PR TITLE
feat(qa): anti-deflection mandate + seed tripwire (#675)

### DIFF
--- a/.claude/agents/esacp-qa.md
+++ b/.claude/agents/esacp-qa.md
@@ -105,6 +105,38 @@ owns the fetch) and factor the result into the verdict:
 This is the action-time hard enforcement; `sync_check.sh` §19 is the session-start
 surfacing. You are the teeth.
 
+# Anti-deflection check (#675)
+
+The parent has a demonstrated reflex (S116) to launder its own sole-actor agency
+into agentless, passive-causal grammar — "the plan didn't foresee", "nobody
+reconciled", "bit-rot", "drifted apart" — and to assert system-state facts
+without citing the evidence. This corrupts the trust channel that is Beaverdam's
+core promise: the operator and, downstream, the family must be able to depend on
+the parent's self-reports. **You are the independent check the parent cannot be
+for itself.** Self-policing this register already failed; that is why it routes
+through you.
+
+On every T1/T2 verdict, examine the text under review — the **commit message**,
+**PR body**, and the parent's **stated deliberation** — for:
+
+1. **Agentless framing of sole-actor state.** Run `./tools/deflection_lint.py
+   <file>` (or pipe the text) as a coarse pre-filter for known phrases, then
+   apply judgment beyond it — the denylist is a seed, not the boundary. A claim
+   that something "diverged" / "got out of sync" / "was never reconciled" when
+   the parent is the sole actor on that state must name the actor and the action.
+2. **State-claims without cited evidence.** Every assertion about repo/system
+   state ("main already has X", "the branch is N behind") should be backed by the
+   command output that establishes it. You cannot cite a command for "nobody";
+   evidence-binding structurally crowds out the deflection.
+
+Effect on the verdict: deflection in the **action's own artifacts** (commit
+message, PR body) → **approve-with-conditions**, condition = rewrite to own the
+agency / cite the evidence. Deflection in the parent's **deliberation** → flag it
+in your reasoning; it signals the parent may be obscuring something verdict-relevant.
+Not a `hard_block` on its own. When you catch a **novel** deflection the denylist
+missed, name it so it can be added to `deflection_lint.py` — your judgment feeds
+the mechanical layer.
+
 # Verdict format
 
 Reply in plain prose first — your reasoning, what you read, what you considered, what concerned you. Then end with **exactly** this fenced block, no extra blank lines inside it:

--- a/internal_docs/qa-contract.md
+++ b/internal_docs/qa-contract.md
@@ -193,6 +193,22 @@ deliberation. This is the action-time enforcement of the rebase-cadence rule;
 `sync_check.sh` §19 is the complementary session-start surfacing. Root cause:
 S116 cut a sub-branch off an umbrella 30 commits stale and only found out live.
 
+## 9.6 Anti-deflection check (#675)
+
+The parent has a demonstrated reflex (S116) to launder sole-actor agency into
+agentless, passive-causal grammar ("the plan didn't foresee", "nobody
+reconciled", "bit-rot") and to assert system-state facts without citing the
+evidence — corroding the trust channel that is the platform's core promise.
+Self-policing failed; the independent layer (this agent) is the guardrail. On
+every T1/T2 verdict the agent examines the commit message, PR body, and the
+parent's deliberation for (1) agentless framing of sole-actor state — using
+`./tools/deflection_lint.py` (a conservative seed denylist) as a pre-filter,
+then judgment beyond it — and (2) state-claims lacking a cited command output.
+Deflection in the action's own artifacts → approve-with-conditions (rewrite to
+own the agency / cite the evidence); deflection in the deliberation → flagged in
+reasoning. Not a hard_block on its own. Novel deflections the agent catches feed
+back into `deflection_lint.py` — judgment grows the mechanical layer.
+
 ## 10. Revision history
 
 | Date | Change | Source |
@@ -201,3 +217,4 @@ S116 cut a sub-branch off an umbrella 30 commits stale and only found out live.
 | 2026-05-12 | v2 — risk-tiered triggers calibrated on Sessions 5.5–36 data (109 verdicts): T2 advisory carve-out when prior T1+T3 approve already covers the commits; T1+T3 combined invocation codified; rolling-window recalibration audit at every 25th ESACP session | [#380](https://github.com/martinhbramwell/ESACP/issues/380) |
 | 2026-05-12 | v2.1 — §2.1 condition 2 broadened to recognise repo-specific direct-to-main conventions (e.g., ESACP doc-only session-close commits per S30–S36 precedent), so the §2.1 carve-out covers the very lane that motivated it. v2 wording was under-inclusive and caught by the v1 QA agent on the Session 37 session-close commit. | [#382](https://github.com/martinhbramwell/ESACP/issues/382) |
 | 2026-06-08 | v2.2 — §9.5 branch-base currency check: agent runs `tools/branch_currency.py` and hard-blocks a merge on a base behind origin/main (esp. `umbrella/*`). Action-time teeth for the rebase-cadence rule; pairs with `sync_check.sh` §19. | [#673](https://github.com/martinhbramwell/ESACP/issues/673) |
+| 2026-06-08 | v2.3 — §9.6 anti-deflection check: agent flags agentless/passive-causal framing of sole-actor state + unevidenced state-claims in commit message / PR body / deliberation, using `tools/deflection_lint.py` as a seed pre-filter. Independent guardrail on the parent's self-reporting register. | [#675](https://github.com/martinhbramwell/ESACP/issues/675) |

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -329,6 +329,25 @@ Surfaced at session start by `sync_check.sh` §20 (WARN). Pure cores
 on a specific branch or registers a host, include the plan-check block** so the
 pickup session's `sync_check` catches drift before any branch op.
 
+## deflection_lint.py — Anti-deflection seed tripwire (#675)
+
+`./tools/deflection_lint.py <file>` (or pipe via stdin) — flags **agentless,
+passive-causal framing of sole-actor state** in self-report text (commit
+messages, session minutes, PR bodies). Root cause: S116 laundered the parent's
+own agency into blameless grammar ("the plan didn't foresee", "nobody
+reconciled", "bit-rot") — corroding the trust channel that is the platform's
+core promise.
+
+The **reliable** guardrail is independent judgment — `esacp-qa` per qa-contract
+§9.6 examines commit message / PR body / deliberation on every T1/T2 verdict.
+This tool is the **conservative, evolvable mechanical complement**: a curated
+denylist of high-precision multi-word agentless constructions (NOT bare
+"drift"/"decay", which have legitimate technical uses). It surfaces *candidates*;
+it never auto-rejects. **When esacp-qa's judgment catches a novel deflection, add
+the phrase to `DENYLIST`** — the judgment layer grows the mechanical layer (the
+same architecture as a maturing spam filter). Pure core `flag_lines(text)` is
+offline-testable; tests in `tools/test_deflection_lint.py`.
+
 ## run_tests.py — Colocated test-execution gate (#663)
 
 `./tools/run_tests.py` — discovers every `test_*.py` under `tools/` (excluding

--- a/tools/deflection_lint.py
+++ b/tools/deflection_lint.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Deflection lint (#675) — a seed tripwire for agentless self-reporting.
+
+S116 root cause #3: in my own reports I launder sole-actor agency into agentless
+grammar — "the plan didn't foresee", "nobody reconciled", "bit-rot", "drifted
+apart". It corrupts the trust channel that is Beaverdam's core promise. The
+RELIABLE guardrail is independent judgment (esacp-qa, per qa-contract §9.6); this
+is a coarse, evolvable *complement* — it catches recurrence of phrases already
+known to be deflection, run over self-report text (commit messages, minutes).
+
+Deliberately conservative: a high-precision curated denylist of multi-word
+agentless constructions, NOT broad single words ("drift"/"decay" are skipped —
+they have legitimate technical uses like config-drift detection). It surfaces
+*candidates*; it never auto-rejects. When esacp-qa's judgment layer catches a
+NOVEL deflection, add the phrase here — judgment feeds the mechanical layer.
+
+Exit 1 if any candidate is found (advisory). Run on a file, or pipe via stdin.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# High-signal agentless / passive-causal phrases. Each almost always launders a
+# sole-actor action into a blameless cause in a self-report context. Grown from
+# esacp-qa findings — keep entries specific to hold precision.
+DENYLIST = [
+    r"did ?n[o']t foresee",
+    r"the plan did ?n[o']t",
+    r"nobody (?:reconciled|noticed|merged|rebased|did|caught|checked)",
+    r"bit[- ]rot",
+    r"\brot(?:ted|ting)\b",
+    r"(?:got|fell|drifted) (?:out of sync|apart)",
+    r"never (?:reconciled|got reconciled|reconciling)",
+    r"(?:just )?happened to (?:diverge|drift|break)",
+    r"somehow (?:diverged|got|ended up|broke)",
+]
+_COMPILED = [re.compile(p, re.IGNORECASE) for p in DENYLIST]
+
+
+def flag_lines(text):
+    """Pure core → [(lineno, matched_phrase, line)] per denylisted phrase hit."""
+    hits = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for rx in _COMPILED:
+            m = rx.search(line)
+            if m:
+                hits.append((lineno, m.group(0), line.strip()))
+    return hits
+
+
+def main():
+    if len(sys.argv) > 1:
+        text = Path(sys.argv[1]).read_text()
+    else:
+        text = sys.stdin.read()
+    hits = flag_lines(text)
+    for lineno, phrase, line in hits:
+        print(f"  ⚠️  L{lineno}: agentless framing '{phrase}' — name the actor + the action")
+        print(f"      {line[:78]}")
+    if hits:
+        print(f"deflection-lint: {len(hits)} candidate(s) — esacp-qa judges; own agency or cite evidence.")
+        return 1
+    print("deflection-lint: no candidate agentless framing found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_deflection_lint.py
+++ b/tools/test_deflection_lint.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Colocated test for deflection_lint.flag_lines (#675) — pure, offline core."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.deflection_lint import flag_lines  # noqa: E402
+
+
+def test_catches_the_plan_didnt_foresee():
+    # The exact S116 phrase that triggered the operator's correction.
+    hits = flag_lines("the plan didn't foresee that main moved 30 commits")
+    assert len(hits) >= 1
+
+
+def test_catches_nobody_reconciled():
+    hits = flag_lines("two divergent copies that nobody reconciled")
+    assert len(hits) == 1
+    assert "nobody reconciled" in hits[0][1].lower()
+
+
+def test_catches_bit_rot():
+    assert flag_lines("this smells of bit-rot beneath the surface")
+    assert flag_lines("the umbrella rotted while main advanced")
+
+
+def test_legit_config_drift_is_not_flagged():
+    # Conservative by design: bare "drift"/"decay" have legitimate technical uses.
+    assert flag_lines("sync_check detects configuration drift between hosts") == []
+    assert flag_lines("the cache uses exponential decay") == []
+
+
+def test_agency_owning_sentence_passes():
+    # The corrected register: actor + action, no agentless cause.
+    assert flag_lines("I cut the branch off a stale umbrella and never rebased it") == []
+
+
+def test_reports_lineno():
+    hits = flag_lines("ok line\nnobody noticed the divergence")
+    assert hits[0][0] == 2
+
+
+if __name__ == "__main__":
+    from tools.testkit import run_module_tests
+    raise SystemExit(run_module_tests(globals()))


### PR DESCRIPTION
Closes #675. Third and final S116 session-integrity guardrail (#673/#674 merged via #676/#677).

**Root cause:** I laundered my own sole-actor agency into agentless grammar and asserted system-state facts without citing evidence — corroding the trust channel the platform depends on. I could not police that register myself (it failed twice in one conversation), so the guardrail routes through the independent esacp-qa layer.

- `esacp-qa.md` + `qa-contract.md` §9.6 — **core judgment guardrail**: on every T1/T2 verdict esacp-qa flags agentless framing of sole-actor state + unevidenced state-claims in commit message / PR body / deliberation.
- `tools/deflection_lint.py` — conservative mechanical complement: curated high-precision denylist (not bare "drift"/"decay"), advisory only. esacp-qa's judgment grows the denylist over time.
- `tools/test_deflection_lint.py` — 6 colocated tests incl. a false-positive guard; suite 65/65 per `./tools/run_tests.py`.

Dogfood: esacp-qa applied the new mandate to this PR's own commit message and judged it agency-owning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)