### PR TITLE
feat(on_boarding): U1 — cost fix (Pro includes Claude Code) + reckoning road-map page

### DIFF
--- a/on_boarding/docs/_layouts/roadmap.html
+++ b/on_boarding/docs/_layouts/roadmap.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <title>{{ page.title | default: site.title }}</title>
+  <meta name="description" content="{{ page.description | default: site.description }}">
+  <link rel="stylesheet" href="{{ '/assets/css/landing.css' | relative_url }}">
+  <link rel="icon" type="image/svg+xml" href="{{ '/assets/favicon/favicon.svg' | relative_url }}">
+  <link rel="icon" type="image/png" sizes="96x96" href="{{ '/assets/favicon/favicon-96x96.png' | relative_url }}">
+  <link rel="shortcut icon" href="{{ '/assets/favicon/favicon.ico' | relative_url }}">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/favicon/apple-touch-icon.png' | relative_url }}">
+  <link rel="manifest" href="{{ '/assets/favicon/site.webmanifest' | relative_url }}">
+  <script>
+    // Apply theme before paint to avoid flash. Shares the landing's saved choice
+    // (same localStorage key), so dark/light carries across from the main site.
+    (function () {
+      try {
+        var saved = localStorage.getItem('esacp-theme');
+        var theme = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) { /* localStorage blocked — fall through to CSS default */ }
+    })();
+  </script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="{{ '/' | relative_url }}" aria-label="Back to the Beaverdam home page">
+        <img class="brand-logo" src="{{ '/assets/images/beaverdam-icon.svg' | relative_url }}" alt="Beaverdam" width="700" height="700">
+      </a>
+      <span class="roadmap-title">Roll-out road map</span>
+      <div class="controls">
+        <button class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
+          <svg class="icon-sun"  width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main class="page">
+    {{ content }}
+
+    <div class="bottom-meta">
+      <p>
+        <a href="{{ '/' | relative_url }}">&lsaquo; Back to the main Beaverdam site</a>
+      </p>
+      <p>
+        The architecture this page describes is documented in
+        <a href="https://github.com/martinhbramwell/ESACP/blob/on_boarding/on_boarding/internal_docs/entry-architecture-notes.md"><code>internal_docs/entry-architecture-notes.md</code></a>.
+      </p>
+      <p>
+        Source: <a href="https://github.com/martinhbramwell/ESACP">martinhbramwell/ESACP</a> on GitHub.
+      </p>
+    </div>
+  </main>
+
+  <script>
+    // Theme toggle — writes the same key the landing reads, so the choice
+    // persists when the visitor returns to the main site.
+    (function () {
+      var $t = document.querySelector('.theme-toggle');
+      if (!$t) return;
+      $t.addEventListener('click', function () {
+        var current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        var next = current === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        try { localStorage.setItem('esacp-theme', next); } catch (e) {}
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -616,6 +616,108 @@ body.tabs-overflow .hamburger  { visibility: visible; pointer-events: auto; }
   color: var(--accent-ink);
 }
 
+/* ── roll-out road map — calm standalone page (layout: roadmap) ── */
+
+/* centred topbar label (between brand and theme toggle) */
+.roadmap-title {
+  text-align: center;
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  color: var(--ink-muted);
+  letter-spacing: 0.01em;
+}
+
+/* the road-map section's own sub-headings — scoped so the landing is untouched */
+#roll_out > h3 {
+  font-family: var(--serif);
+  font-size: clamp(1.1rem, 2.8vw, 1.35rem);
+  font-weight: 600;
+  color: var(--accent);
+  margin: 2.25rem 0 0.85rem;
+}
+
+/* the 8-rung ladder table */
+.ladder {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0 1.75rem;
+  font-size: 0.95rem;
+}
+
+.ladder th,
+.ladder td {
+  text-align: left;
+  padding: 0.62rem 0.7rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.ladder thead th {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  border-bottom: 2px solid var(--rule);
+}
+
+.ladder .rung-num {
+  font-family: var(--serif);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.ladder .rung-meta {
+  color: var(--ink-muted);
+  font-size: 0.86em;
+}
+
+.ladder .ladder-money { white-space: nowrap; }
+
+.ladder .ladder-break td {
+  background: var(--accent-tint);
+  color: var(--accent-ink);
+  font-style: italic;
+  font-size: 0.88rem;
+  text-align: center;
+}
+
+@media (max-width: 34rem) {
+  .ladder { font-size: 0.86rem; }
+  .ladder th, .ladder td { padding: 0.5rem 0.4rem; }
+}
+
+/* the two-question self-check gate */
+.self-check {
+  margin: 2.25rem 0 0;
+  padding: 1.25rem 1.4rem 1.35rem;
+  background: var(--accent-tint);
+  border: 2px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius: var(--radius);
+  color: var(--accent-ink);
+  line-height: 1.55;
+
+  h3 {
+    margin: 0 0 0.6rem;
+    font-family: var(--serif);
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--accent-strong);
+  }
+
+  p { margin: 0.6rem 0; font-size: 0.97rem; }
+
+  ol { margin: 0.7rem 0; padding-left: 1.5rem; }
+
+  li {
+    margin: 0.35rem 0;
+    font-weight: 600;
+    font-size: 1.02rem;
+  }
+
+  .off-ramp { margin-top: 0.95rem; }
+}
+
 /* panel-end nudge link — +50% from prior */
 
 .panel-cue {

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -199,7 +199,7 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
     ... you brain-dump &mdash; in one message, in plain language, and only what you're comfortable sharing &mdash; about the information your business runs on, what you'd most like a computer to handle, what computers you have, and how comfortable you are with computers, AI, and "the cloud".  Bring any doubts, too. 
     </p>
     <p>
-          Nick answers your questions, checks that you can actually run Beaverdam, and names the one unavoidable cost up front: a <strong>Claude Code</strong> subscription, about $20 a month.  Nothing touches your computer, and no sensitive customer or financial detail is needed here.
+          Nick answers your questions, checks that you can actually run Beaverdam, and names the one unavoidable cost up front: a <strong>Claude Pro</strong> subscription, about $20 a month &mdash; which <em>includes</em> Claude Code, the tool you&rsquo;ll use in stage 2. Nothing touches your computer, and no sensitive customer or financial detail is needed here.
     </p>
     <p class="comment">
       No installation. No commitment. No disruption. The summary is useful even
@@ -211,7 +211,7 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
     <p class="role">Stage 2 &mdash; the rope</p>
     <h3>A safe local launcher environment.</h3>
     <p>
-      We call this stage "the controller".  Using your previous description of your computing environment we explain to you how to get started with Claude Code (+/- $20/mth) in one of your machines.  You then paste your questionnaire result as a prompt to Claude.  With your approval, step by step, Claude will help you create the third stage, the full ERP development, staging and production platform.  Those steps would normally cost you thousands of $$$ in consulting fees, (because learning it all takes months!)
+      We call this stage "the controller".  Using your previous description of your computing environment we explain how to get started with Claude Code &mdash; included in that same Claude Pro subscription (about $20/month, no extra charge) &mdash; on one of your machines.  You then paste your questionnaire result as a prompt to Claude.  With your approval, step by step, Claude will help you create the third stage, the full ERP development, staging and production platform.  Those steps would normally cost you thousands of $$$ in consulting fees, (because learning it all takes months!)
     </p>
     <p class="comment">
       Reversible by design. If it does not make sense, you stop before anything
@@ -393,9 +393,10 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
     <span class="tag caveat-tag">Cost</span>
     <h3>The first conversation is free. Real operation has real costs.</h3>
     <p>
-      Stage 1 can be tried with a free Claude account. Later stages may require
-      Claude Code, hosting, backups, and occasional human help. The target is around 
-      100 bucks a month all included, once the system becomes real.
+      Stage 1 is free with a free Claude account. Stage 2 needs Claude Pro &mdash; about
+      $20 a month, which <em>includes</em> Claude Code. A real, running system later adds
+      hosting and backups: the target is around 100 bucks a month all-in, once the system
+      becomes real.
     </p>
   </div>
 
@@ -433,9 +434,8 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
 
 <div class="essex-demo-note">
   <p>
-    Curious what Nick sounds like after discovery?
-    <a href="essex-demo.html">See a worked example of a stage-2 conversation</a>
-    where Nick helps a small-business owner set up a sandbox on a Windows 11 machine.
+    Curious what the full string &rarr; rope &rarr; chain will look like?
+    Read the <a href="{{ '/roll_out/' | relative_url }}">roll-out road map</a>.
   </p>
 </div>
 

--- a/on_boarding/docs/roll_out/index.md
+++ b/on_boarding/docs/roll_out/index.md
@@ -1,0 +1,152 @@
+---
+layout: roadmap
+permalink: /roll_out/
+title: "Beaverdam — the roll-out road map"
+description: >-
+  The whole string-to-rope-to-chain climb, laid out honestly before you spend
+  a cent: every rung, what it really costs you in time, and what it costs in money.
+---
+
+<section data-panel="roll_out" id="roll_out" class="is-active">
+
+<h2>The roll-out road map &mdash; the whole climb, before you pay a cent</h2>
+
+<p class="intro">
+  You found this page because you read all the way to the bottom of
+  <a href="{{ '/#catch' | relative_url }}">What&rsquo;s the Catch?</a> &mdash; which means
+  you&rsquo;re seriously weighing this up. Good. Here is the honest shape of the
+  <strong>whole</strong> thing, laid out <strong>before</strong> the first dollar. No
+  surprise steps appear after you pay.
+</p>
+
+<p class="intro">
+  The thing most likely to make someone quit later is not the money &mdash; it&rsquo;s
+  <strong>time they didn&rsquo;t see coming</strong>. So we put the time in front of you
+  now, with your eyes open. Read it, and decide for yourself.
+</p>
+
+<blockquote class="chain-narrative">
+  This is a tiny fraction of the time you&rsquo;d spend finding your own way &mdash; but it
+  is <strong>not</strong> &ldquo;sign up and wake up to a finished AI-run business when you
+  arrive with your coffee.&rdquo; You are buying a <strong>guided climb</strong>, not a
+  finished building.
+</blockquote>
+
+<h3>The eight rungs, light to heavy</h3>
+
+<p>
+  To get a heavy chain over a high beam you don&rsquo;t throw the chain. You throw a
+  <strong>shoe on a string</strong>; the string pulls a <strong>rope</strong>; the rope
+  pulls the <strong>chain</strong>. Beaverdam climbs the same way. Here is every rung,
+  what it really costs you in <strong>time</strong>, and what it costs in <strong>money</strong>:
+</p>
+
+<table class="ladder">
+  <thead>
+    <tr>
+      <th scope="col">The rung</th>
+      <th scope="col">What it really asks of you (time)</th>
+      <th scope="col">Money</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="rung-num">1.</span> The first conversation <span class="rung-meta">(this site &rarr; a free chat)</span></td>
+      <td>A few minutes&rsquo; reading, then a chat</td>
+      <td class="ladder-money">Free</td>
+    </tr>
+    <tr>
+      <td><span class="rung-num">2.</span> Discovery with the free advisor</td>
+      <td>About 10&ndash;20 minutes</td>
+      <td class="ladder-money">Free</td>
+    </tr>
+    <tr>
+      <td><span class="rung-num">3.</span> Upgrade to Claude Pro</td>
+      <td>A few minutes to upgrade</td>
+      <td class="ladder-money">~$20/mo<br><span class="rung-meta">(includes Claude&nbsp;Code)</span></td>
+    </tr>
+    <tr>
+      <td><span class="rung-num">4.</span> Install Claude Code and meet your guide</td>
+      <td>Minutes to about an hour</td>
+      <td class="ladder-money">Included in Pro</td>
+    </tr>
+    <tr class="ladder-break">
+      <td colspan="3">&mdash;&nbsp; from here the machine does the lifting; you approve rather than transcribe &nbsp;&mdash;</td>
+    </tr>
+    <tr>
+      <td><span class="rung-num">5.</span> Free sign-ups Beaverdam uses <span class="rung-meta">(e.g. GitHub)</span></td>
+      <td>An evening, spread out</td>
+      <td class="ladder-money">Mostly free</td>
+    </tr>
+    <tr>
+      <td><span class="rung-num">6&ndash;7.</span> Beaverdam builds your private lab</td>
+      <td>Mostly automated &mdash; plus real <em>learning</em>, a few hours across several days</td>
+      <td class="ladder-money">Hosting ~$100/mo<br><span class="rung-meta">once it&rsquo;s real</span></td>
+    </tr>
+    <tr>
+      <td><span class="rung-num">8.</span> Move your business into ERPNext, at your pace</td>
+      <td><strong>The big one</strong> &mdash; weeks to months, entirely your speed</td>
+      <td class="ladder-money">&mdash;</td>
+    </tr>
+  </tbody>
+</table>
+
+<p class="comment">
+  The break in the middle is the important part: up to Claude Code you carry each step by
+  hand; past it, Beaverdam does the heavy hauling and you simply approve what it proposes.
+</p>
+
+<h3>Two things to keep straight about the time</h3>
+
+<ul class="pairing-list">
+  <li>
+    <strong>One-time setup vs. ongoing-at-your-pace.</strong> Rungs 1&ndash;5 are mostly a
+    one-time push to get set up. Rungs 6&ndash;8 are ongoing &mdash; and entirely at the
+    speed you choose, with no clock running.
+  </li>
+  <li>
+    <strong>Beaverdam&rsquo;s &ldquo;tax&rdquo; vs. your ERP&rsquo;s own time.</strong>
+    Installing the tools and learning the system is overhead Beaverdam adds. But the
+    biggest block &mdash; rung 8, putting your real data and decisions into the system
+    &mdash; is time you&rsquo;d spend with <em>any</em> ERP. Beaverdam guides and shortens
+    it; it doesn&rsquo;t invent it.
+  </li>
+</ul>
+
+<div class="self-check">
+  <h3>Before you pay, ask yourself two questions</h3>
+  <p>
+    Be very clear about what you&rsquo;re choosing. Look at the whole ladder above, then
+    answer honestly:
+  </p>
+  <ol>
+    <li>Do I have time for all that?</li>
+    <li>Will the time I spend pay for itself?</li>
+  </ol>
+  <p>
+    To weigh the second one: on the cost side is the ladder above &mdash; a few hours of
+    setup, ~$20/mo, then hosting later. On the value side is a business whose operations
+    are understandable, repeatable, and <strong>not dependent on one irreplaceable person
+    forever</strong>. Only you can do that arithmetic &mdash; we won&rsquo;t do it for you.
+  </p>
+  <p class="off-ramp">
+    <strong>If you can&rsquo;t say yes to both, there&rsquo;s no reason to go further
+    &mdash; until you can.</strong> &ldquo;Not now&rdquo; is a real answer, not a failure.
+    This is a pause, not a door slamming: come back when there&rsquo;s more time or the
+    payoff is clearer. We would honestly rather tell you to wait than watch you sink an
+    evening into something that isn&rsquo;t right for you yet.
+  </p>
+</div>
+
+<p class="intro">
+  And remember &mdash; you never sign up for the whole climb at once. You only ever commit
+  to the <strong>next light step</strong>, and you can stop after any rung with everything
+  you&rsquo;ve gained still yours.
+</p>
+
+<p class="panel-cue">
+  Said yes to both?
+  <a href="{{ '/#start' | relative_url }}" class="panel-cue-link">Throw the shoe &mdash; start your first conversation &rsaquo;</a>
+</p>
+
+</section>


### PR DESCRIPTION
**U1** of the Letter-of-Introduction build plan (umbrella #731).

- Landing cost/phasing fix: the ~\$20/mo is **Claude Pro**, which *includes* Claude Code (corrected in Stage-1, Stage-2, and the Cost caveat).
- New `/roll_out/` reckoning road-map page: 8-step time/money ladder, two-question self-check, warm off-ramp.
- "What's the Catch?" foot now links to the road map.

esacp-qa T1 = approve-with-conditions (all cleared). `fixes #731` in the commit; manual T5 close on merge (on_boarding trunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)