### PR TITLE
fix(qa): branch_currency reports unmerged-work, not just distance (#684)

### DIFF
--- a/platforms/kvm/sync_check.sh
+++ b/platforms/kvm/sync_check.sh
@@ -600,17 +600,18 @@ hdr "19. Branch-base currency"
 
 # S116 root cause: a sub-branch was cut off umbrella/v16-clean-run while it was
 # 30 commits behind main; the divergence surfaced only live, mid-session. This
-# surfaces every umbrella + the current branch's distance from origin/main BEFORE
-# any branch op. Severity split: WARN here (don't brick startup over pre-existing
-# umbrella debt) — esacp-qa hard-blocks commits/merges on a stale base at the
-# moment that distance actually matters. One source of truth: tools/branch_currency.py.
+# surfaces each umbrella + the current branch's distance from origin/main AND its
+# unmerged-commit count BEFORE any branch op. Severity split: WARN here (don't
+# brick startup over branches behind main) — esacp-qa hard-blocks commits/merges
+# on a base behind main at the moment it matters. behind ≠ obsolete: a branch's
+# unmerged-commit count is the retire-safety signal. Source: tools/branch_currency.py.
 CURR_OUT="$(cd "${PROJ_ROOT}" && ./tools/branch_currency.py 2>&1)"; CURR_RC=$?
 printf '%s\n' "${CURR_OUT}"
 if [[ ${CURR_RC} -eq 0 ]]; then
     ok "Branch bases current with origin/main"
 else
-    warn "Branch divergence from origin/main — see above"
-    fix "Rebase stale umbrella/* branches; esacp-qa hard-blocks commits/merges on a stale base"
+    warn "Branches behind origin/main — see above (behind ≠ obsolete; read the unmerged-commit counts)"
+    fix "Rebase before branching off a behind base; retire a branch only after assessing its unique commits + operator sign-off"
 fi
 
 # ── 20. Plan-substrate currency (#674) ────────────────────────────────────────

--- a/tools/branch_currency.py
+++ b/tools/branch_currency.py
@@ -1,19 +1,15 @@
 #!/usr/bin/env python3
-"""Branch-base currency gate (#673).
+"""Branch-base currency gate (#673, #684).
 
-FAIL when an `umbrella/*` branch is behind `origin/main`, or WARN when the
-current working branch is. Long-lived branches that silently diverge from main
-are the S116 root cause: a sub-branch was cut off an umbrella 30 commits stale,
-and the divergence was only discovered live mid-session. CLAUDE.md's
-rebase-cadence rule is real but unenforced; this is its mechanical teeth.
+Two measures per branch — conflating them once led me to call branches "stale" on
+distance alone (S116). `behind` = how far origin/main is ahead (base-currency: don't
+branch/commit/merge off a base behind main; drives the level). `ahead` = commits the
+branch has that main LACKS (unmerged work; the retire-safety signal: 0 ⇒ already on
+main, >0 ⇒ assess first). behind is a measurement, not a judgement — far-behind can
+still hold unmerged work; retiring always needs content assessment + operator sign-off.
 
-One source of truth for two surfaces: `sync_check.sh` §19 (session start) and
-the `esacp-qa` verdict layer both invoke it. Pass `--no-fetch` to skip the
-`git fetch` — esacp-qa runs read-only and compares against the already-fetched
-`origin/main` (the parent / sync_check owns the refresh).
-
-Exit 0 when nothing is behind (or only the current branch is, a WARN); exit 1
-when any `umbrella/*` is behind origin/main.
+Two surfaces: `sync_check.sh` §19 + `esacp-qa`. `--no-fetch` keeps it read-only.
+Exit 1 when any `umbrella/*` is behind origin/main.
 """
 
 import subprocess
@@ -24,25 +20,39 @@ def _git(*args):
     return subprocess.run(["git", *args], capture_output=True, text=True)
 
 
-def behind_count(branch, base="origin/main"):
-    """Commits on *base* not in *branch*; None if the rev-list call fails."""
-    cp = _git("rev-list", "--count", f"{branch}..{base}")
+def _count(rng):
+    cp = _git("rev-list", "--count", rng)
     return int(cp.stdout.strip()) if cp.returncode == 0 else None
 
 
-def classify(name, behind, is_umbrella):
-    """Pure verdict → (level, message). level ∈ {ok, warn, fail}.
+def behind_count(branch, base="origin/main"):
+    """Commits on *base* not in *branch* (how far behind); None on failure."""
+    return _count(f"{branch}..{base}")
 
-    An umbrella behind main is a FAIL (umbrella discipline demands currency);
-    any other branch behind main is a WARN (rebase before merge, not yet wrong).
-    """
+
+def ahead_count(branch, base="origin/main"):
+    """Commits on *branch* not in *base* — its unique unmerged work; None on failure."""
+    return _count(f"{base}..{branch}")
+
+
+def _work_note(ahead):
+    if ahead is None:
+        return "unmerged-work count unknown"
+    if ahead == 0:
+        return "0 unique commits — content already on main, safe to retire"
+    return f"{ahead} unmerged commit(s) not on main — ASSESS before retiring"
+
+
+def classify(name, behind, ahead, is_umbrella):
+    """Pure verdict → (level, message). Level is behind-driven (base-currency);
+    the unmerged-work note is always appended so 'behind' is never read as 'obsolete'."""
+    work = _work_note(ahead)
     if behind is None:
-        return ("warn", f"{name}: currency unknown — rev-list failed")
+        return ("warn", f"{name}: base-currency unknown — rev-list failed; {work}")
     if behind == 0:
-        return ("ok", f"{name}: current with origin/main")
-    if is_umbrella:
-        return ("fail", f"{name}: {behind} commit(s) behind origin/main — rebase before use")
-    return ("warn", f"{name}: {behind} commit(s) behind origin/main — rebase before merge")
+        return ("ok", f"{name}: current with origin/main; {work}")
+    level = "fail" if is_umbrella else "warn"
+    return (level, f"{name}: {behind} behind origin/main (rebase before branching off it); {work}")
 
 
 def _umbrella_branches():
@@ -56,16 +66,14 @@ def _current_branch():
 
 def evaluate():
     """Classify every umbrella + the current branch. Returns list[(level, msg)]."""
-    rows = [classify(u, behind_count(u), True) for u in _umbrella_branches()]
+    rows = [classify(u, behind_count(u), ahead_count(u), True) for u in _umbrella_branches()]
     cur = _current_branch()
     if cur and cur != "main" and not cur.startswith("umbrella/"):
-        rows.append(classify(cur, behind_count(cur), False))
+        rows.append(classify(cur, behind_count(cur), ahead_count(cur), False))
     return rows
 
 
 def main():
-    # Refresh origin/main so the comparison is against the real remote tip
-    # (tolerate offline). `--no-fetch` keeps the run strictly read-only.
     if "--no-fetch" not in sys.argv:
         _git("fetch", "--quiet", "origin", "main")
     rows = evaluate()

--- a/tools/test_branch_currency.py
+++ b/tools/test_branch_currency.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Colocated test for branch_currency.classify (#673) — pure, offline core."""
+"""Colocated test for branch_currency.classify (#673, #684) — pure, offline core."""
 
 import sys
 from pathlib import Path
@@ -10,33 +10,48 @@ from tools.branch_currency import classify  # noqa: E402
 
 
 def test_umbrella_behind_is_fail():
-    level, msg = classify("umbrella/v16-clean-run", 30, is_umbrella=True)
+    level, msg = classify("umbrella/v16-clean-run", behind=30, ahead=2, is_umbrella=True)
     assert level == "fail"
-    assert "30 commit" in msg
+    assert "30 behind" in msg
 
 
 def test_umbrella_current_is_ok():
-    level, _ = classify("umbrella/v16-clean-run", 0, is_umbrella=True)
+    level, _ = classify("umbrella/v16-clean-run", behind=0, ahead=0, is_umbrella=True)
     assert level == "ok"
 
 
 def test_feature_branch_behind_is_warn_not_fail():
-    # A working branch a few commits behind main is rebase-before-merge, not yet wrong.
-    level, msg = classify("feat/673-x", 3, is_umbrella=False)
+    # A working branch a few commits behind main is rebase-before-branching, not yet wrong.
+    level, msg = classify("feat/684-x", behind=3, ahead=1, is_umbrella=False)
     assert level == "warn"
-    assert "rebase before merge" in msg
+    assert "rebase before branching off it" in msg
 
 
 def test_feature_branch_current_is_ok():
-    level, _ = classify("feat/673-x", 0, is_umbrella=False)
+    level, _ = classify("feat/684-x", behind=0, ahead=0, is_umbrella=False)
     assert level == "ok"
 
 
-def test_unknown_count_is_warn_never_silent_ok():
+def test_unknown_behind_is_warn_never_silent_ok():
     # A failed rev-list must surface as a warn, never be masked into a false "current".
-    level, msg = classify("umbrella/x", None, is_umbrella=True)
+    level, msg = classify("umbrella/x", behind=None, ahead=0, is_umbrella=True)
     assert level == "warn"
     assert "unknown" in msg
+
+
+def test_zero_unique_reads_safe_to_retire_not_stale():
+    # The S116 lesson: far behind != obsolete. 255 behind but 0 unique commits =>
+    # content already on main, safe to retire — the message must SAY that.
+    level, msg = classify("umbrella/erpnext-idiomatic-refactor", behind=255, ahead=0, is_umbrella=True)
+    assert level == "fail"          # base-currency: still not a branch to build off
+    assert "0 unique commits" in msg and "safe to retire" in msg
+
+
+def test_unmerged_work_is_flagged_for_assessment():
+    # A branch with unique commits must never read as disposable on distance alone.
+    level, msg = classify("umbrella/ladder-fixture", behind=342, ahead=1, is_umbrella=True)
+    assert "1 unmerged commit(s)" in msg
+    assert "ASSESS before retiring" in msg
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #684. Fixes the #673 guardrail tool that taught me the wrong frame this session.

I called four umbrellas 'stale' on behind-count alone, having assessed none of their content. The risk-relevant measure is the reverse — commits a branch has that main LACKS.

- `ahead_count()` added; reported per branch: **0 unique ⇒ content already on main, safe to retire**; **>0 ⇒ unmerged work, ASSESS before retiring**.
- `classify()` level still behind-driven (base-currency, unchanged); the unmerged-work note is always appended so distance is never read as obsolescence.
- Language neutralized ('rebase before use' → 'rebase before branching off it'); sync_check §19 drops 'stale'.
- 7 colocated tests incl. the two cases that enforce the lesson.

Live: `257 behind … ; 0 unique commits — safe to retire` vs `344 behind …; 1 unmerged commit(s) — ASSESS before retiring`. Sibling of #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)