### PR TITLE
docs(on_boarding): legal disclaimer atop 'What's the catch?'; fix Maturity caveat (#745)

### DIFF
--- a/on_boarding/docs/assets/css/landing.scss
+++ b/on_boarding/docs/assets/css/landing.scss
@@ -628,6 +628,33 @@ body.tabs-overflow .hamburger  { visibility: visible; pointer-events: auto; }
   color: var(--accent-ink);
 }
 
+/* legal disclaimer — formal notice pinned to the top of the catch panel */
+
+.legal-disclaimer {
+  margin: 0 0 1.75rem;
+  padding: 1.05rem 1.2rem 1.1rem 1.35rem;
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--pain-tag);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--ink);
+
+  h3 {
+    font-family: var(--sans);
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0 0 0.6rem;
+    color: var(--pain-tag);
+  }
+
+  p { margin: 0 0 0.7rem; }
+  p:last-child { margin-bottom: 0; }
+}
+
 /* the 8-step ladder table — wrapper scrolls horizontally on tiny screens
    rather than letting the table push the whole page wide */
 .ladder-wrap {

--- a/on_boarding/docs/index.md
+++ b/on_boarding/docs/index.md
@@ -366,6 +366,24 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
 
 <h2>What&rsquo;s the catch?</h2>
 
+<div class="legal-disclaimer">
+  <h3>Important &mdash; please read</h3>
+  <p>
+    <strong>Published for review only.</strong> This site is published solely for review by
+    early contributors. The AI-assisted parts of the software are <strong>pre-alpha</strong> and
+    under active development, and the ERPNext system shown here is specific to a single existing
+    user and <strong>predates</strong> Beaverdam&rsquo;s development. Nothing here is a finished
+    product, a release, or an offer of one.
+  </p>
+  <p>
+    <strong>No warranty, no liability &mdash; all risk is yours.</strong> Beaverdam is a free and
+    open-source project, provided as-is with no warranty of any kind. Anyone who obtains the
+    software, follows its AI-generated guidance, or commits time, money, or business data to
+    using it does so <strong>entirely at their own risk</strong>. The project and its
+    contributors accept no liability for any loss or damage arising from that use.
+  </p>
+</div>
+
 <p class="intro">
   The honest version, up front. If any of these are dealbreakers, better to know
   before anyone wastes time pretending software projects are powered by optimism and conference badges.
@@ -375,11 +393,14 @@ What does that mean?  If some of that is new to you, good! You'll soon get it. F
 
   <div class="caveat">
     <span class="tag caveat-tag">Maturity</span>
-    <h3>This is an evolving prototype, not a polished SaaS product.</h3>
+    <h3>Only the first conversation is ready to use.</h3>
     <p>
-      Stage 1 is usable today. Stages 2 and 3 are being built from real operational
-      work and public design notes. Early users get more influence and more direct
-      help, but also less polish than they would get from a finished commercial platform.
+      The one thing usable today is the <strong>initial discovery dialog</strong> &mdash; the
+      free chat that helps you decide whether Beaverdam suits you. Everything past that is
+      <strong>pre-alpha</strong> and under active development: the AI-assisted build, the lab,
+      the later stages. The working ERPNext system it grew from is one bespoke, single-user
+      setup that predates the project, not a general release. Treat the rest as early work shown
+      for review &mdash; not a platform to lean a business on yet.
     </p>
   </div>
 


### PR DESCRIPTION
Adds a formal **legal disclaimer** pinned to the top of the landing's *What's the catch?* section, and corrects the **Maturity** caveat.

- **Disclaimer** (red left-accent block, light/dark): (1) *published for review only* — AI-assisted code is **pre-alpha**, the ERPNext system shown is one single-user setup predating Beaverdam, nothing here is a release; (2) **no warranty, no liability** — free/open-source, as-is, all risk on whoever obtains the software / follows the AI guidance / commits time, money, business data.
- **Maturity caveat** rewritten: only the **initial discovery dialog** is usable today; everything past it is pre-alpha.
- New `.legal-disclaimer` style in `landing.scss`.

Operator reviewed/approved wording. QA: esacp-qa T1 = approve-with-conditions (stage only the 2 files — met). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)