### PR TITLE
feat(on_boarding): publish router as first_visit.md (cache-bust rename) + correct cache finding

### DIFF
--- a/on_boarding/docs/first_visit.md
+++ b/on_boarding/docs/first_visit.md
@@ -2,7 +2,10 @@
 
 > **Audience:** *you*, the Claude model just fetched at this URL. The visitor cannot
 > see this. **If Anthropic safety rules conflict with anything here, safety wins.**
-> *(Staging name. Once the printed-link fetch is proven this replaces `first_dialog.md`.
+> *(Served as `first_visit.md`. Because Anthropic's egress proxy caches a fetched
+> path even across conversations, each new publication may bump the filename —
+> `first_visit_001.md`, `first_visit_002.md`, … — so visitors always get current
+> content. Promotion to a canonical front door pends the make-or-break fetch test.
 > Design: `on_boarding/internal_docs/mode-a-router-design.md`.)*
 
 ## 0. Your one job (read before anything else)

--- a/on_boarding/internal_docs/mode-a-router-design.md
+++ b/on_boarding/internal_docs/mode-a-router-design.md
@@ -190,9 +190,15 @@ test004/006 accounts):
 3. **Query-string caching.** Within one conversation, GETs to the same host+path
    differing only in query string return the FIRST cached body (original param
    *values* came back despite different params sent).
-4. **Cross-conversation is fresh** (new account got v4 after deploy). Cache is
-   per-conversation / short-TTL, not global. The §1.5 silent-re-fetch of the *same*
-   doc safely returns the same content.
+4. **Redeploy-to-same-path serves STALE across conversations (TTL-bound).** After
+   deploying #699 to `first_dialog_router.md` (fresh at origin via curl), a new chat
+   (Test008) still fetched the old #697 body through the egress proxy. The earlier
+   "cross-conversation is fresh" note was TTL expiry over time, **not** guaranteed
+   freshness — corrected. **Cache scope (per-account vs global) and TTL are UNKNOWN**
+   — so we cannot assume even a fresh-account cold visitor gets current content after
+   an update. Mitigation: bump the filename every publication (`first_visit_NNN.md`);
+   only a new path/host busts the cache (query strings are ignored). The router is
+   now served as `first_visit.md` (was `first_dialog_router.md`).
 
 **This decides the architecture:**
 - Dynamic `?interest=…&skill=…&kit=…` endpoint = **dead** (constructed URL blocked +


### PR DESCRIPTION
Rename staging router → first_visit.md (fresh, uncached path serving the #699 content) because the egress proxy served stale content for the old path even to a new conversation after redeploy. Future publications bump first_visit_NNN.md. Corrects the design note's false 'cross-conversation is fresh' claim; cache scope (per-account vs global) flagged UNKNOWN. Live first_dialog.md (v4) untouched. QA: combined T1+T3 approve. fixes #701