### PR TITLE
docs(on_boarding): letter-of-introduction continuity — copy-paste, Chrome convenience (#736)

### DIFF
--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -327,8 +327,12 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
         plain-language note about your situation and what you&rsquo;re hoping for. Save it somewhere you can find it.
       </p>
       <p class="why">
-        The letter is yours. You hand it to Nick after you install Claude Code, so you do
-        not have to explain the same business twice.
+        The letter is yours, and it stays put &mdash; it lives in your claude.ai
+        <em>Beaverdam Discovery</em> project, which simply becomes a <strong>Pro</strong>
+        project when you upgrade, nothing to move or recreate. When you reach Claude Code, you
+        hand the letter to Nick by copy-pasting it in &mdash; or, if you have <strong>Claude in
+        Chrome</strong>, just let it read the letter across from your open claude.ai tab. Either
+        way you never explain the same business twice.
       </p>
     </div>
   </div>

--- a/on_boarding/docs/roll_out/inside/index.md
+++ b/on_boarding/docs/roll_out/inside/index.md
@@ -194,7 +194,7 @@ description: >-
     <span class="tag gain-tag">Step 4</span>
     <h3>Install Claude Code, meet your guide.</h3>
     <p>
-      The free chat advisor has done all it can with its resources; now you have Claude&rsquo;s full power for general use.  It&rsquo;ll introduce you to Nick who has the specialized, in depth, training in Beaverdam to guide you towards the full system.
+      The free chat advisor has done all it can with its resources; now you have Claude&rsquo;s full power for general use.  It&rsquo;ll introduce you to Nick who has the specialized, in depth, training in Beaverdam to guide you towards the full system. Bring the <strong>letter of introduction</strong> from your discovery chat &mdash; paste it in, or let Claude in Chrome read it across from your open claude.ai tab &mdash; so Nick starts already knowing your situation.
     </p>
   </div>
 


### PR DESCRIPTION
Follow-up to PR #743 (#736). Explains how the discovery **letter of introduction** carries from the free chat into Claude Code.

- **`index.md`** — reworded the *Keep your letter of introduction* step: the letter lives in your claude.ai *Beaverdam Discovery* project, which becomes a **Pro** project on upgrade (nothing to move); you hand it to Nick by **copy-paste** (led with), or — with **Claude in Chrome** — let it read the letter across from the open claude.ai tab.
- **`roll_out/inside/index.md`** — one-line Step 4 callback to bring the letter across so Nick starts already knowing the visitor's situation.

Operator-directed wording (lead copy-paste, Chrome as convenience). QA: esacp-qa T1 = approve. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)